### PR TITLE
HBX-451 feat(ormpindexer): advance datalens checkpoints

### DIFF
--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -14,6 +14,7 @@ pub struct DatalensLogQuery {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DatalensLog {
     #[serde(default)]
     pub id: Option<String>,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,7 @@
 use tokio::time::sleep;
 
+use anyhow::Context;
+
 use crate::{
     checkpoint::{CheckpointStore, plan_next_range},
     config::RuntimeConfig,
@@ -90,9 +92,16 @@ where
                 events.extend(self.decoder.decode(log).await?);
             }
             let written = self.writer.write_events(&events).await?;
+            let next_block = range
+                .to_block
+                .checked_add(1)
+                .context("checkpoint next block overflow")?;
+            self.checkpoints
+                .advance(chain.chain_id, &self.config.dataset, next_block)
+                .await?;
 
             log::info!(
-                "ORMP Datalens dry-run batch completed chain_id={} dataset={} from_block={} to_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=false",
+                "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true",
                 chain.chain_id,
                 self.config.dataset,
                 range.from_block,
@@ -100,7 +109,7 @@ where
                 result.logs.len(),
                 events.len(),
                 written,
-                checkpoint.next_block,
+                next_block,
             );
 
             report.chains_processed += 1;
@@ -108,6 +117,7 @@ where
             report.records_read += result.logs.len() as u64;
             report.records_decoded += events.len() as u64;
             report.records_written += written as u64;
+            report.checkpoints_advanced += 1;
         }
 
         Ok(report)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -2,9 +2,9 @@ use anyhow::Context;
 
 use crate::{
     config::RuntimeConfig,
-    database::{DryRunEventWriter, PostgresCheckpointStore, apply_migrations, connect},
+    database::{PostgresCheckpointStore, PostgresEventWriter, apply_migrations, connect},
     datalens::DatalensHttpClient,
-    decoder::NoopDecoder,
+    decoder::EvmEventDecoder,
     runner::IndexerRunner,
 };
 
@@ -18,7 +18,7 @@ pub async fn run(run_once: bool) -> anyhow::Result<()> {
     apply_migrations(&pool).await?;
 
     log::info!(
-        "starting ORMP Datalens indexer endpoint={} application={} token_configured={} database_configured=true chains={} batch_size={} dataset={} finality={} dry_run=true",
+        "starting ORMP Datalens indexer endpoint={} application={} token_configured={} database_configured=true chains={} batch_size={} dataset={} finality={} dry_run=false",
         config.datalens.endpoint,
         config.datalens.application,
         config.datalens.token.is_some(),
@@ -31,9 +31,9 @@ pub async fn run(run_once: bool) -> anyhow::Result<()> {
     let runner = IndexerRunner::new(
         config.clone(),
         DatalensHttpClient::new(config.datalens.clone()),
-        PostgresCheckpointStore::new(pool),
-        NoopDecoder,
-        DryRunEventWriter,
+        PostgresCheckpointStore::new(pool.clone()),
+        EvmEventDecoder,
+        PostgresEventWriter::new(pool),
     );
 
     if run_once {

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -1,0 +1,31 @@
+use ormpindexer::datalens::DatalensLog;
+
+#[test]
+fn test_datalens_log_decodes_native_graphql_camel_case_response() {
+    let log: DatalensLog = serde_json::from_value(serde_json::json!({
+        "id": "46-0xtx-3",
+        "chainId": 46,
+        "blockNumber": 123,
+        "blockTimestamp": 456,
+        "transactionHash": "0xtx",
+        "transactionIndex": 2,
+        "logIndex": 3,
+        "address": "0xcontract",
+        "transactionFrom": "0xsender",
+        "topics": ["0xtopic"],
+        "data": "0xdata"
+    }))
+    .expect("decode native GraphQL log shape");
+
+    assert_eq!(log.id.as_deref(), Some("46-0xtx-3"));
+    assert_eq!(log.chain_id, 46);
+    assert_eq!(log.block_number, 123);
+    assert_eq!(log.block_timestamp, Some(456));
+    assert_eq!(log.transaction_hash, "0xtx");
+    assert_eq!(log.transaction_index, Some(2));
+    assert_eq!(log.log_index, 3);
+    assert_eq!(log.address, "0xcontract");
+    assert_eq!(log.transaction_from.as_deref(), Some("0xsender"));
+    assert_eq!(log.topics, vec!["0xtopic"]);
+    assert_eq!(log.data, "0xdata");
+}

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -3,10 +3,11 @@ use std::{cell::RefCell, collections::BTreeMap};
 use ormpindexer::{
     checkpoint::{Checkpoint, InMemoryCheckpointStore, plan_next_range},
     config::{FinalityMode, RuntimeConfig},
-    database::DryRunEventWriter,
+    database::{DryRunEventWriter, EventWriter},
     datalens::{DatalensLog, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader},
     decoder::NoopDecoder,
     runner::{IndexerRunner, RunnerReport},
+    schema::LegacyOrmPEvent,
 };
 
 #[test]
@@ -102,7 +103,7 @@ fn test_plan_next_range_uses_checkpoint_and_batch_size() {
 }
 
 #[tokio::test]
-async fn test_runner_dry_run_queries_datalens_and_leaves_checkpoint_unchanged() {
+async fn test_runner_successful_batch_advances_checkpoint_to_next_range() {
     let env = BTreeMap::from([
         (
             "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
@@ -144,7 +145,7 @@ async fn test_runner_dry_run_queries_datalens_and_leaves_checkpoint_unchanged() 
         DryRunEventWriter,
     );
 
-    let report = runner.run_once().await.expect("dry run pass succeeds");
+    let report = runner.run_once().await.expect("batch pass succeeds");
 
     assert_eq!(
         report,
@@ -154,12 +155,135 @@ async fn test_runner_dry_run_queries_datalens_and_leaves_checkpoint_unchanged() 
             records_read: 1,
             records_decoded: 0,
             records_written: 0,
-            checkpoints_advanced: 0,
+            checkpoints_advanced: 1,
         }
     );
     assert_eq!(
         checkpoints.next_block(46, "datalens-native").await.unwrap(),
+        15
+    );
+}
+
+#[tokio::test]
+async fn test_runner_empty_logs_still_advance_after_successful_query_and_write() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let runner = IndexerRunner::new(
+        config,
+        RecordingDatalensReader::new(Vec::new()),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let report = runner.run_once().await.expect("empty batch succeeds");
+
+    assert_eq!(report.checkpoints_advanced, 1);
+    assert_eq!(
+        checkpoints.next_block(46, "datalens-native").await.unwrap(),
+        15
+    );
+}
+
+#[tokio::test]
+async fn test_runner_writer_failure_does_not_advance_checkpoint() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let runner = IndexerRunner::new(
+        config,
+        RecordingDatalensReader::new(Vec::new()),
+        checkpoints.clone(),
+        NoopDecoder,
+        FailingEventWriter,
+    );
+
+    let error = runner
+        .run_once()
+        .await
+        .expect_err("writer failure fails the batch");
+
+    assert!(error.to_string().contains("write failed"));
+    assert_eq!(
+        checkpoints.next_block(46, "datalens-native").await.unwrap(),
         10
+    );
+}
+
+#[tokio::test]
+async fn test_runner_reports_and_advances_multiple_chains() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "1,46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+        (
+            "ORMPINDEXER_CHAIN_46_START_BLOCK".to_owned(),
+            "20".to_owned(),
+        ),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let runner = IndexerRunner::new(
+        config,
+        RecordingDatalensReader::new(Vec::new()),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let report = runner.run_once().await.expect("multi-chain pass succeeds");
+
+    assert_eq!(
+        report,
+        RunnerReport {
+            chains_processed: 2,
+            ranges_queried: 2,
+            records_read: 0,
+            records_decoded: 0,
+            records_written: 0,
+            checkpoints_advanced: 2,
+        }
+    );
+    assert_eq!(
+        checkpoints.next_block(1, "datalens-native").await.unwrap(),
+        15
+    );
+    assert_eq!(
+        checkpoints.next_block(46, "datalens-native").await.unwrap(),
+        25
     );
 }
 
@@ -183,5 +307,13 @@ impl DatalensLogReader for RecordingDatalensReader {
         Ok(DatalensLogQueryResult {
             logs: self.logs.clone(),
         })
+    }
+}
+
+struct FailingEventWriter;
+
+impl EventWriter for FailingEventWriter {
+    async fn write_events(&self, _events: &[LegacyOrmPEvent]) -> anyhow::Result<usize> {
+        anyhow::bail!("write failed");
     }
 }


### PR DESCRIPTION
## Summary
- advance ORMP Datalens checkpoints to `to_block + 1` only after event writes succeed
- wire runtime production path to `EvmEventDecoder`, `PostgresEventWriter`, and `PostgresCheckpointStore`
- add runner coverage for successful, empty, failure, and multi-chain checkpoint behavior

## Verification
- `cargo fmt --check`
- `cargo build`
- `cargo test`