### PR TITLE
feat: allow disabling Subsquid gateways

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ GQL_PORT=4350
 # Uncommenting this line enables the debug mode
 # More info at https://docs.subsquid.io/basics/logging/
 #SQD_DEBUG=*
+
+# Set to true to skip Subsquid gateways and use the configured RPC endpoints only.
+#ORMPINDEX_DISABLE_GATEWAY=true

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,13 +10,19 @@ interface RunProcessorOptions {
   ormpContract: OrmpContractChain;
 }
 
+function isGatewayDisabled(): boolean {
+  return ["1", "true", "yes", "on"].includes(
+    (process.env.ORMPINDEX_DISABLE_GATEWAY ?? "").toLowerCase()
+  );
+}
+
 async function runProcessorEvm(options: RunProcessorOptions) {
   const { ormpContract } = options;
   const processor = new EvmBatchProcessor()
     .setRpcEndpoint(ormpContract.rpcs[0])
     .setFields(evmFieldSelection)
     .setFinalityConfirmation(ormpContract.finalityConfirmation ?? 50);
-  if (ormpContract.gateway) {
+  if (!isGatewayDisabled() && ormpContract.gateway) {
     processor.setGateway(ormpContract.gateway);
   }
   processor.addLog({
@@ -38,7 +44,7 @@ async function runProcessorTron(options: RunProcessorOptions) {
       strideSize: 1,
     })
     .setFields(tronFieldSelection);
-  if (ormpContract.gateway) {
+  if (!isGatewayDisabled() && ormpContract.gateway) {
     processor.setGateway(ormpContract.gateway);
   }
   processor.addLog({


### PR DESCRIPTION
## Summary
- add ORMPINDEX_DISABLE_GATEWAY to skip Subsquid gateway usage
- keep existing gateway behavior by default
- document the RPC-only switch in .env.example

## Verification
- npm install --legacy-peer-deps
- npm run build