### PR TITLE
HBX-446 define ormpindexer schema compatibility contract

### DIFF
--- a/migrations/0001_schema_compat.sql
+++ b/migrations/0001_schema_compat.sql
@@ -1,0 +1,122 @@
+-- ORMP legacy schema compatibility contract.
+--
+-- This initializes the tables exposed by the previous Subsquid GraphQL schema.
+-- It does not migrate old rows or define the future event ingestion runner.
+
+CREATE TABLE IF NOT EXISTS ormp_hash_imported (
+  id VARCHAR NOT NULL PRIMARY KEY,
+  block_number NUMERIC NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  block_timestamp NUMERIC NOT NULL,
+  chain_id NUMERIC NOT NULL,
+  src_chain_id NUMERIC NOT NULL,
+  target_chain_id NUMERIC NOT NULL,
+  oracle TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  msg_index NUMERIC NOT NULL,
+  hash TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS ormp_message_accepted (
+  id VARCHAR NOT NULL PRIMARY KEY,
+  block_number NUMERIC NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  block_timestamp NUMERIC NOT NULL,
+  chain_id NUMERIC NOT NULL,
+  log_index INTEGER NOT NULL,
+  msg_hash TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  "index" NUMERIC NOT NULL,
+  from_chain_id NUMERIC NOT NULL,
+  "from" TEXT NOT NULL,
+  to_chain_id NUMERIC NOT NULL,
+  "to" TEXT NOT NULL,
+  gas_limit NUMERIC NOT NULL,
+  encoded TEXT NOT NULL,
+  oracle TEXT,
+  oracle_assigned BOOLEAN,
+  oracle_assigned_fee NUMERIC,
+  relayer TEXT,
+  relayer_assigned BOOLEAN,
+  relayer_assigned_fee NUMERIC
+);
+
+CREATE TABLE IF NOT EXISTS ormp_message_assigned (
+  id VARCHAR NOT NULL PRIMARY KEY,
+  block_number NUMERIC NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  block_timestamp NUMERIC NOT NULL,
+  chain_id NUMERIC NOT NULL,
+  msg_hash TEXT NOT NULL,
+  oracle TEXT NOT NULL,
+  relayer TEXT NOT NULL,
+  oracle_fee NUMERIC NOT NULL,
+  relayer_fee NUMERIC NOT NULL,
+  params TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS ormp_message_dispatched (
+  id VARCHAR NOT NULL PRIMARY KEY,
+  block_number NUMERIC NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  block_timestamp NUMERIC NOT NULL,
+  chain_id NUMERIC NOT NULL,
+  target_chain_id NUMERIC NOT NULL,
+  msg_hash TEXT NOT NULL,
+  dispatch_result BOOLEAN NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS msgport_message_recv (
+  id VARCHAR NOT NULL PRIMARY KEY,
+  block_number NUMERIC NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  block_timestamp NUMERIC NOT NULL,
+  transaction_index INTEGER NOT NULL,
+  log_index INTEGER NOT NULL,
+  chain_id NUMERIC NOT NULL,
+  port_address TEXT NOT NULL,
+  msg_id TEXT NOT NULL,
+  result BOOLEAN NOT NULL,
+  return_data TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS msgport_message_sent (
+  id VARCHAR NOT NULL PRIMARY KEY,
+  block_number NUMERIC NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  block_timestamp NUMERIC NOT NULL,
+  transaction_index INTEGER NOT NULL,
+  log_index INTEGER NOT NULL,
+  chain_id NUMERIC NOT NULL,
+  port_address TEXT NOT NULL,
+  transaction_from TEXT,
+  from_chain_id NUMERIC NOT NULL,
+  msg_id TEXT NOT NULL,
+  from_dapp TEXT NOT NULL,
+  to_chain_id NUMERIC NOT NULL,
+  to_dapp TEXT NOT NULL,
+  message TEXT NOT NULL,
+  params TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS signature_pub_signature_submittion (
+  id VARCHAR NOT NULL PRIMARY KEY,
+  block_number NUMERIC NOT NULL,
+  transaction_hash TEXT NOT NULL,
+  block_timestamp NUMERIC NOT NULL,
+  chain_id NUMERIC NOT NULL,
+  channel TEXT NOT NULL,
+  signer TEXT NOT NULL,
+  msg_index NUMERIC NOT NULL,
+  signature TEXT NOT NULL,
+  data TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS ormp_message_accepted_msg_hash_idx
+  ON ormp_message_accepted (msg_hash);
+CREATE INDEX IF NOT EXISTS ormp_message_assigned_msg_hash_idx
+  ON ormp_message_assigned (msg_hash);
+CREATE INDEX IF NOT EXISTS msgport_message_sent_msg_id_idx
+  ON msgport_message_sent (msg_id);
+CREATE INDEX IF NOT EXISTS msgport_message_recv_msg_id_idx
+  ON msgport_message_recv (msg_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod schema;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,4 +1,5 @@
 use crate::config::RuntimeConfig;
+use ormpindexer::schema::POSTGRES_SCHEMA_MIGRATION;
 
 pub async fn run() -> anyhow::Result<()> {
     let config = RuntimeConfig::from_env();
@@ -18,7 +19,8 @@ pub async fn migrate() -> anyhow::Result<()> {
     let config = RuntimeConfig::from_env();
 
     log::info!(
-        "no ORMP indexer migrations are defined yet database_configured={}",
+        "ORMP indexer schema compatibility migration is defined bytes={} database_configured={}",
+        POSTGRES_SCHEMA_MIGRATION.len(),
         config.database_url.is_some(),
     );
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,800 @@
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LegacyColumnType {
+    Text,
+    Numeric,
+    Integer,
+    Boolean,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LegacyColumn {
+    pub name: &'static str,
+    pub graphql_name: &'static str,
+    pub column_type: LegacyColumnType,
+    pub nullable: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LegacyTable {
+    pub table_name: &'static str,
+    pub graphql_entity: &'static str,
+    pub id_rule: LegacyIdRule,
+    pub columns: &'static [LegacyColumn],
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LegacyIdRule {
+    EventId,
+    HashField(&'static str),
+    MessageHash,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EventSource {
+    Evm,
+    Tron,
+}
+
+impl EventSource {
+    pub fn transaction_from_source(self) -> Option<&'static str> {
+        match self {
+            Self::Evm => Some("transaction.from"),
+            Self::Tron => Some("transaction.internalTransactions[logIndex].callerAddress"),
+        }
+    }
+
+    pub fn event_index_source(self) -> &'static str {
+        match self {
+            Self::Evm => "log.logIndex",
+            Self::Tron => "log.logIndex as eventIndex-compatible slot",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChainLogMetadata {
+    pub id: String,
+    pub source: EventSource,
+    pub chain_id: u128,
+    pub block_number: u128,
+    pub block_timestamp: u128,
+    pub transaction_hash: String,
+    pub transaction_index: i32,
+    pub log_index: i32,
+    pub contract_address: String,
+    pub transaction_from: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LegacyOrmPEvent {
+    HashImported {
+        metadata: ChainLogMetadata,
+        src_chain_id: u128,
+        target_chain_id: u128,
+        oracle: String,
+        channel: String,
+        msg_index: u128,
+        hash: String,
+    },
+    MessageAccepted {
+        metadata: ChainLogMetadata,
+        msg_hash: String,
+        channel: String,
+        index: u128,
+        from_chain_id: u128,
+        from: String,
+        to_chain_id: u128,
+        to: String,
+        gas_limit: u128,
+        encoded: String,
+    },
+    MessageAssigned {
+        metadata: ChainLogMetadata,
+        msg_hash: String,
+        oracle: String,
+        relayer: String,
+        oracle_fee: u128,
+        relayer_fee: u128,
+        params: String,
+    },
+    MessageDispatched {
+        metadata: ChainLogMetadata,
+        target_chain_id: u128,
+        msg_hash: String,
+        dispatch_result: bool,
+    },
+    MsgportMessageRecv {
+        metadata: ChainLogMetadata,
+        msg_id: String,
+        result: bool,
+        return_data: String,
+    },
+    MsgportMessageSent {
+        metadata: ChainLogMetadata,
+        msg_id: String,
+        from_dapp: String,
+        to_chain_id: u128,
+        to_dapp: String,
+        message: String,
+        params: String,
+    },
+    SignatureSubmittion {
+        metadata: ChainLogMetadata,
+        chain_id: u128,
+        channel: String,
+        signer: String,
+        msg_index: u128,
+        signature: String,
+        data: String,
+    },
+}
+
+pub const ADDRESS_RELAYER: &[&str] = &[
+    "0x114890eb7386f94eae410186f20968bfaf66142a",
+    "0xb607762f43f1a72593715497d4a7ddd754c62a6a",
+];
+
+pub const ADDRESS_ORACLE: &[&str] = &[
+    "0x8d8a2bd991c1d900c59a82a2eeb0df44e0671aab",
+    "0x2cdc7178013de451ed99607ac15def6bab8c37e6",
+];
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AssignmentConfig {
+    pub oracle_addresses: Vec<String>,
+    pub relayer_addresses: Vec<String>,
+}
+
+impl AssignmentConfig {
+    pub fn legacy_defaults() -> Self {
+        Self {
+            oracle_addresses: ADDRESS_ORACLE
+                .iter()
+                .map(|address| address.to_string())
+                .collect(),
+            relayer_addresses: ADDRESS_RELAYER
+                .iter()
+                .map(|address| address.to_string())
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct AssignmentUpdate {
+    pub oracle: bool,
+    pub relayer: bool,
+}
+
+pub fn apply_assignment_to_accepted(
+    accepted: &mut OrmpMessageAcceptedRow,
+    assigned: &OrmpMessageAssignedRow,
+    config: &AssignmentConfig,
+) -> AssignmentUpdate {
+    if accepted.id != assigned.msg_hash {
+        return AssignmentUpdate::default();
+    }
+
+    let mut update = AssignmentUpdate::default();
+
+    if contains_address(&config.relayer_addresses, &assigned.relayer) {
+        accepted.relayer = Some(assigned.relayer.clone());
+        accepted.relayer_assigned = Some(true);
+        accepted.relayer_assigned_fee = Some(assigned.relayer_fee);
+        update.relayer = true;
+    }
+
+    if contains_address(&config.oracle_addresses, &assigned.oracle) {
+        accepted.oracle = Some(assigned.oracle.clone());
+        accepted.oracle_assigned = Some(true);
+        accepted.oracle_assigned_fee = Some(assigned.oracle_fee);
+        update.oracle = true;
+    }
+
+    update
+}
+
+fn contains_address(addresses: &[String], candidate: &str) -> bool {
+    let candidate = candidate.to_ascii_lowercase();
+    addresses
+        .iter()
+        .any(|address| address.eq_ignore_ascii_case(&candidate))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OrmpHashImportedRow {
+    pub id: String,
+    pub block_number: u128,
+    pub transaction_hash: String,
+    pub block_timestamp: u128,
+    pub chain_id: u128,
+    pub src_chain_id: u128,
+    pub target_chain_id: u128,
+    pub oracle: String,
+    pub channel: String,
+    pub msg_index: u128,
+    pub hash: String,
+}
+
+impl OrmpHashImportedRow {
+    pub fn from_event(event: LegacyOrmPEvent) -> Self {
+        match event {
+            LegacyOrmPEvent::HashImported {
+                metadata,
+                src_chain_id,
+                target_chain_id,
+                oracle,
+                channel,
+                msg_index,
+                hash,
+            } => Self {
+                id: hash.clone(),
+                block_number: metadata.block_number,
+                transaction_hash: metadata.transaction_hash,
+                block_timestamp: metadata.block_timestamp,
+                chain_id: metadata.chain_id,
+                src_chain_id,
+                target_chain_id,
+                oracle,
+                channel,
+                msg_index,
+                hash,
+            },
+            _ => panic!("expected HashImported event"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OrmpMessageAcceptedRow {
+    pub id: String,
+    pub block_number: u128,
+    pub transaction_hash: String,
+    pub block_timestamp: u128,
+    pub chain_id: u128,
+    pub log_index: i32,
+    pub msg_hash: String,
+    pub channel: String,
+    pub index: u128,
+    pub from_chain_id: u128,
+    pub from: String,
+    pub to_chain_id: u128,
+    pub to: String,
+    pub gas_limit: u128,
+    pub encoded: String,
+    pub oracle: Option<String>,
+    pub oracle_assigned: Option<bool>,
+    pub oracle_assigned_fee: Option<u128>,
+    pub relayer: Option<String>,
+    pub relayer_assigned: Option<bool>,
+    pub relayer_assigned_fee: Option<u128>,
+}
+
+impl OrmpMessageAcceptedRow {
+    pub fn from_event(event: LegacyOrmPEvent) -> Self {
+        match event {
+            LegacyOrmPEvent::MessageAccepted {
+                metadata,
+                msg_hash,
+                channel,
+                index,
+                from_chain_id,
+                from,
+                to_chain_id,
+                to,
+                gas_limit,
+                encoded,
+            } => Self {
+                id: msg_hash.clone(),
+                block_number: metadata.block_number,
+                transaction_hash: metadata.transaction_hash,
+                block_timestamp: metadata.block_timestamp,
+                chain_id: metadata.chain_id,
+                log_index: metadata.log_index,
+                msg_hash,
+                channel,
+                index,
+                from_chain_id,
+                from,
+                to_chain_id,
+                to,
+                gas_limit,
+                encoded,
+                oracle: None,
+                oracle_assigned: None,
+                oracle_assigned_fee: None,
+                relayer: None,
+                relayer_assigned: None,
+                relayer_assigned_fee: None,
+            },
+            _ => panic!("expected MessageAccepted event"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OrmpMessageAssignedRow {
+    pub id: String,
+    pub block_number: u128,
+    pub transaction_hash: String,
+    pub block_timestamp: u128,
+    pub chain_id: u128,
+    pub msg_hash: String,
+    pub oracle: String,
+    pub relayer: String,
+    pub oracle_fee: u128,
+    pub relayer_fee: u128,
+    pub params: String,
+}
+
+impl OrmpMessageAssignedRow {
+    pub fn from_event(event: LegacyOrmPEvent) -> Self {
+        match event {
+            LegacyOrmPEvent::MessageAssigned {
+                metadata,
+                msg_hash,
+                oracle,
+                relayer,
+                oracle_fee,
+                relayer_fee,
+                params,
+            } => Self {
+                id: metadata.id,
+                block_number: metadata.block_number,
+                transaction_hash: metadata.transaction_hash,
+                block_timestamp: metadata.block_timestamp,
+                chain_id: metadata.chain_id,
+                msg_hash,
+                oracle,
+                relayer,
+                oracle_fee,
+                relayer_fee,
+                params,
+            },
+            _ => panic!("expected MessageAssigned event"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OrmpMessageDispatchedRow {
+    pub id: String,
+    pub block_number: u128,
+    pub transaction_hash: String,
+    pub block_timestamp: u128,
+    pub chain_id: u128,
+    pub target_chain_id: u128,
+    pub msg_hash: String,
+    pub dispatch_result: bool,
+}
+
+impl OrmpMessageDispatchedRow {
+    pub fn from_event(event: LegacyOrmPEvent) -> Self {
+        match event {
+            LegacyOrmPEvent::MessageDispatched {
+                metadata,
+                target_chain_id,
+                msg_hash,
+                dispatch_result,
+            } => Self {
+                id: msg_hash.clone(),
+                block_number: metadata.block_number,
+                transaction_hash: metadata.transaction_hash,
+                block_timestamp: metadata.block_timestamp,
+                chain_id: metadata.chain_id,
+                target_chain_id,
+                msg_hash,
+                dispatch_result,
+            },
+            _ => panic!("expected MessageDispatched event"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MsgportMessageRecvRow {
+    pub id: String,
+    pub block_number: u128,
+    pub transaction_hash: String,
+    pub block_timestamp: u128,
+    pub transaction_index: i32,
+    pub log_index: i32,
+    pub chain_id: u128,
+    pub port_address: String,
+    pub msg_id: String,
+    pub result: bool,
+    pub return_data: String,
+}
+
+impl MsgportMessageRecvRow {
+    pub fn from_event(event: LegacyOrmPEvent) -> Self {
+        match event {
+            LegacyOrmPEvent::MsgportMessageRecv {
+                metadata,
+                msg_id,
+                result,
+                return_data,
+            } => Self {
+                id: metadata.id,
+                block_number: metadata.block_number,
+                transaction_hash: metadata.transaction_hash,
+                block_timestamp: metadata.block_timestamp,
+                transaction_index: metadata.transaction_index,
+                log_index: metadata.log_index,
+                chain_id: metadata.chain_id,
+                port_address: metadata.contract_address,
+                msg_id,
+                result,
+                return_data,
+            },
+            _ => panic!("expected MsgportMessageRecv event"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MsgportMessageSentRow {
+    pub id: String,
+    pub block_number: u128,
+    pub transaction_hash: String,
+    pub block_timestamp: u128,
+    pub transaction_index: i32,
+    pub log_index: i32,
+    pub chain_id: u128,
+    pub port_address: String,
+    pub transaction_from: Option<String>,
+    pub from_chain_id: u128,
+    pub msg_id: String,
+    pub from_dapp: String,
+    pub to_chain_id: u128,
+    pub to_dapp: String,
+    pub message: String,
+    pub params: String,
+}
+
+impl MsgportMessageSentRow {
+    pub fn from_event(event: LegacyOrmPEvent) -> Self {
+        match event {
+            LegacyOrmPEvent::MsgportMessageSent {
+                metadata,
+                msg_id,
+                from_dapp,
+                to_chain_id,
+                to_dapp,
+                message,
+                params,
+            } => Self {
+                id: metadata.id,
+                block_number: metadata.block_number,
+                transaction_hash: metadata.transaction_hash,
+                block_timestamp: metadata.block_timestamp,
+                transaction_index: metadata.transaction_index,
+                log_index: metadata.log_index,
+                chain_id: metadata.chain_id,
+                port_address: metadata.contract_address,
+                transaction_from: metadata.transaction_from,
+                from_chain_id: metadata.chain_id,
+                msg_id,
+                from_dapp,
+                to_chain_id,
+                to_dapp,
+                message,
+                params,
+            },
+            _ => panic!("expected MsgportMessageSent event"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SignaturePubSignatureSubmittionRow {
+    pub id: String,
+    pub block_number: u128,
+    pub transaction_hash: String,
+    pub block_timestamp: u128,
+    pub chain_id: u128,
+    pub channel: String,
+    pub signer: String,
+    pub msg_index: u128,
+    pub signature: String,
+    pub data: String,
+}
+
+impl SignaturePubSignatureSubmittionRow {
+    pub fn from_event(event: LegacyOrmPEvent) -> Self {
+        match event {
+            LegacyOrmPEvent::SignatureSubmittion {
+                metadata,
+                chain_id,
+                channel,
+                signer,
+                msg_index,
+                signature,
+                data,
+            } => Self {
+                id: metadata.id,
+                block_number: metadata.block_number,
+                transaction_hash: metadata.transaction_hash,
+                block_timestamp: metadata.block_timestamp,
+                chain_id,
+                channel,
+                signer,
+                msg_index,
+                signature,
+                data,
+            },
+            _ => panic!("expected SignatureSubmittion event"),
+        }
+    }
+}
+
+pub struct LegacySchema;
+
+impl LegacySchema {
+    pub fn tables() -> &'static [LegacyTable] {
+        LEGACY_TABLES
+    }
+}
+
+pub const POSTGRES_SCHEMA_MIGRATION: &str = include_str!("../migrations/0001_schema_compat.sql");
+
+const COMMON_COLUMNS: &[LegacyColumn] = &[
+    column("id", "id", LegacyColumnType::Text, false),
+    column(
+        "block_number",
+        "blockNumber",
+        LegacyColumnType::Numeric,
+        false,
+    ),
+    column(
+        "transaction_hash",
+        "transactionHash",
+        LegacyColumnType::Text,
+        false,
+    ),
+    column(
+        "block_timestamp",
+        "blockTimestamp",
+        LegacyColumnType::Numeric,
+        false,
+    ),
+    column("chain_id", "chainId", LegacyColumnType::Numeric, false),
+];
+
+const ORMP_HASH_IMPORTED_COLUMNS: &[LegacyColumn] = &[
+    COMMON_COLUMNS[0],
+    COMMON_COLUMNS[1],
+    COMMON_COLUMNS[2],
+    COMMON_COLUMNS[3],
+    COMMON_COLUMNS[4],
+    column(
+        "src_chain_id",
+        "srcChainId",
+        LegacyColumnType::Numeric,
+        false,
+    ),
+    column(
+        "target_chain_id",
+        "targetChainId",
+        LegacyColumnType::Numeric,
+        false,
+    ),
+    column("oracle", "oracle", LegacyColumnType::Text, false),
+    column("channel", "channel", LegacyColumnType::Text, false),
+    column("msg_index", "msgIndex", LegacyColumnType::Numeric, false),
+    column("hash", "hash", LegacyColumnType::Text, false),
+];
+
+const ORMP_MESSAGE_ACCEPTED_COLUMNS: &[LegacyColumn] = &[
+    COMMON_COLUMNS[0],
+    COMMON_COLUMNS[1],
+    COMMON_COLUMNS[2],
+    COMMON_COLUMNS[3],
+    COMMON_COLUMNS[4],
+    column("log_index", "logIndex", LegacyColumnType::Integer, false),
+    column("msg_hash", "msgHash", LegacyColumnType::Text, false),
+    column("channel", "channel", LegacyColumnType::Text, false),
+    column("index", "index", LegacyColumnType::Numeric, false),
+    column(
+        "from_chain_id",
+        "fromChainId",
+        LegacyColumnType::Numeric,
+        false,
+    ),
+    column("from", "from", LegacyColumnType::Text, false),
+    column("to_chain_id", "toChainId", LegacyColumnType::Numeric, false),
+    column("to", "to", LegacyColumnType::Text, false),
+    column("gas_limit", "gasLimit", LegacyColumnType::Numeric, false),
+    column("encoded", "encoded", LegacyColumnType::Text, false),
+    column("oracle", "oracle", LegacyColumnType::Text, true),
+    column(
+        "oracle_assigned",
+        "oracleAssigned",
+        LegacyColumnType::Boolean,
+        true,
+    ),
+    column(
+        "oracle_assigned_fee",
+        "oracleAssignedFee",
+        LegacyColumnType::Numeric,
+        true,
+    ),
+    column("relayer", "relayer", LegacyColumnType::Text, true),
+    column(
+        "relayer_assigned",
+        "relayerAssigned",
+        LegacyColumnType::Boolean,
+        true,
+    ),
+    column(
+        "relayer_assigned_fee",
+        "relayerAssignedFee",
+        LegacyColumnType::Numeric,
+        true,
+    ),
+];
+
+const ORMP_MESSAGE_ASSIGNED_COLUMNS: &[LegacyColumn] = &[
+    COMMON_COLUMNS[0],
+    COMMON_COLUMNS[1],
+    COMMON_COLUMNS[2],
+    COMMON_COLUMNS[3],
+    COMMON_COLUMNS[4],
+    column("msg_hash", "msgHash", LegacyColumnType::Text, false),
+    column("oracle", "oracle", LegacyColumnType::Text, false),
+    column("relayer", "relayer", LegacyColumnType::Text, false),
+    column("oracle_fee", "oracleFee", LegacyColumnType::Numeric, false),
+    column(
+        "relayer_fee",
+        "relayerFee",
+        LegacyColumnType::Numeric,
+        false,
+    ),
+    column("params", "params", LegacyColumnType::Text, false),
+];
+
+const ORMP_MESSAGE_DISPATCHED_COLUMNS: &[LegacyColumn] = &[
+    COMMON_COLUMNS[0],
+    COMMON_COLUMNS[1],
+    COMMON_COLUMNS[2],
+    COMMON_COLUMNS[3],
+    COMMON_COLUMNS[4],
+    column(
+        "target_chain_id",
+        "targetChainId",
+        LegacyColumnType::Numeric,
+        false,
+    ),
+    column("msg_hash", "msgHash", LegacyColumnType::Text, false),
+    column(
+        "dispatch_result",
+        "dispatchResult",
+        LegacyColumnType::Boolean,
+        false,
+    ),
+];
+
+const MSGPORT_MESSAGE_RECV_COLUMNS: &[LegacyColumn] = &[
+    COMMON_COLUMNS[0],
+    COMMON_COLUMNS[1],
+    COMMON_COLUMNS[2],
+    COMMON_COLUMNS[3],
+    column(
+        "transaction_index",
+        "transactionIndex",
+        LegacyColumnType::Integer,
+        false,
+    ),
+    column("log_index", "logIndex", LegacyColumnType::Integer, false),
+    COMMON_COLUMNS[4],
+    column("port_address", "portAddress", LegacyColumnType::Text, false),
+    column("msg_id", "msgId", LegacyColumnType::Text, false),
+    column("result", "result", LegacyColumnType::Boolean, false),
+    column("return_data", "returnData", LegacyColumnType::Text, false),
+];
+
+const MSGPORT_MESSAGE_SENT_COLUMNS: &[LegacyColumn] = &[
+    COMMON_COLUMNS[0],
+    COMMON_COLUMNS[1],
+    COMMON_COLUMNS[2],
+    COMMON_COLUMNS[3],
+    column(
+        "transaction_index",
+        "transactionIndex",
+        LegacyColumnType::Integer,
+        false,
+    ),
+    column("log_index", "logIndex", LegacyColumnType::Integer, false),
+    COMMON_COLUMNS[4],
+    column("port_address", "portAddress", LegacyColumnType::Text, false),
+    column(
+        "transaction_from",
+        "transactionFrom",
+        LegacyColumnType::Text,
+        true,
+    ),
+    column(
+        "from_chain_id",
+        "fromChainId",
+        LegacyColumnType::Numeric,
+        false,
+    ),
+    column("msg_id", "msgId", LegacyColumnType::Text, false),
+    column("from_dapp", "fromDapp", LegacyColumnType::Text, false),
+    column("to_chain_id", "toChainId", LegacyColumnType::Numeric, false),
+    column("to_dapp", "toDapp", LegacyColumnType::Text, false),
+    column("message", "message", LegacyColumnType::Text, false),
+    column("params", "params", LegacyColumnType::Text, false),
+];
+
+const SIGNATURE_PUB_SIGNATURE_SUBMITTION_COLUMNS: &[LegacyColumn] = &[
+    COMMON_COLUMNS[0],
+    COMMON_COLUMNS[1],
+    COMMON_COLUMNS[2],
+    COMMON_COLUMNS[3],
+    COMMON_COLUMNS[4],
+    column("channel", "channel", LegacyColumnType::Text, false),
+    column("signer", "signer", LegacyColumnType::Text, false),
+    column("msg_index", "msgIndex", LegacyColumnType::Numeric, false),
+    column("signature", "signature", LegacyColumnType::Text, false),
+    column("data", "data", LegacyColumnType::Text, false),
+];
+
+const LEGACY_TABLES: &[LegacyTable] = &[
+    LegacyTable {
+        table_name: "ormp_hash_imported",
+        graphql_entity: "ORMPHashImported",
+        id_rule: LegacyIdRule::HashField("hash"),
+        columns: ORMP_HASH_IMPORTED_COLUMNS,
+    },
+    LegacyTable {
+        table_name: "ormp_message_accepted",
+        graphql_entity: "ORMPMessageAccepted",
+        id_rule: LegacyIdRule::MessageHash,
+        columns: ORMP_MESSAGE_ACCEPTED_COLUMNS,
+    },
+    LegacyTable {
+        table_name: "ormp_message_assigned",
+        graphql_entity: "ORMPMessageAssigned",
+        id_rule: LegacyIdRule::EventId,
+        columns: ORMP_MESSAGE_ASSIGNED_COLUMNS,
+    },
+    LegacyTable {
+        table_name: "ormp_message_dispatched",
+        graphql_entity: "ORMPMessageDispatched",
+        id_rule: LegacyIdRule::MessageHash,
+        columns: ORMP_MESSAGE_DISPATCHED_COLUMNS,
+    },
+    LegacyTable {
+        table_name: "msgport_message_recv",
+        graphql_entity: "MsgportMessageRecv",
+        id_rule: LegacyIdRule::EventId,
+        columns: MSGPORT_MESSAGE_RECV_COLUMNS,
+    },
+    LegacyTable {
+        table_name: "msgport_message_sent",
+        graphql_entity: "MsgportMessageSent",
+        id_rule: LegacyIdRule::EventId,
+        columns: MSGPORT_MESSAGE_SENT_COLUMNS,
+    },
+    LegacyTable {
+        table_name: "signature_pub_signature_submittion",
+        graphql_entity: "SignaturePubSignatureSubmittion",
+        id_rule: LegacyIdRule::EventId,
+        columns: SIGNATURE_PUB_SIGNATURE_SUBMITTION_COLUMNS,
+    },
+];
+
+const fn column(
+    name: &'static str,
+    graphql_name: &'static str,
+    column_type: LegacyColumnType,
+    nullable: bool,
+) -> LegacyColumn {
+    LegacyColumn {
+        name,
+        graphql_name,
+        column_type,
+        nullable,
+    }
+}

--- a/tests/schema_compatibility.rs
+++ b/tests/schema_compatibility.rs
@@ -1,0 +1,198 @@
+use ormpindexer::schema::{
+    ADDRESS_ORACLE, ADDRESS_RELAYER, AssignmentConfig, ChainLogMetadata, EventSource,
+    LegacyOrmPEvent, LegacySchema, MsgportMessageRecvRow, MsgportMessageSentRow,
+    OrmpMessageAcceptedRow, OrmpMessageAssignedRow, SignaturePubSignatureSubmittionRow,
+    apply_assignment_to_accepted,
+};
+
+#[test]
+fn test_ormp_accepted_uses_msg_hash_id_and_nullable_assignment_fields() {
+    let event = LegacyOrmPEvent::MessageAccepted {
+        metadata: evm_metadata("log-1"),
+        msg_hash: "0xabc".to_owned(),
+        channel: "0xchannel".to_owned(),
+        index: 7,
+        from_chain_id: 1,
+        from: "0xfrom".to_owned(),
+        to_chain_id: 46,
+        to: "0xto".to_owned(),
+        gas_limit: 500_000,
+        encoded: "0xencoded".to_owned(),
+    };
+
+    let row = OrmpMessageAcceptedRow::from_event(event);
+
+    assert_eq!(row.id, "0xabc");
+    assert_eq!(row.msg_hash, "0xabc");
+    assert_eq!(row.log_index, 3);
+    assert_eq!(row.transaction_hash, "0xtx");
+    assert_eq!(row.oracle, None);
+    assert_eq!(row.oracle_assigned, None);
+    assert_eq!(row.oracle_assigned_fee, None);
+    assert_eq!(row.relayer, None);
+    assert_eq!(row.relayer_assigned, None);
+    assert_eq!(row.relayer_assigned_fee, None);
+}
+
+#[test]
+fn test_assigned_backfills_accepted_when_configured_addresses_match() {
+    let accepted_event = LegacyOrmPEvent::MessageAccepted {
+        metadata: evm_metadata("accepted-log"),
+        msg_hash: "0xmsg".to_owned(),
+        channel: "0xchannel".to_owned(),
+        index: 8,
+        from_chain_id: 1,
+        from: "0xfrom".to_owned(),
+        to_chain_id: 46,
+        to: "0xto".to_owned(),
+        gas_limit: 500_000,
+        encoded: "0xencoded".to_owned(),
+    };
+    let mut accepted = OrmpMessageAcceptedRow::from_event(accepted_event);
+    let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+        metadata: evm_metadata("assigned-log"),
+        msg_hash: "0xmsg".to_owned(),
+        oracle: ADDRESS_ORACLE[0].to_ascii_uppercase(),
+        relayer: ADDRESS_RELAYER[0].to_ascii_uppercase(),
+        oracle_fee: 11,
+        relayer_fee: 22,
+        params: "0xparams".to_owned(),
+    });
+
+    let updated = apply_assignment_to_accepted(
+        &mut accepted,
+        &assigned,
+        &AssignmentConfig::legacy_defaults(),
+    );
+
+    assert!(updated.oracle);
+    assert!(updated.relayer);
+    assert_eq!(accepted.oracle.as_deref(), Some(assigned.oracle.as_str()));
+    assert_eq!(accepted.oracle_assigned, Some(true));
+    assert_eq!(accepted.oracle_assigned_fee, Some(11));
+    assert_eq!(accepted.relayer.as_deref(), Some(assigned.relayer.as_str()));
+    assert_eq!(accepted.relayer_assigned, Some(true));
+    assert_eq!(accepted.relayer_assigned_fee, Some(22));
+}
+
+#[test]
+fn test_msgport_sent_and_recv_preserve_event_metadata() {
+    let sent = MsgportMessageSentRow::from_event(LegacyOrmPEvent::MsgportMessageSent {
+        metadata: evm_metadata("sent-log"),
+        msg_id: "0xmsgid".to_owned(),
+        from_dapp: "0xfromdapp".to_owned(),
+        to_chain_id: 728_126_428,
+        to_dapp: "0xtodapp".to_owned(),
+        message: "0xmessage".to_owned(),
+        params: "0xparams".to_owned(),
+    });
+    let recv = MsgportMessageRecvRow::from_event(LegacyOrmPEvent::MsgportMessageRecv {
+        metadata: tron_metadata("recv-log"),
+        msg_id: "0xmsgid".to_owned(),
+        result: true,
+        return_data: "0xreturn".to_owned(),
+    });
+
+    assert_eq!(sent.id, "sent-log");
+    assert_eq!(sent.from_chain_id, sent.chain_id);
+    assert_eq!(sent.transaction_index, 2);
+    assert_eq!(sent.log_index, 3);
+    assert_eq!(sent.transaction_from.as_deref(), Some("0xsender"));
+
+    assert_eq!(recv.id, "recv-log");
+    assert_eq!(recv.transaction_index, 9);
+    assert_eq!(recv.log_index, 5);
+    assert_eq!(recv.port_address, "0xtronport");
+}
+
+#[test]
+fn test_signature_submittion_uses_event_id_and_event_payload_fields() {
+    let row =
+        SignaturePubSignatureSubmittionRow::from_event(LegacyOrmPEvent::SignatureSubmittion {
+            metadata: evm_metadata("sig-log"),
+            chain_id: 46,
+            channel: "0xchannel".to_owned(),
+            signer: "0xsigner".to_owned(),
+            msg_index: 99,
+            signature: "0xsig".to_owned(),
+            data: "0xdata".to_owned(),
+        });
+
+    assert_eq!(row.id, "sig-log");
+    assert_eq!(row.block_number, 123);
+    assert_eq!(row.transaction_hash, "0xtx");
+    assert_eq!(row.chain_id, 46);
+    assert_eq!(row.msg_index, 99);
+    assert_eq!(row.signature, "0xsig");
+}
+
+#[test]
+fn test_schema_contract_lists_legacy_tables_and_metadata_gaps() {
+    let tables = LegacySchema::tables();
+    let names = tables
+        .iter()
+        .map(|table| table.table_name)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        names,
+        vec![
+            "ormp_hash_imported",
+            "ormp_message_accepted",
+            "ormp_message_assigned",
+            "ormp_message_dispatched",
+            "msgport_message_recv",
+            "msgport_message_sent",
+            "signature_pub_signature_submittion",
+        ]
+    );
+    assert!(
+        tables
+            .iter()
+            .find(|table| table.table_name == "ormp_message_accepted")
+            .expect("accepted table")
+            .columns
+            .iter()
+            .any(|column| column.name == "oracle_assigned_fee" && column.nullable)
+    );
+    assert!(
+        ormpindexer::schema::POSTGRES_SCHEMA_MIGRATION
+            .contains("CREATE TABLE IF NOT EXISTS ormp_message_accepted")
+    );
+    assert_eq!(
+        EventSource::Tron
+            .transaction_from_source()
+            .expect("tron source is documented"),
+        "transaction.internalTransactions[logIndex].callerAddress"
+    );
+}
+
+fn evm_metadata(id: &str) -> ChainLogMetadata {
+    ChainLogMetadata {
+        id: id.to_owned(),
+        source: EventSource::Evm,
+        chain_id: 46,
+        block_number: 123,
+        block_timestamp: 456,
+        transaction_hash: "0xtx".to_owned(),
+        transaction_index: 2,
+        log_index: 3,
+        contract_address: "0xport".to_owned(),
+        transaction_from: Some("0xsender".to_owned()),
+    }
+}
+
+fn tron_metadata(id: &str) -> ChainLogMetadata {
+    ChainLogMetadata {
+        id: id.to_owned(),
+        source: EventSource::Tron,
+        chain_id: 728_126_428,
+        block_number: 987,
+        block_timestamp: 654,
+        transaction_hash: "0xtrontx".to_owned(),
+        transaction_index: 9,
+        log_index: 5,
+        contract_address: "0xtronport".to_owned(),
+        transaction_from: None,
+    }
+}


### PR DESCRIPTION
## Summary
- define the legacy ORMP/Msgport/SignaturePub schema compatibility contract in Rust
- add a Postgres schema compatibility migration matching the old Subsquid tables
- add regression tests for accepted mapping, assignment backfill, Msgport sent/recv, and SignaturePub submittion mapping

## Validation
- cargo fmt --check
- cargo build
- cargo test