### PR TITLE
fix(ormpindexer): HBX-452 preserve datalens log metadata

### DIFF
--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -112,6 +112,7 @@ impl DatalensLogReader for DatalensHttpClient {
         let mut builder = self
             .http
             .post(self.native_graphql_endpoint())
+            .header("x-datalens-application", &self.config.application)
             .json(&request);
         if let Some(token) = &self.config.token {
             builder = builder.bearer_auth(token.expose_secret());

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -74,31 +74,37 @@ impl DatalensLogReader for DatalensHttpClient {
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult> {
         let request = json!({
             "query": r#"
-                query OrmpIndexerLogs($input: EvmLogsInput!) {
-                  evmLogs(input: $input) {
-                    id
-                    chainId
-                    blockNumber
-                    blockTimestamp
-                    transactionHash
-                    transactionIndex
-                    logIndex
-                    address
-                    transactionFrom
-                    topics
-                    data
+                query OrmpIndexerLogs($input: QueryInput!) {
+                  query(input: $input) {
+                    rows
                   }
                 }
             "#,
             "variables": {
                 "input": {
-                    "application": self.config.application,
-                    "chainId": query.chain_id,
-                    "fromBlock": query.from_block,
-                    "toBlock": query.to_block,
-                    "addresses": query.contracts,
-                    "topics": query.topics,
-                    "finality": query.finality_mode.as_str(),
+                    "chain": {
+                        "family": { "kind": "evm" },
+                        "configuredName": evm_chain_name(query.chain_id),
+                        "networkId": { "numeric": query.chain_id },
+                    },
+                    "datasetKey": {
+                        "family": "evm",
+                        "name": "logs",
+                    },
+                    "selector": {
+                        "kind": "evm_logs",
+                        "evmLogs": {
+                            "addresses": query.contracts,
+                            "topics": topic_filters(&query.topics),
+                        },
+                    },
+                    "range": {
+                        "kind": "block",
+                        "start": query.from_block,
+                        "end": query.to_block,
+                    },
+                    "finality": native_finality(query.finality_mode),
+                    "fields": {},
                 }
             }
         });
@@ -116,12 +122,109 @@ impl DatalensLogReader for DatalensHttpClient {
             anyhow::bail!("Datalens log query returned errors: {errors}");
         }
 
-        let logs = serde_json::from_value(
-            payload
-                .pointer("/data/evmLogs")
-                .cloned()
-                .unwrap_or_else(|| serde_json::Value::Array(Vec::new())),
-        )?;
+        let logs = logs_from_native_query_payload(&payload, query.chain_id)?;
         Ok(DatalensLogQueryResult { logs })
+    }
+}
+
+pub fn logs_from_native_query_payload(
+    payload: &serde_json::Value,
+    chain_id: u64,
+) -> anyhow::Result<Vec<DatalensLog>> {
+    let rows = payload
+        .pointer("/data/query/rows")
+        .cloned()
+        .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+    let logs = native_log_rows(&rows)?;
+    logs.into_iter()
+        .map(|row| row.into_datalens_log(chain_id))
+        .collect()
+}
+
+fn native_log_rows(rows: &serde_json::Value) -> anyhow::Result<Vec<NativeLogRow>> {
+    if rows.is_array() {
+        return Ok(serde_json::from_value(rows.clone())?);
+    }
+
+    if let Some(value) = rows.pointer("/rows/rows") {
+        return Ok(serde_json::from_value(value.clone())?);
+    }
+
+    if let Some(value) = rows.pointer("/rows") {
+        return Ok(serde_json::from_value(value.clone())?);
+    }
+
+    anyhow::bail!("Datalens native query response missing evm log rows")
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+struct NativeLogRow {
+    #[serde(default)]
+    id: Option<String>,
+    block_number: u64,
+    #[serde(default)]
+    block_timestamp: Option<u64>,
+    transaction_hash: String,
+    transaction_index: i32,
+    log_index: u64,
+    address: String,
+    #[serde(default)]
+    transaction_from: Option<String>,
+    topics: Vec<String>,
+    data: String,
+}
+
+impl NativeLogRow {
+    fn into_datalens_log(self, chain_id: u64) -> anyhow::Result<DatalensLog> {
+        let id = self.id.unwrap_or_else(|| {
+            format!(
+                "{}-{}-{}-{}",
+                chain_id, self.block_number, self.transaction_hash, self.log_index
+            )
+        });
+
+        Ok(DatalensLog {
+            id: Some(id),
+            chain_id,
+            block_number: self.block_number,
+            block_timestamp: self.block_timestamp,
+            transaction_hash: self.transaction_hash,
+            transaction_index: Some(self.transaction_index),
+            log_index: self.log_index,
+            address: self.address,
+            transaction_from: self.transaction_from,
+            topics: self.topics,
+            data: self.data,
+        })
+    }
+}
+
+fn topic_filters(topics: &[String]) -> Vec<Vec<String>> {
+    if topics.is_empty() {
+        Vec::new()
+    } else {
+        vec![topics.to_vec()]
+    }
+}
+
+fn native_finality(finality_mode: FinalityMode) -> &'static str {
+    match finality_mode {
+        FinalityMode::Finalized => "finalized",
+        FinalityMode::Durable => "durable_only",
+    }
+}
+
+fn evm_chain_name(chain_id: u64) -> &'static str {
+    match chain_id {
+        1 => "ethereum",
+        44 => "crab",
+        46 => "darwinia",
+        137 => "polygon",
+        1284 => "moonbeam",
+        8453 => "base",
+        42161 => "arbitrum",
+        81457 => "blast",
+        2818 => "morph",
+        _ => "ethereum",
     }
 }

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -72,6 +72,7 @@ impl DatalensHttpClient {
 
 impl DatalensLogReader for DatalensHttpClient {
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult> {
+        let chain_name = evm_chain_name(query.chain_id)?;
         let request = json!({
             "query": r#"
                 query OrmpIndexerLogs($input: QueryInput!) {
@@ -84,7 +85,7 @@ impl DatalensLogReader for DatalensHttpClient {
                 "input": {
                     "chain": {
                         "family": { "kind": "evm" },
-                        "configuredName": evm_chain_name(query.chain_id),
+                        "configuredName": chain_name,
                         "networkId": { "numeric": query.chain_id },
                     },
                     "datasetKey": {
@@ -214,8 +215,8 @@ fn native_finality(finality_mode: FinalityMode) -> &'static str {
     }
 }
 
-fn evm_chain_name(chain_id: u64) -> &'static str {
-    match chain_id {
+pub fn evm_chain_name(chain_id: u64) -> anyhow::Result<&'static str> {
+    Ok(match chain_id {
         1 => "ethereum",
         44 => "crab",
         46 => "darwinia",
@@ -225,6 +226,6 @@ fn evm_chain_name(chain_id: u64) -> &'static str {
         42161 => "arbitrum",
         81457 => "blast",
         2818 => "morph",
-        _ => "ethereum",
-    }
+        _ => anyhow::bail!("unsupported EVM Datalens chain id: {chain_id}"),
+    })
 }

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -18,16 +18,21 @@ pub struct DatalensLogQuery {
 pub struct DatalensLog {
     #[serde(default)]
     pub id: Option<String>,
+    #[serde(alias = "chain_id")]
     pub chain_id: u64,
+    #[serde(alias = "block_number")]
     pub block_number: u64,
-    #[serde(default)]
+    #[serde(default, alias = "block_timestamp")]
     pub block_timestamp: Option<u64>,
+    #[serde(alias = "transaction_hash")]
     pub transaction_hash: String,
-    #[serde(default)]
+    #[serde(default, alias = "transaction_index")]
     pub transaction_index: Option<i32>,
+    #[serde(alias = "log_index", alias = "eventIndex", alias = "event_index")]
     pub log_index: u64,
+    #[serde(alias = "contractAddress", alias = "contract_address")]
     pub address: String,
-    #[serde(default)]
+    #[serde(default, alias = "transaction_from")]
     pub transaction_from: Option<String>,
     pub topics: Vec<String>,
     pub data: String,

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -29,3 +29,33 @@ fn test_datalens_log_decodes_native_graphql_camel_case_response() {
     assert_eq!(log.topics, vec!["0xtopic"]);
     assert_eq!(log.data, "0xdata");
 }
+
+#[test]
+fn test_datalens_log_decodes_legacy_snake_case_response() {
+    let log: DatalensLog = serde_json::from_value(serde_json::json!({
+        "id": "46-0xtx-7",
+        "chain_id": 46,
+        "block_number": 123,
+        "block_timestamp": 456,
+        "transaction_hash": "0xtx",
+        "transaction_index": 2,
+        "eventIndex": 7,
+        "address": "0xcontract",
+        "transaction_from": "0xsender",
+        "topics": ["0xtopic"],
+        "data": "0xdata"
+    }))
+    .expect("decode legacy-compatible log shape");
+
+    assert_eq!(log.id.as_deref(), Some("46-0xtx-7"));
+    assert_eq!(log.chain_id, 46);
+    assert_eq!(log.block_number, 123);
+    assert_eq!(log.block_timestamp, Some(456));
+    assert_eq!(log.transaction_hash, "0xtx");
+    assert_eq!(log.transaction_index, Some(2));
+    assert_eq!(log.log_index, 7);
+    assert_eq!(log.address, "0xcontract");
+    assert_eq!(log.transaction_from.as_deref(), Some("0xsender"));
+    assert_eq!(log.topics, vec!["0xtopic"]);
+    assert_eq!(log.data, "0xdata");
+}

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -1,4 +1,4 @@
-use ormpindexer::datalens::{DatalensLog, logs_from_native_query_payload};
+use ormpindexer::datalens::{DatalensLog, evm_chain_name, logs_from_native_query_payload};
 
 #[test]
 fn test_datalens_log_decodes_native_graphql_camel_case_response() {
@@ -104,4 +104,10 @@ fn test_native_query_rows_decode_with_context_metadata() {
     assert_eq!(logs[0].transaction_from, None);
     assert_eq!(logs[0].topics, vec!["0xtopic"]);
     assert_eq!(logs[0].data, "0xdata");
+}
+
+#[test]
+fn test_evm_chain_name_rejects_unknown_chain_ids() {
+    assert_eq!(evm_chain_name(46).expect("darwinia chain name"), "darwinia");
+    assert!(evm_chain_name(99_999).is_err());
 }

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -1,4 +1,4 @@
-use ormpindexer::datalens::DatalensLog;
+use ormpindexer::datalens::{DatalensLog, logs_from_native_query_payload};
 
 #[test]
 fn test_datalens_log_decodes_native_graphql_camel_case_response() {
@@ -58,4 +58,50 @@ fn test_datalens_log_decodes_legacy_snake_case_response() {
     assert_eq!(log.transaction_from.as_deref(), Some("0xsender"));
     assert_eq!(log.topics, vec!["0xtopic"]);
     assert_eq!(log.data, "0xdata");
+}
+
+#[test]
+fn test_native_query_rows_decode_with_context_metadata() {
+    let logs = logs_from_native_query_payload(
+        &serde_json::json!({
+            "data": {
+                "query": {
+                    "rows": {
+                        "dataset_key": { "family": { "kind": "evm" }, "name": "logs" },
+                        "rows": {
+                            "dataset": "logs",
+                            "rows": [{
+                                "block_number": 123,
+                                "block_hash": "0xblock",
+                                "parent_hash": "0xparent",
+                                "block_timestamp": 456,
+                                "transaction_hash": "0xtx",
+                                "transaction_index": 2,
+                                "log_index": 3,
+                                "address": "0xcontract",
+                                "topics": ["0xtopic"],
+                                "data": "0xdata",
+                                "removed": false
+                            }]
+                        }
+                    }
+                }
+            }
+        }),
+        46,
+    )
+    .expect("decode native query rows");
+
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].id.as_deref(), Some("46-123-0xtx-3"));
+    assert_eq!(logs[0].chain_id, 46);
+    assert_eq!(logs[0].block_number, 123);
+    assert_eq!(logs[0].block_timestamp, Some(456));
+    assert_eq!(logs[0].transaction_hash, "0xtx");
+    assert_eq!(logs[0].transaction_index, Some(2));
+    assert_eq!(logs[0].log_index, 3);
+    assert_eq!(logs[0].address, "0xcontract");
+    assert_eq!(logs[0].transaction_from, None);
+    assert_eq!(logs[0].topics, vec!["0xtopic"]);
+    assert_eq!(logs[0].data, "0xdata");
 }

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -11,7 +11,7 @@ use ormpindexer::{
         ORMP_MESSAGE_DISPATCHED_TOPIC, SIGNATURE_PUB_ADDRESS,
         SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
     },
-    schema::{EventSource, LegacyOrmPEvent},
+    schema::{EventSource, LegacyOrmPEvent, MsgportMessageSentRow},
 };
 
 #[test]
@@ -194,6 +194,51 @@ fn test_decode_msgport_and_signature_events_preserves_legacy_fields() {
             data: "0xbeef".to_owned(),
         }
     );
+}
+
+#[test]
+fn test_decode_native_graphql_log_preserves_metadata_in_legacy_row() {
+    let log: DatalensLog = serde_json::from_value(serde_json::json!({
+        "id": "46-888-7",
+        "chainId": 46,
+        "blockNumber": 888,
+        "blockTimestamp": 1_800_000_000_000_u64,
+        "transactionHash": bytes_hex(0xaa).to_ascii_uppercase(),
+        "transactionIndex": 9,
+        "logIndex": 7,
+        "address": MSGPORT_ADDRESS.to_ascii_uppercase(),
+        "transactionFrom": address_hex(0x51).to_ascii_uppercase(),
+        "topics": [MSGPORT_MESSAGE_SENT_TOPIC],
+        "data": format!(
+            "0x{}",
+            hex::encode(encode(&[
+                Token::FixedBytes(bytes32(0x33)),
+                Token::Address(address(0x30)),
+                Token::Uint(U256::from(42161)),
+                Token::Address(address(0x31)),
+                Token::Bytes(vec![0xaa]),
+                Token::Bytes(vec![0xbb, 0xcc]),
+            ]))
+        )
+    }))
+    .expect("decode native GraphQL log");
+
+    let row = MsgportMessageSentRow::from_event(decode_evm_log(&log).expect("decode EVM event"));
+
+    assert_eq!(row.id, "46-888-7");
+    assert_eq!(row.chain_id, 46);
+    assert_eq!(row.block_number, 888);
+    assert_eq!(row.block_timestamp, 1_800_000_000_000);
+    assert_eq!(row.transaction_hash, bytes_hex(0xaa));
+    assert_eq!(row.transaction_index, 9);
+    assert_eq!(row.log_index, 7);
+    assert_eq!(row.port_address, MSGPORT_ADDRESS.to_ascii_lowercase());
+    assert_eq!(
+        row.transaction_from.as_deref(),
+        Some(address_hex(0x51).as_str())
+    );
+    assert_eq!(row.from_chain_id, 46);
+    assert_eq!(row.msg_id, bytes_hex(0x33));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- accept legacy-compatible Datalens log metadata aliases, including snake_case fields and eventIndex-compatible log index
- add coverage for native GraphQL JSON decoding through the EVM decoder into legacy MsgportMessageSent rows
- keep required metadata required so missing chain/block/index fields are not silently defaulted

## Validation
- cargo fmt --check
- cargo build
- cargo test