### PR TITLE
HBX-448: add EVM Datalens log query planner

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use std::{collections::BTreeMap, env, fmt, time::Duration};
 
 use anyhow::{Context, bail};
 
+use crate::planner::default_evm_chain_config;
+
 pub const DEFAULT_DATASET: &str = "datalens-native";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -36,7 +38,7 @@ impl RuntimeConfig {
     }
 
     pub fn from_env_map(env: &BTreeMap<String, String>) -> anyhow::Result<Self> {
-        let start_block = optional_u64(env, "ORMPINDEXER_START_BLOCK")?.unwrap_or(0);
+        let start_block = optional_u64(env, "ORMPINDEXER_START_BLOCK")?;
         let chain_ids = required_list(env, "ORMPINDEXER_ENABLED_CHAINS")?
             .into_iter()
             .map(|value| {
@@ -62,7 +64,7 @@ impl RuntimeConfig {
             database_url: optional_env(env, "ORMPINDEXER_DATABASE_URL").map(SecretString::new),
             enabled_chains,
             batch_size: optional_u64(env, "ORMPINDEXER_BATCH_SIZE")?.unwrap_or(1_000),
-            start_block,
+            start_block: start_block.unwrap_or(0),
             finality_mode: optional_env(env, "ORMPINDEXER_FINALITY_MODE")
                 .as_deref()
                 .map(str::parse)
@@ -102,19 +104,29 @@ impl ChainConfig {
     fn from_env_map(
         env: &BTreeMap<String, String>,
         chain_id: u64,
-        default_start_block: u64,
+        default_start_block: Option<u64>,
     ) -> anyhow::Result<Self> {
         let prefix = format!("ORMPINDEXER_CHAIN_{chain_id}");
-        let contracts = required_list(env, &format!("{prefix}_CONTRACTS"))?;
+        let default = default_evm_chain_config(chain_id)?;
+        let contracts = optional_list(env, &format!("{prefix}_CONTRACTS"));
         let topics = optional_list(env, &format!("{prefix}_TOPICS"));
-        let start_block =
-            optional_u64(env, &format!("{prefix}_START_BLOCK"))?.unwrap_or(default_start_block);
+        let start_block = optional_u64(env, &format!("{prefix}_START_BLOCK"))?
+            .or(default_start_block)
+            .unwrap_or(default.start_block);
 
         Ok(Self {
             chain_id,
             start_block,
-            contracts,
-            topics,
+            contracts: if contracts.is_empty() {
+                default.contracts
+            } else {
+                contracts
+            },
+            topics: if topics.is_empty() {
+                default.topics
+            } else {
+                topics
+            },
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod database;
 pub mod datalens;
 pub mod decoder;
+pub mod planner;
 pub mod runner;
 pub mod runtime;
 pub mod schema;

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -1,0 +1,178 @@
+use anyhow::{bail, ensure};
+
+use crate::{
+    config::{ChainConfig, FinalityMode},
+    datalens::DatalensLogQuery,
+};
+
+pub const MSGPORT_ADDRESS: &str = "0x2cd1867Fb8016f93710B6386f7f9F1D540A60812";
+pub const ORMP_ADDRESS: &str = "0x13b2211a7cA45Db2808F6dB05557ce5347e3634e";
+pub const SIGNATURE_PUB_ADDRESS: &str = "0x57Aa601A0377f5AB313C5A955ee874f5D495fC92";
+
+pub const MSGPORT_MESSAGE_RECV_TOPIC: &str =
+    "0xea087580bb17f433441f3b6c0c0b80cae92ee74a8d7f50050388646d9ffd1431";
+pub const MSGPORT_MESSAGE_SENT_TOPIC: &str =
+    "0x40195d26d027672e04e23e34282d68c3d43ea138415b24c54fcdb9c2573e5975";
+pub const ORMP_HASH_IMPORTED_TOPIC: &str =
+    "0xa931ec14fe958397dcb26e285e56292c13d77907712b51bbaa24cfc9349b789d";
+pub const ORMP_MESSAGE_ACCEPTED_TOPIC: &str =
+    "0xcfb9b3466878aff0c7df17da215fd57d59eb245a5d03f5a7b57294d54581eb18";
+pub const ORMP_MESSAGE_ASSIGNED_TOPIC: &str =
+    "0x3832f95736b288316c84b775a004a9d17177362548ce253cba9acb4801875f4d";
+pub const ORMP_MESSAGE_DISPATCHED_TOPIC: &str =
+    "0x62b1dc20fd6f1518626da5b6f9897e8cd4ebadbad071bb66dc96a37c970087a8";
+pub const SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC: &str =
+    "0x8b3975e4768e70d323e926e2cef0676fc9a3250437d9b8f90b52c770f0d7545f";
+
+pub const PRODUCTION_EVM_CHAIN_IDS: &[u64] = &[1, 46, 137, 42161];
+
+const DEFAULT_EVM_CHAINS: &[DefaultEvmChain] = &[
+    DefaultEvmChain {
+        chain_id: 1,
+        start_block: 20_009_590,
+        include_signature_pub: false,
+    },
+    DefaultEvmChain {
+        chain_id: 46,
+        start_block: 2_830_100,
+        include_signature_pub: true,
+    },
+    DefaultEvmChain {
+        chain_id: 137,
+        start_block: 57_244_567,
+        include_signature_pub: false,
+    },
+    DefaultEvmChain {
+        chain_id: 42161,
+        start_block: 217_891_600,
+        include_signature_pub: false,
+    },
+    DefaultEvmChain {
+        chain_id: 8453,
+        start_block: 30_508_102,
+        include_signature_pub: false,
+    },
+    DefaultEvmChain {
+        chain_id: 44,
+        start_block: 2_900_604,
+        include_signature_pub: false,
+    },
+    DefaultEvmChain {
+        chain_id: 1284,
+        start_block: 6_294_138,
+        include_signature_pub: false,
+    },
+    DefaultEvmChain {
+        chain_id: 81457,
+        start_block: 4_293_849,
+        include_signature_pub: false,
+    },
+    DefaultEvmChain {
+        chain_id: 2818,
+        start_block: 59_565,
+        include_signature_pub: false,
+    },
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct DefaultEvmChain {
+    chain_id: u64,
+    start_block: u64,
+    include_signature_pub: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PlannedDatalensLogQuery {
+    pub dataset: String,
+    pub query: DatalensLogQuery,
+}
+
+pub fn default_evm_chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
+    let Some(default) = DEFAULT_EVM_CHAINS
+        .iter()
+        .find(|chain| chain.chain_id == chain_id)
+    else {
+        bail!("unconfigured ORMP EVM chain {chain_id}");
+    };
+
+    Ok(ChainConfig {
+        chain_id,
+        start_block: default.start_block,
+        contracts: default_contracts(default.include_signature_pub),
+        topics: default_topics(default.include_signature_pub),
+    })
+}
+
+pub fn plan_evm_log_queries(
+    dataset: &str,
+    chain: &ChainConfig,
+    from_block: u64,
+    to_block: u64,
+    max_range_len: u64,
+    finality_mode: FinalityMode,
+) -> anyhow::Result<Vec<PlannedDatalensLogQuery>> {
+    ensure!(
+        max_range_len > 0,
+        "max range length must be greater than zero"
+    );
+    ensure!(
+        from_block <= to_block,
+        "from block must be less than or equal to to block"
+    );
+    ensure!(
+        !chain.contracts.is_empty(),
+        "EVM log query planner requires at least one contract address"
+    );
+    ensure!(
+        !chain.topics.is_empty(),
+        "EVM log query planner requires at least one event topic"
+    );
+
+    let mut plans = Vec::new();
+    let mut next_from = from_block;
+
+    while next_from <= to_block {
+        let range_end = next_from.saturating_add(max_range_len - 1).min(to_block);
+        plans.push(PlannedDatalensLogQuery {
+            dataset: dataset.to_owned(),
+            query: DatalensLogQuery {
+                chain_id: chain.chain_id,
+                from_block: next_from,
+                to_block: range_end,
+                contracts: chain.contracts.clone(),
+                topics: chain.topics.clone(),
+                finality_mode,
+            },
+        });
+
+        if range_end == u64::MAX {
+            break;
+        }
+        next_from = range_end + 1;
+    }
+
+    Ok(plans)
+}
+
+fn default_contracts(include_signature_pub: bool) -> Vec<String> {
+    let mut contracts = vec![MSGPORT_ADDRESS.to_owned(), ORMP_ADDRESS.to_owned()];
+    if include_signature_pub {
+        contracts.push(SIGNATURE_PUB_ADDRESS.to_owned());
+    }
+    contracts
+}
+
+fn default_topics(include_signature_pub: bool) -> Vec<String> {
+    let mut topics = vec![
+        MSGPORT_MESSAGE_RECV_TOPIC.to_owned(),
+        MSGPORT_MESSAGE_SENT_TOPIC.to_owned(),
+        ORMP_HASH_IMPORTED_TOPIC.to_owned(),
+        ORMP_MESSAGE_ACCEPTED_TOPIC.to_owned(),
+        ORMP_MESSAGE_ASSIGNED_TOPIC.to_owned(),
+        ORMP_MESSAGE_DISPATCHED_TOPIC.to_owned(),
+    ];
+    if include_signature_pub {
+        topics.push(SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC.to_owned());
+    }
+    topics
+}

--- a/tests/datalens_planner.rs
+++ b/tests/datalens_planner.rs
@@ -1,0 +1,134 @@
+use std::collections::BTreeMap;
+
+use ormpindexer::{
+    config::{FinalityMode, RuntimeConfig},
+    planner::{
+        PRODUCTION_EVM_CHAIN_IDS, SIGNATURE_PUB_ADDRESS, SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
+        default_evm_chain_config, plan_evm_log_queries,
+    },
+};
+
+#[test]
+fn test_production_evm_chains_produce_default_query_plans() {
+    for chain_id in PRODUCTION_EVM_CHAIN_IDS {
+        let chain = default_evm_chain_config(*chain_id).expect("configured production chain");
+        let plans = plan_evm_log_queries(
+            "datalens-native",
+            &chain,
+            chain.start_block,
+            chain.start_block + 9,
+            100,
+            FinalityMode::Finalized,
+        )
+        .expect("query plans");
+
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].dataset, "datalens-native");
+        assert_eq!(plans[0].query.chain_id, *chain_id);
+        assert_eq!(plans[0].query.from_block, chain.start_block);
+        assert_eq!(plans[0].query.to_block, chain.start_block + 9);
+        assert_eq!(plans[0].query.contracts, chain.contracts);
+        assert_eq!(plans[0].query.topics, chain.topics);
+        assert_eq!(plans[0].query.finality_mode, FinalityMode::Finalized);
+    }
+}
+
+#[test]
+fn test_darwinia_includes_signature_pub_but_other_defaults_do_not() {
+    let darwinia = default_evm_chain_config(46).expect("darwinia");
+    let ethereum = default_evm_chain_config(1).expect("ethereum");
+    let polygon = default_evm_chain_config(137).expect("polygon");
+    let arbitrum = default_evm_chain_config(42161).expect("arbitrum");
+
+    assert!(
+        darwinia
+            .contracts
+            .contains(&SIGNATURE_PUB_ADDRESS.to_owned())
+    );
+    assert!(
+        darwinia
+            .topics
+            .contains(&SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC.to_owned())
+    );
+
+    for chain in [ethereum, polygon, arbitrum] {
+        assert!(!chain.contracts.contains(&SIGNATURE_PUB_ADDRESS.to_owned()));
+        assert!(
+            !chain
+                .topics
+                .contains(&SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC.to_owned())
+        );
+    }
+}
+
+#[test]
+fn test_plan_evm_log_queries_splits_ranges_by_limit() {
+    let chain = default_evm_chain_config(46).expect("darwinia");
+    let plans = plan_evm_log_queries(
+        "datalens-native",
+        &chain,
+        100,
+        220,
+        50,
+        FinalityMode::Durable,
+    )
+    .expect("split plans");
+    let ranges = plans
+        .iter()
+        .map(|plan| (plan.query.from_block, plan.query.to_block))
+        .collect::<Vec<_>>();
+
+    assert_eq!(ranges, vec![(100, 149), (150, 199), (200, 220)]);
+    assert!(plans.iter().all(|plan| plan.query.chain_id == 46));
+    assert!(
+        plans
+            .iter()
+            .all(|plan| plan.query.finality_mode == FinalityMode::Durable)
+    );
+}
+
+#[test]
+fn test_unknown_chain_returns_clear_error() {
+    let error = default_evm_chain_config(999_999).expect_err("unknown chain");
+
+    assert!(
+        error
+            .to_string()
+            .contains("unconfigured ORMP EVM chain 999999")
+    );
+}
+
+#[test]
+fn test_runtime_config_uses_confirmed_defaults_without_lisk() {
+    let env = BTreeMap::from([("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "1,46".to_owned())]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+
+    assert!(config.chain(1).is_some());
+    assert!(config.chain(46).is_some());
+    assert!(config.chain(1135).is_none());
+    assert_eq!(config.chain(1).expect("ethereum").start_block, 20_009_590);
+    assert_eq!(config.chain(46).expect("darwinia").start_block, 2_830_100);
+}
+
+#[test]
+fn test_confirmed_evm_chain_defaults_are_available_without_lisk() {
+    let starts = [
+        (1, 20_009_590),
+        (46, 2_830_100),
+        (137, 57_244_567),
+        (42161, 217_891_600),
+        (8453, 30_508_102),
+        (44, 2_900_604),
+        (1284, 6_294_138),
+        (81457, 4_293_849),
+        (2818, 59_565),
+    ];
+
+    for (chain_id, start_block) in starts {
+        let chain = default_evm_chain_config(chain_id).expect("confirmed default chain");
+
+        assert_eq!(chain.start_block, start_block);
+    }
+
+    assert!(default_evm_chain_config(1135).is_err());
+}


### PR DESCRIPTION
## Summary
- add EVM ORMP Datalens log query planner defaults and range splitting
- add legacy Msgport/ORMP/SignaturePub contract and topic constants
- let runtime config use confirmed EVM defaults when per-chain env selectors are omitted

## Validation
- cargo fmt --check
- cargo build
- cargo test

HBX-448