### PR TITLE
HBX-449: decode legacy ORMP events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +147,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -226,6 +250,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,6 +308,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -341,6 +392,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethabi"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+dependencies = [
+ "ethereum-types",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 1.0.69",
+ "uint",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +451,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.6",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "flume"
@@ -382,6 +489,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -758,6 +871,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +946,30 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -975,6 +1150,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ethabi",
+ "hex",
  "log",
  "reqwest",
  "serde",
@@ -983,6 +1160,34 @@ dependencies = [
  "tokio",
  "tracing-log",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1087,6 +1292,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,7 +1336,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1130,7 +1357,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1164,6 +1391,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1243,6 +1476,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1312,6 +1557,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1591,12 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustls"
@@ -1468,6 +1729,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,7 +1848,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1657,7 +1928,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -1694,7 +1965,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "whoami",
 ]
@@ -1717,7 +1988,7 @@ dependencies = [
  "percent-encoding",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "url",
 ]
@@ -1727,6 +1998,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -1783,12 +2060,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1809,6 +2112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -1881,6 +2193,36 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2001,6 +2343,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2380,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2437,6 +2797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,6 +2816,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 [dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.6.1", features = ["derive"] }
+ethabi = "18.0.0"
+hex = "0.4.3"
 log = "0.4.30"
 reqwest = { version = "0.12.26", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -15,11 +15,19 @@ pub struct DatalensLogQuery {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DatalensLog {
+    #[serde(default)]
+    pub id: Option<String>,
     pub chain_id: u64,
     pub block_number: u64,
+    #[serde(default)]
+    pub block_timestamp: Option<u64>,
     pub transaction_hash: String,
+    #[serde(default)]
+    pub transaction_index: Option<i32>,
     pub log_index: u64,
     pub address: String,
+    #[serde(default)]
+    pub transaction_from: Option<String>,
     pub topics: Vec<String>,
     pub data: String,
 }
@@ -62,11 +70,15 @@ impl DatalensLogReader for DatalensHttpClient {
             "query": r#"
                 query OrmpIndexerLogs($input: EvmLogsInput!) {
                   evmLogs(input: $input) {
+                    id
                     chainId
                     blockNumber
+                    blockTimestamp
                     transactionHash
+                    transactionIndex
                     logIndex
                     address
+                    transactionFrom
                     topics
                     data
                   }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,5 +1,15 @@
-use crate::datalens::DatalensLog;
-use crate::schema::LegacyOrmPEvent;
+use anyhow::{Context, bail, ensure};
+use ethabi::{ParamType, Token, decode};
+
+use crate::{
+    datalens::DatalensLog,
+    planner::{
+        MSGPORT_MESSAGE_RECV_TOPIC, MSGPORT_MESSAGE_SENT_TOPIC, ORMP_HASH_IMPORTED_TOPIC,
+        ORMP_MESSAGE_ACCEPTED_TOPIC, ORMP_MESSAGE_ASSIGNED_TOPIC, ORMP_MESSAGE_DISPATCHED_TOPIC,
+        SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
+    },
+    schema::{ChainLogMetadata, EventSource, LegacyOrmPEvent},
+};
 
 #[allow(async_fn_in_trait)]
 pub trait EventDecoder {
@@ -13,4 +23,306 @@ impl EventDecoder for NoopDecoder {
     async fn decode(&self, _log: &DatalensLog) -> anyhow::Result<Vec<LegacyOrmPEvent>> {
         Ok(Vec::new())
     }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EvmEventDecoder;
+
+impl EventDecoder for EvmEventDecoder {
+    async fn decode(&self, log: &DatalensLog) -> anyhow::Result<Vec<LegacyOrmPEvent>> {
+        decode_evm_log(log).map(|event| vec![event])
+    }
+}
+
+pub fn decode_evm_log(log: &DatalensLog) -> anyhow::Result<LegacyOrmPEvent> {
+    let topic0 = log
+        .topics
+        .first()
+        .map(|topic| normalize_hex(topic))
+        .transpose()?
+        .context("EVM log is missing topic0")?;
+    let metadata = evm_metadata(log)?;
+    let data = decode_hex(&log.data).context("decode EVM log data")?;
+
+    match topic0.as_str() {
+        ORMP_HASH_IMPORTED_TOPIC => decode_hash_imported(metadata, &data),
+        ORMP_MESSAGE_ACCEPTED_TOPIC => decode_message_accepted(metadata, &data),
+        ORMP_MESSAGE_ASSIGNED_TOPIC => decode_message_assigned(metadata, &data),
+        ORMP_MESSAGE_DISPATCHED_TOPIC => decode_message_dispatched(metadata, &data),
+        MSGPORT_MESSAGE_RECV_TOPIC => decode_msgport_message_recv(metadata, &data),
+        MSGPORT_MESSAGE_SENT_TOPIC => decode_msgport_message_sent(metadata, &data),
+        SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC => decode_signature_submittion(metadata, &data),
+        _ => bail!("unsupported ORMP EVM event topic0 {topic0}"),
+    }
+}
+
+fn evm_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
+    Ok(ChainLogMetadata {
+        id: log
+            .id
+            .clone()
+            .context("EVM log is missing legacy event id")?,
+        source: EventSource::Evm,
+        chain_id: log.chain_id.into(),
+        block_number: log.block_number.into(),
+        block_timestamp: log
+            .block_timestamp
+            .context("EVM log is missing block timestamp")?
+            .into(),
+        transaction_hash: normalize_hex(&log.transaction_hash)?,
+        transaction_index: log
+            .transaction_index
+            .context("EVM log is missing transaction index")?,
+        log_index: i32::try_from(log.log_index).context("EVM log index overflows i32")?,
+        contract_address: normalize_hex(&log.address)?,
+        transaction_from: log
+            .transaction_from
+            .as_deref()
+            .map(normalize_hex)
+            .transpose()?,
+    })
+}
+
+fn decode_hash_imported(
+    metadata: ChainLogMetadata,
+    data: &[u8],
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let mut tokens = decode_event(
+        &[
+            ParamType::Address,
+            ParamType::Uint(256),
+            ParamType::Address,
+            ParamType::Uint(256),
+            ParamType::FixedBytes(32),
+        ],
+        data,
+    )?;
+    Ok(LegacyOrmPEvent::HashImported {
+        target_chain_id: metadata.chain_id,
+        metadata,
+        oracle: token_address(take(&mut tokens, "oracle")?)?,
+        src_chain_id: token_uint(take(&mut tokens, "chainId")?)?,
+        channel: token_address(take(&mut tokens, "channel")?)?,
+        msg_index: token_uint(take(&mut tokens, "msgIndex")?)?,
+        hash: token_fixed_bytes(take(&mut tokens, "hash")?)?,
+    })
+}
+
+fn decode_message_accepted(
+    metadata: ChainLogMetadata,
+    data: &[u8],
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let mut tokens = decode_event(
+        &[
+            ParamType::FixedBytes(32),
+            ParamType::Tuple(vec![
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Uint(256),
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Bytes,
+            ]),
+        ],
+        data,
+    )?;
+    let msg_hash = token_fixed_bytes(take(&mut tokens, "msgHash")?)?;
+    let message = take(&mut tokens, "message")?;
+    let Token::Tuple(mut message) = message else {
+        bail!("message is not an ABI tuple");
+    };
+    ensure!(message.len() == 8, "message tuple must contain 8 fields");
+
+    Ok(LegacyOrmPEvent::MessageAccepted {
+        metadata,
+        msg_hash,
+        channel: token_address(take(&mut message, "message.channel")?)?,
+        index: token_uint(take(&mut message, "message.index")?)?,
+        from_chain_id: token_uint(take(&mut message, "message.fromChainId")?)?,
+        from: token_address(take(&mut message, "message.from")?)?,
+        to_chain_id: token_uint(take(&mut message, "message.toChainId")?)?,
+        to: token_address(take(&mut message, "message.to")?)?,
+        gas_limit: token_uint(take(&mut message, "message.gasLimit")?)?,
+        encoded: token_bytes(take(&mut message, "message.encoded")?)?,
+    })
+}
+
+fn decode_message_assigned(
+    metadata: ChainLogMetadata,
+    data: &[u8],
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let mut tokens = decode_event(
+        &[
+            ParamType::FixedBytes(32),
+            ParamType::Address,
+            ParamType::Address,
+            ParamType::Uint(256),
+            ParamType::Uint(256),
+            ParamType::Bytes,
+        ],
+        data,
+    )?;
+    Ok(LegacyOrmPEvent::MessageAssigned {
+        metadata,
+        msg_hash: token_fixed_bytes(take(&mut tokens, "msgHash")?)?,
+        oracle: token_address(take(&mut tokens, "oracle")?)?,
+        relayer: token_address(take(&mut tokens, "relayer")?)?,
+        oracle_fee: token_uint(take(&mut tokens, "oracleFee")?)?,
+        relayer_fee: token_uint(take(&mut tokens, "relayerFee")?)?,
+        params: token_bytes(take(&mut tokens, "params")?)?,
+    })
+}
+
+fn decode_message_dispatched(
+    metadata: ChainLogMetadata,
+    data: &[u8],
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let mut tokens = decode_event(&[ParamType::FixedBytes(32), ParamType::Bool], data)?;
+    Ok(LegacyOrmPEvent::MessageDispatched {
+        target_chain_id: metadata.chain_id,
+        metadata,
+        msg_hash: token_fixed_bytes(take(&mut tokens, "msgHash")?)?,
+        dispatch_result: token_bool(take(&mut tokens, "dispatchResult")?)?,
+    })
+}
+
+fn decode_msgport_message_recv(
+    metadata: ChainLogMetadata,
+    data: &[u8],
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let mut tokens = decode_event(
+        &[ParamType::FixedBytes(32), ParamType::Bool, ParamType::Bytes],
+        data,
+    )?;
+    Ok(LegacyOrmPEvent::MsgportMessageRecv {
+        metadata,
+        msg_id: token_fixed_bytes(take(&mut tokens, "msgId")?)?,
+        result: token_bool(take(&mut tokens, "result")?)?,
+        return_data: token_bytes(take(&mut tokens, "returnData")?)?,
+    })
+}
+
+fn decode_msgport_message_sent(
+    metadata: ChainLogMetadata,
+    data: &[u8],
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let mut tokens = decode_event(
+        &[
+            ParamType::FixedBytes(32),
+            ParamType::Address,
+            ParamType::Uint(256),
+            ParamType::Address,
+            ParamType::Bytes,
+            ParamType::Bytes,
+        ],
+        data,
+    )?;
+    Ok(LegacyOrmPEvent::MsgportMessageSent {
+        metadata,
+        msg_id: token_fixed_bytes(take(&mut tokens, "msgId")?)?,
+        from_dapp: token_address(take(&mut tokens, "fromDapp")?)?,
+        to_chain_id: token_uint(take(&mut tokens, "toChainId")?)?,
+        to_dapp: token_address(take(&mut tokens, "toDapp")?)?,
+        message: token_bytes(take(&mut tokens, "message")?)?,
+        params: token_bytes(take(&mut tokens, "params")?)?,
+    })
+}
+
+fn decode_signature_submittion(
+    metadata: ChainLogMetadata,
+    data: &[u8],
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let mut tokens = decode_event(
+        &[
+            ParamType::Uint(256),
+            ParamType::Address,
+            ParamType::Address,
+            ParamType::Uint(256),
+            ParamType::Bytes,
+            ParamType::Bytes,
+        ],
+        data,
+    )?;
+    Ok(LegacyOrmPEvent::SignatureSubmittion {
+        metadata,
+        chain_id: token_uint(take(&mut tokens, "chainId")?)?,
+        channel: token_address(take(&mut tokens, "channel")?)?,
+        signer: token_address(take(&mut tokens, "signer")?)?,
+        msg_index: token_uint(take(&mut tokens, "msgIndex")?)?,
+        signature: token_bytes(take(&mut tokens, "signature")?)?,
+        data: token_bytes(take(&mut tokens, "data")?)?,
+    })
+}
+
+fn decode_event(types: &[ParamType], data: &[u8]) -> anyhow::Result<Vec<Token>> {
+    decode(types, data).context("decode ABI event data")
+}
+
+fn take(tokens: &mut Vec<Token>, name: &str) -> anyhow::Result<Token> {
+    if tokens.is_empty() {
+        bail!("ABI token {name} is missing");
+    }
+    Ok(tokens.remove(0))
+}
+
+fn token_address(token: Token) -> anyhow::Result<String> {
+    match token {
+        Token::Address(value) => Ok(format!("0x{}", hex::encode(value.as_bytes()))),
+        _ => bail!("ABI token is not an address"),
+    }
+}
+
+fn token_fixed_bytes(token: Token) -> anyhow::Result<String> {
+    match token {
+        Token::FixedBytes(value) => Ok(format!("0x{}", hex::encode(value))),
+        _ => bail!("ABI token is not fixed bytes"),
+    }
+}
+
+fn token_bytes(token: Token) -> anyhow::Result<String> {
+    match token {
+        Token::Bytes(value) => Ok(format!("0x{}", hex::encode(value))),
+        _ => bail!("ABI token is not bytes"),
+    }
+}
+
+fn token_bool(token: Token) -> anyhow::Result<bool> {
+    match token {
+        Token::Bool(value) => Ok(value),
+        _ => bail!("ABI token is not bool"),
+    }
+}
+
+fn token_uint(token: Token) -> anyhow::Result<u128> {
+    match token {
+        Token::Uint(value) => {
+            ensure!(value.bits() <= 128, "ABI uint overflows u128");
+            Ok(value.as_u128())
+        }
+        _ => bail!("ABI token is not uint"),
+    }
+}
+
+fn normalize_hex(value: &str) -> anyhow::Result<String> {
+    let value = value.trim();
+    let value = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value);
+    ensure!(
+        value.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "invalid hex value"
+    );
+    Ok(format!("0x{}", value.to_ascii_lowercase()))
+}
+
+fn decode_hex(value: &str) -> anyhow::Result<Vec<u8>> {
+    let value = value.trim();
+    let value = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .unwrap_or(value);
+    Ok(hex::decode(value)?)
 }

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -1,0 +1,292 @@
+use ethabi::{
+    Token, encode,
+    ethereum_types::{H160, U256},
+};
+use ormpindexer::{
+    datalens::DatalensLog,
+    decoder::decode_evm_log,
+    planner::{
+        MSGPORT_ADDRESS, MSGPORT_MESSAGE_RECV_TOPIC, MSGPORT_MESSAGE_SENT_TOPIC, ORMP_ADDRESS,
+        ORMP_HASH_IMPORTED_TOPIC, ORMP_MESSAGE_ACCEPTED_TOPIC, ORMP_MESSAGE_ASSIGNED_TOPIC,
+        ORMP_MESSAGE_DISPATCHED_TOPIC, SIGNATURE_PUB_ADDRESS,
+        SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
+    },
+    schema::{EventSource, LegacyOrmPEvent},
+};
+
+#[test]
+fn test_decode_ormp_events_preserves_legacy_fields() {
+    let msg_hash = bytes32(0x11);
+    let hash_imported = decode_evm_log(&log(
+        ORMP_HASH_IMPORTED_TOPIC,
+        ORMP_ADDRESS,
+        encode(&[
+            Token::Address(address(0x10)),
+            Token::Uint(U256::from(46)),
+            Token::Address(address(0x20)),
+            Token::Uint(U256::from(7)),
+            Token::FixedBytes(msg_hash.clone()),
+        ]),
+    ))
+    .expect("HashImported decodes");
+    assert_eq!(
+        hash_imported,
+        LegacyOrmPEvent::HashImported {
+            metadata: metadata(ORMP_ADDRESS),
+            src_chain_id: 46,
+            target_chain_id: 1,
+            oracle: address_hex(0x10),
+            channel: address_hex(0x20),
+            msg_index: 7,
+            hash: bytes_hex(0x11),
+        }
+    );
+
+    let accepted = decode_evm_log(&log(
+        ORMP_MESSAGE_ACCEPTED_TOPIC,
+        ORMP_ADDRESS,
+        encode(&[
+            Token::FixedBytes(msg_hash.clone()),
+            Token::Tuple(vec![
+                Token::Address(address(0x21)),
+                Token::Uint(U256::from(8)),
+                Token::Uint(U256::from(46)),
+                Token::Address(address(0x22)),
+                Token::Uint(U256::from(137)),
+                Token::Address(address(0x23)),
+                Token::Uint(U256::from(500_000)),
+                Token::Bytes(vec![0xab, 0xcd]),
+            ]),
+        ]),
+    ))
+    .expect("MessageAccepted decodes");
+    assert_eq!(
+        accepted,
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: metadata(ORMP_ADDRESS),
+            msg_hash: bytes_hex(0x11),
+            channel: address_hex(0x21),
+            index: 8,
+            from_chain_id: 46,
+            from: address_hex(0x22),
+            to_chain_id: 137,
+            to: address_hex(0x23),
+            gas_limit: 500_000,
+            encoded: "0xabcd".to_owned(),
+        }
+    );
+
+    let assigned = decode_evm_log(&log(
+        ORMP_MESSAGE_ASSIGNED_TOPIC,
+        ORMP_ADDRESS,
+        encode(&[
+            Token::FixedBytes(msg_hash.clone()),
+            Token::Address(address(0x24)),
+            Token::Address(address(0x25)),
+            Token::Uint(U256::from(9)),
+            Token::Uint(U256::from(10)),
+            Token::Bytes(vec![0x01, 0x02]),
+        ]),
+    ))
+    .expect("MessageAssigned decodes");
+    assert_eq!(
+        assigned,
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: metadata(ORMP_ADDRESS),
+            msg_hash: bytes_hex(0x11),
+            oracle: address_hex(0x24),
+            relayer: address_hex(0x25),
+            oracle_fee: 9,
+            relayer_fee: 10,
+            params: "0x0102".to_owned(),
+        }
+    );
+
+    let dispatched = decode_evm_log(&log(
+        ORMP_MESSAGE_DISPATCHED_TOPIC,
+        ORMP_ADDRESS,
+        encode(&[Token::FixedBytes(msg_hash), Token::Bool(true)]),
+    ))
+    .expect("MessageDispatched decodes");
+    assert_eq!(
+        dispatched,
+        LegacyOrmPEvent::MessageDispatched {
+            metadata: metadata(ORMP_ADDRESS),
+            target_chain_id: 1,
+            msg_hash: bytes_hex(0x11),
+            dispatch_result: true,
+        }
+    );
+}
+
+#[test]
+fn test_decode_msgport_and_signature_events_preserves_legacy_fields() {
+    let msg_id = bytes32(0x33);
+
+    let recv = decode_evm_log(&log(
+        MSGPORT_MESSAGE_RECV_TOPIC,
+        MSGPORT_ADDRESS,
+        encode(&[
+            Token::FixedBytes(msg_id.clone()),
+            Token::Bool(false),
+            Token::Bytes(vec![0xff]),
+        ]),
+    ))
+    .expect("MessageRecv decodes");
+    assert_eq!(
+        recv,
+        LegacyOrmPEvent::MsgportMessageRecv {
+            metadata: metadata(MSGPORT_ADDRESS),
+            msg_id: bytes_hex(0x33),
+            result: false,
+            return_data: "0xff".to_owned(),
+        }
+    );
+
+    let sent = decode_evm_log(&log(
+        MSGPORT_MESSAGE_SENT_TOPIC,
+        MSGPORT_ADDRESS,
+        encode(&[
+            Token::FixedBytes(msg_id),
+            Token::Address(address(0x30)),
+            Token::Uint(U256::from(42161)),
+            Token::Address(address(0x31)),
+            Token::Bytes(vec![0xaa]),
+            Token::Bytes(vec![0xbb, 0xcc]),
+        ]),
+    ))
+    .expect("MessageSent decodes");
+    assert_eq!(
+        sent,
+        LegacyOrmPEvent::MsgportMessageSent {
+            metadata: metadata(MSGPORT_ADDRESS),
+            msg_id: bytes_hex(0x33),
+            from_dapp: address_hex(0x30),
+            to_chain_id: 42161,
+            to_dapp: address_hex(0x31),
+            message: "0xaa".to_owned(),
+            params: "0xbbcc".to_owned(),
+        }
+    );
+
+    let submittion = decode_evm_log(&log(
+        SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
+        SIGNATURE_PUB_ADDRESS,
+        encode(&[
+            Token::Uint(U256::from(46)),
+            Token::Address(address(0x40)),
+            Token::Address(address(0x41)),
+            Token::Uint(U256::from(12)),
+            Token::Bytes(vec![0xde, 0xad]),
+            Token::Bytes(vec![0xbe, 0xef]),
+        ]),
+    ))
+    .expect("SignatureSubmittion decodes");
+    assert_eq!(
+        submittion,
+        LegacyOrmPEvent::SignatureSubmittion {
+            metadata: metadata(SIGNATURE_PUB_ADDRESS),
+            chain_id: 46,
+            channel: address_hex(0x40),
+            signer: address_hex(0x41),
+            msg_index: 12,
+            signature: "0xdead".to_owned(),
+            data: "0xbeef".to_owned(),
+        }
+    );
+}
+
+#[test]
+fn test_decode_errors_are_explicit() {
+    let missing_topic = DatalensLog {
+        topics: Vec::new(),
+        ..log(MSGPORT_MESSAGE_RECV_TOPIC, MSGPORT_ADDRESS, Vec::new())
+    };
+    assert!(
+        decode_evm_log(&missing_topic)
+            .expect_err("missing topic should fail")
+            .to_string()
+            .contains("missing topic0")
+    );
+
+    let unknown = DatalensLog {
+        topics: vec![bytes_hex(0x99)],
+        ..log(MSGPORT_MESSAGE_RECV_TOPIC, MSGPORT_ADDRESS, Vec::new())
+    };
+    assert!(
+        decode_evm_log(&unknown)
+            .expect_err("unknown topic should fail")
+            .to_string()
+            .contains("unsupported ORMP EVM event topic0")
+    );
+
+    let malformed = log(
+        MSGPORT_MESSAGE_RECV_TOPIC,
+        MSGPORT_ADDRESS,
+        vec![0x01, 0x02],
+    );
+    assert!(
+        decode_evm_log(&malformed)
+            .expect_err("malformed ABI should fail")
+            .to_string()
+            .contains("decode ABI event data")
+    );
+
+    let missing_metadata = DatalensLog {
+        block_timestamp: None,
+        ..log(MSGPORT_MESSAGE_RECV_TOPIC, MSGPORT_ADDRESS, Vec::new())
+    };
+    assert!(
+        decode_evm_log(&missing_metadata)
+            .expect_err("missing metadata should fail")
+            .to_string()
+            .contains("missing block timestamp")
+    );
+}
+
+fn log(topic: &str, address: &str, data: Vec<u8>) -> DatalensLog {
+    DatalensLog {
+        id: Some("1-100-0".to_owned()),
+        chain_id: 1,
+        block_number: 100,
+        block_timestamp: Some(1_700_000_000_000),
+        transaction_hash: bytes_hex(0xaa),
+        transaction_index: Some(2),
+        log_index: 3,
+        address: address.to_owned(),
+        transaction_from: Some(address_hex(0x50)),
+        topics: vec![topic.to_owned()],
+        data: format!("0x{}", hex::encode(data)),
+    }
+}
+
+fn metadata(address: &str) -> ormpindexer::schema::ChainLogMetadata {
+    ormpindexer::schema::ChainLogMetadata {
+        id: "1-100-0".to_owned(),
+        source: EventSource::Evm,
+        chain_id: 1,
+        block_number: 100,
+        block_timestamp: 1_700_000_000_000,
+        transaction_hash: bytes_hex(0xaa),
+        transaction_index: 2,
+        log_index: 3,
+        contract_address: address.to_ascii_lowercase(),
+        transaction_from: Some(address_hex(0x50)),
+    }
+}
+
+fn address(value: u64) -> H160 {
+    H160::from_low_u64_be(value)
+}
+
+fn address_hex(value: u64) -> String {
+    format!("0x{}", hex::encode(address(value).as_bytes()))
+}
+
+fn bytes32(value: u8) -> Vec<u8> {
+    vec![value; 32]
+}
+
+fn bytes_hex(value: u8) -> String {
+    format!("0x{}", hex::encode(bytes32(value)))
+}

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -124,11 +124,15 @@ async fn test_runner_dry_run_queries_datalens_and_leaves_checkpoint_unchanged() 
     let config = RuntimeConfig::from_env_map(&env).expect("config parses");
     let checkpoints = InMemoryCheckpointStore::default();
     let reader = RecordingDatalensReader::new(vec![DatalensLog {
+        id: Some("46-0xtx-1".to_owned()),
         chain_id: 46,
         block_number: 12,
+        block_timestamp: Some(1_700_000_000_000),
         transaction_hash: "0xtx".to_owned(),
+        transaction_index: Some(0),
         log_index: 1,
         address: "0x333".to_owned(),
+        transaction_from: None,
         topics: vec!["0xaaa".to_owned()],
         data: "0x".to_owned(),
     }]);


### PR DESCRIPTION
## Summary
- add EVM ABI decoder for ORMP, Msgport, and SignaturePub legacy events
- extend Datalens log metadata inputs needed by schema-compatible event mapping
- add fixture coverage for all seven legacy event types and decode error paths

## Validation
- cargo fmt --check
- cargo build
- cargo test

HBX-449