### PR TITLE
HBX-453 feat(ormpindexer): support tron datalens events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,6 +1156,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "tokio",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.30"
 reqwest = { version = "0.12.26", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+sha2 = "0.10.9"
 sqlx = { version = "0.8.6", default-features = false, features = ["macros", "migrate", "postgres", "runtime-tokio-rustls"] }
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
 tracing-log = "0.2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, env, fmt, time::Duration};
 
 use anyhow::{Context, bail};
 
-use crate::planner::default_evm_chain_config;
+use crate::planner::default_chain_config;
 
 pub const DEFAULT_DATASET: &str = "datalens-native";
 
@@ -107,7 +107,7 @@ impl ChainConfig {
         default_start_block: Option<u64>,
     ) -> anyhow::Result<Self> {
         let prefix = format!("ORMPINDEXER_CHAIN_{chain_id}");
-        let default = default_evm_chain_config(chain_id)?;
+        let default = default_chain_config(chain_id)?;
         let contracts = optional_list(env, &format!("{prefix}_CONTRACTS"));
         let topics = optional_list(env, &format!("{prefix}_TOPICS"));
         let start_block = optional_u64(env, &format!("{prefix}_START_BLOCK"))?

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, env, fmt, time::Duration};
 
 use anyhow::{Context, bail};
 
-use crate::planner::default_chain_config;
+use crate::planner::{TRON_CHAIN_ID, default_chain_config};
 
 pub const DEFAULT_DATASET: &str = "datalens-native";
 
@@ -113,6 +113,9 @@ impl ChainConfig {
         let start_block = optional_u64(env, &format!("{prefix}_START_BLOCK"))?
             .or(default_start_block)
             .unwrap_or(default.start_block);
+        if chain_id == TRON_CHAIN_ID && start_block == 0 {
+            bail!("{prefix}_START_BLOCK must be configured for Tron");
+        }
 
         Ok(Self {
             chain_id,

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,12 +110,15 @@ impl ChainConfig {
         let default = default_chain_config(chain_id)?;
         let contracts = optional_list(env, &format!("{prefix}_CONTRACTS"));
         let topics = optional_list(env, &format!("{prefix}_TOPICS"));
-        let start_block = optional_u64(env, &format!("{prefix}_START_BLOCK"))?
-            .or(default_start_block)
-            .unwrap_or(default.start_block);
-        if chain_id == TRON_CHAIN_ID && start_block == 0 {
-            bail!("{prefix}_START_BLOCK must be configured for Tron");
-        }
+        let chain_start_block = optional_u64(env, &format!("{prefix}_START_BLOCK"))?;
+        let start_block = if chain_id == TRON_CHAIN_ID {
+            chain_start_block
+                .with_context(|| format!("{prefix}_START_BLOCK must be configured for Tron"))?
+        } else {
+            chain_start_block
+                .or(default_start_block)
+                .unwrap_or(default.start_block)
+        };
 
         Ok(Self {
             chain_id,

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -384,17 +384,21 @@ fn tron_event_selector(
 fn normalize_tron_contract_address(address: &str) -> anyhow::Result<String> {
     let address = address.trim();
     let hex = address.strip_prefix("0x").unwrap_or(address);
-    let normalized = match hex.len() {
-        40 if hex.bytes().all(|byte| byte.is_ascii_hexdigit()) => format!("41{hex}"),
-        42 if hex.starts_with("41") && hex.bytes().all(|byte| byte.is_ascii_hexdigit()) => {
-            hex.to_owned()
-        }
-        _ => address.to_owned(),
-    };
-    if normalized.is_empty() || normalized.contains('/') || normalized.contains('\\') {
-        anyhow::bail!("Tron contract address must be a non-empty address");
+    if hex.len() == 40 && hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Ok(format!("41{}", hex.to_ascii_lowercase()));
     }
-    Ok(normalized.to_ascii_lowercase())
+    if hex.len() == 42 && hex.starts_with("41") && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Ok(hex.to_ascii_lowercase());
+    }
+    if address.len() == 34
+        && address.starts_with('T')
+        && address.bytes().all(|byte| byte.is_ascii_alphanumeric())
+    {
+        return Ok(address.to_owned());
+    }
+
+    anyhow::bail!("Tron contract address must be hex, 41-prefixed hex, or base58")
 }
 
 fn normalize_tron_event_name(name: &str) -> anyhow::Result<String> {

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use sha2::{Digest, Sha256};
 
 use crate::config::{DatalensConfig, FinalityMode};
+use crate::planner::TRON_CHAIN_ID;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DatalensLogQuery {
@@ -36,6 +38,14 @@ pub struct DatalensLog {
     pub transaction_from: Option<String>,
     pub topics: Vec<String>,
     pub data: String,
+    #[serde(default, alias = "event_name")]
+    pub event_name: Option<String>,
+    #[serde(default, alias = "event_signature")]
+    pub event_signature: Option<String>,
+    #[serde(default, alias = "indexed_fields")]
+    pub indexed_fields: Vec<serde_json::Value>,
+    #[serde(default, alias = "non_indexed_fields")]
+    pub non_indexed_fields: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -72,43 +82,7 @@ impl DatalensHttpClient {
 
 impl DatalensLogReader for DatalensHttpClient {
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult> {
-        let chain_name = evm_chain_name(query.chain_id)?;
-        let request = json!({
-            "query": r#"
-                query OrmpIndexerLogs($input: QueryInput!) {
-                  query(input: $input) {
-                    rows
-                  }
-                }
-            "#,
-            "variables": {
-                "input": {
-                    "chain": {
-                        "family": { "kind": "evm" },
-                        "configuredName": chain_name,
-                        "networkId": { "numeric": query.chain_id },
-                    },
-                    "datasetKey": {
-                        "family": "evm",
-                        "name": "logs",
-                    },
-                    "selector": {
-                        "kind": "evm_logs",
-                        "evmLogs": {
-                            "addresses": query.contracts,
-                            "topics": topic_filters(&query.topics),
-                        },
-                    },
-                    "range": {
-                        "kind": "block",
-                        "start": query.from_block,
-                        "end": query.to_block,
-                    },
-                    "finality": native_finality(query.finality_mode),
-                    "fields": {},
-                }
-            }
-        });
+        let request = native_graphql_request(&query)?;
         let mut builder = self
             .http
             .post(self.native_graphql_endpoint())
@@ -129,6 +103,27 @@ impl DatalensLogReader for DatalensHttpClient {
     }
 }
 
+pub fn native_graphql_request(query: &DatalensLogQuery) -> anyhow::Result<serde_json::Value> {
+    let input = if query.chain_id == TRON_CHAIN_ID {
+        tron_query_input(query)?
+    } else {
+        evm_query_input(query)?
+    };
+
+    Ok(json!({
+        "query": r#"
+            query OrmpIndexerLogs($input: QueryInput!) {
+              query(input: $input) {
+                rows
+              }
+            }
+        "#,
+        "variables": {
+            "input": input
+        }
+    }))
+}
+
 pub fn logs_from_native_query_payload(
     payload: &serde_json::Value,
     chain_id: u64,
@@ -137,6 +132,14 @@ pub fn logs_from_native_query_payload(
         .pointer("/data/query/rows")
         .cloned()
         .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+    if chain_id == TRON_CHAIN_ID {
+        let logs = native_tron_event_rows(&rows)?;
+        return logs
+            .into_iter()
+            .map(|row| row.into_datalens_log(chain_id))
+            .collect();
+    }
+
     let logs = native_log_rows(&rows)?;
     logs.into_iter()
         .map(|row| row.into_datalens_log(chain_id))
@@ -197,8 +200,220 @@ impl NativeLogRow {
             transaction_from: self.transaction_from,
             topics: self.topics,
             data: self.data,
+            event_name: None,
+            event_signature: None,
+            indexed_fields: Vec::new(),
+            non_indexed_fields: None,
         })
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+struct NativeTronEventRow {
+    #[serde(default)]
+    id: Option<String>,
+    contract_address: String,
+    #[serde(default)]
+    event_name: Option<String>,
+    #[serde(default)]
+    event_signature: Option<String>,
+    #[serde(default)]
+    indexed_fields: Vec<serde_json::Value>,
+    #[serde(default)]
+    non_indexed_fields: Option<serde_json::Value>,
+    transaction_id: String,
+    block_number: u64,
+    block_timestamp: u64,
+    transaction_index: i32,
+    event_index: u64,
+}
+
+impl NativeTronEventRow {
+    fn into_datalens_log(self, chain_id: u64) -> anyhow::Result<DatalensLog> {
+        let id = self.id.unwrap_or_else(|| {
+            format!(
+                "{}-{}-{}-{}",
+                chain_id, self.block_number, self.transaction_id, self.event_index
+            )
+        });
+        let topics = self
+            .indexed_fields
+            .iter()
+            .filter_map(|field| field.as_str().map(ToOwned::to_owned))
+            .collect::<Vec<_>>();
+        let data = self
+            .non_indexed_fields
+            .as_ref()
+            .map(|fields| {
+                fields
+                    .as_str()
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| fields.to_string())
+            })
+            .unwrap_or_default();
+
+        Ok(DatalensLog {
+            id: Some(id),
+            chain_id,
+            block_number: self.block_number,
+            block_timestamp: Some(self.block_timestamp),
+            transaction_hash: self.transaction_id,
+            transaction_index: Some(self.transaction_index),
+            log_index: self.event_index,
+            address: self.contract_address,
+            transaction_from: None,
+            topics,
+            data,
+            event_name: self.event_name,
+            event_signature: self.event_signature,
+            indexed_fields: self.indexed_fields,
+            non_indexed_fields: self.non_indexed_fields,
+        })
+    }
+}
+
+fn native_tron_event_rows(rows: &serde_json::Value) -> anyhow::Result<Vec<NativeTronEventRow>> {
+    if rows.is_array() {
+        return Ok(serde_json::from_value(rows.clone())?);
+    }
+
+    if let Some(value) = rows.pointer("/rows/rows") {
+        return Ok(serde_json::from_value(value.clone())?);
+    }
+
+    if let Some(value) = rows.pointer("/rows") {
+        return Ok(serde_json::from_value(value.clone())?);
+    }
+
+    anyhow::bail!("Datalens native query response missing Tron event rows")
+}
+
+fn evm_query_input(query: &DatalensLogQuery) -> anyhow::Result<serde_json::Value> {
+    let chain_name = evm_chain_name(query.chain_id)?;
+    Ok(json!({
+        "chain": {
+            "family": { "kind": "evm" },
+            "configuredName": chain_name,
+            "networkId": { "numeric": query.chain_id },
+        },
+        "datasetKey": {
+            "family": "evm",
+            "name": "logs",
+        },
+        "selector": {
+            "kind": "evm_logs",
+            "evmLogs": {
+                "addresses": query.contracts,
+                "topics": topic_filters(&query.topics),
+            },
+        },
+        "range": {
+            "kind": "block",
+            "start": query.from_block,
+            "end": query.to_block,
+        },
+        "finality": native_finality(query.finality_mode),
+        "fields": {},
+    }))
+}
+
+fn tron_query_input(query: &DatalensLogQuery) -> anyhow::Result<serde_json::Value> {
+    let selector = tron_event_selector(&query.contracts, &query.topics)?;
+    Ok(json!({
+        "chain": {
+            "family": { "kind": "other", "other": "tron" },
+            "configuredName": tron_chain_name(query.chain_id)?,
+            "networkId": { "numeric": query.chain_id },
+        },
+        "datasetKey": {
+            "family": "tron",
+            "name": "events",
+        },
+        "selector": {
+            "kind": "other",
+            "other": selector,
+        },
+        "range": {
+            "kind": "block",
+            "start": query.from_block,
+            "end": query.to_block,
+        },
+        "finality": native_finality(query.finality_mode),
+        "fields": {},
+    }))
+}
+
+fn tron_event_selector(
+    contracts: &[String],
+    event_names: &[String],
+) -> anyhow::Result<serde_json::Value> {
+    let mut contracts = contracts
+        .iter()
+        .map(|address| normalize_tron_contract_address(address))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    contracts.sort();
+    contracts.dedup();
+    if contracts.is_empty() {
+        anyhow::bail!("Tron event selector requires at least one contract address");
+    }
+
+    let mut event_names = event_names
+        .iter()
+        .map(|name| normalize_tron_event_name(name))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    event_names.sort();
+    event_names.dedup();
+
+    let canonical_key = format!(
+        "contracts/{}/events/{}",
+        contracts.join("+"),
+        if event_names.is_empty() {
+            "all".to_owned()
+        } else {
+            event_names.join("+")
+        }
+    );
+
+    Ok(json!({
+        "kind": "tron_events",
+        "fingerprint": format!("tron-events/{}", digest_prefix(&canonical_key, 12)),
+        "canonicalKey": canonical_key,
+    }))
+}
+
+fn normalize_tron_contract_address(address: &str) -> anyhow::Result<String> {
+    let address = address.trim();
+    let hex = address.strip_prefix("0x").unwrap_or(address);
+    let normalized = match hex.len() {
+        40 if hex.bytes().all(|byte| byte.is_ascii_hexdigit()) => format!("41{hex}"),
+        42 if hex.starts_with("41") && hex.bytes().all(|byte| byte.is_ascii_hexdigit()) => {
+            hex.to_owned()
+        }
+        _ => address.to_owned(),
+    };
+    if normalized.is_empty() || normalized.contains('/') || normalized.contains('\\') {
+        anyhow::bail!("Tron contract address must be a non-empty address");
+    }
+    Ok(normalized.to_ascii_lowercase())
+}
+
+fn normalize_tron_event_name(name: &str) -> anyhow::Result<String> {
+    let name = name.trim();
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        anyhow::bail!("Tron event name must be a non-empty identifier");
+    }
+    Ok(name.to_owned())
+}
+
+fn digest_prefix(value: &str, bytes: usize) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    hex::encode(&digest[..bytes])
 }
 
 fn topic_filters(topics: &[String]) -> Vec<Vec<String>> {
@@ -228,5 +443,12 @@ pub fn evm_chain_name(chain_id: u64) -> anyhow::Result<&'static str> {
         81457 => "blast",
         2818 => "morph",
         _ => anyhow::bail!("unsupported EVM Datalens chain id: {chain_id}"),
+    })
+}
+
+pub fn tron_chain_name(chain_id: u64) -> anyhow::Result<&'static str> {
+    Ok(match chain_id {
+        TRON_CHAIN_ID => "tron-mainnet",
+        _ => anyhow::bail!("unsupported Tron Datalens chain id: {chain_id}"),
     })
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,12 +1,15 @@
 use anyhow::{Context, bail, ensure};
 use ethabi::{ParamType, Token, decode};
+use serde_json::{Map, Value};
 
 use crate::{
     datalens::DatalensLog,
     planner::{
         MSGPORT_MESSAGE_RECV_TOPIC, MSGPORT_MESSAGE_SENT_TOPIC, ORMP_HASH_IMPORTED_TOPIC,
         ORMP_MESSAGE_ACCEPTED_TOPIC, ORMP_MESSAGE_ASSIGNED_TOPIC, ORMP_MESSAGE_DISPATCHED_TOPIC,
-        SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
+        SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC, TRON_CHAIN_ID, TRON_HASH_IMPORTED_EVENT,
+        TRON_MESSAGE_ACCEPTED_EVENT, TRON_MESSAGE_ASSIGNED_EVENT, TRON_MESSAGE_DISPATCHED_EVENT,
+        TRON_MESSAGE_RECV_EVENT, TRON_MESSAGE_SENT_EVENT, TRON_SIGNATURE_SUBMITTION_EVENT,
     },
     schema::{ChainLogMetadata, EventSource, LegacyOrmPEvent},
 };
@@ -30,6 +33,10 @@ pub struct EvmEventDecoder;
 
 impl EventDecoder for EvmEventDecoder {
     async fn decode(&self, log: &DatalensLog) -> anyhow::Result<Vec<LegacyOrmPEvent>> {
+        if log.chain_id == TRON_CHAIN_ID {
+            return decode_tron_event(log).map(|event| vec![event]);
+        }
+
         decode_evm_log(log).map(|event| vec![event])
     }
 }
@@ -80,6 +87,169 @@ fn evm_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
             .as_deref()
             .map(normalize_hex)
             .transpose()?,
+    })
+}
+
+pub fn decode_tron_event(log: &DatalensLog) -> anyhow::Result<LegacyOrmPEvent> {
+    let event_name = log
+        .event_name
+        .as_deref()
+        .context("Tron event is missing event_name")?;
+    let metadata = tron_metadata(log)?;
+    let fields = log
+        .non_indexed_fields
+        .as_ref()
+        .context("Tron event is missing non_indexed_fields")?
+        .as_object()
+        .context("Tron event payload must be an object")?;
+
+    match event_name {
+        TRON_HASH_IMPORTED_EVENT => decode_tron_hash_imported(metadata, fields),
+        TRON_MESSAGE_ACCEPTED_EVENT => decode_tron_message_accepted(metadata, fields),
+        TRON_MESSAGE_ASSIGNED_EVENT => decode_tron_message_assigned(metadata, fields),
+        TRON_MESSAGE_DISPATCHED_EVENT => decode_tron_message_dispatched(metadata, fields),
+        TRON_MESSAGE_RECV_EVENT => decode_tron_msgport_message_recv(metadata, fields),
+        TRON_MESSAGE_SENT_EVENT => decode_tron_msgport_message_sent(metadata, fields),
+        TRON_SIGNATURE_SUBMITTION_EVENT | "SignatureSubmission" => {
+            decode_tron_signature_submittion(metadata, fields)
+        }
+        _ => bail!("unsupported ORMP Tron event name {event_name}"),
+    }
+}
+
+fn tron_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
+    Ok(ChainLogMetadata {
+        id: log
+            .id
+            .clone()
+            .context("Tron event is missing legacy event id")?,
+        source: EventSource::Tron,
+        chain_id: log.chain_id.into(),
+        block_number: log.block_number.into(),
+        block_timestamp: log
+            .block_timestamp
+            .context("Tron event is missing block timestamp")?
+            .into(),
+        transaction_hash: log.transaction_hash.clone(),
+        transaction_index: log
+            .transaction_index
+            .context("Tron event is missing transaction index")?,
+        log_index: i32::try_from(log.log_index).context("Tron event index overflows i32")?,
+        contract_address: normalize_tron_address(&log.address)?,
+        transaction_from: log
+            .transaction_from
+            .as_deref()
+            .map(normalize_tron_address)
+            .transpose()?,
+    })
+}
+
+fn decode_tron_hash_imported(
+    metadata: ChainLogMetadata,
+    fields: &Map<String, Value>,
+) -> anyhow::Result<LegacyOrmPEvent> {
+    Ok(LegacyOrmPEvent::HashImported {
+        target_chain_id: metadata.chain_id,
+        metadata,
+        oracle: tron_address_field(fields, &["oracle"])?,
+        src_chain_id: tron_uint_field(fields, &["chainId", "srcChainId"])?,
+        channel: tron_address_field(fields, &["channel"])?,
+        msg_index: tron_uint_field(fields, &["msgIndex"])?,
+        hash: tron_hex_field(fields, &["hash"])?,
+    })
+}
+
+fn decode_tron_message_accepted(
+    metadata: ChainLogMetadata,
+    fields: &Map<String, Value>,
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let message = match optional_field(fields, &["message"])? {
+        Some(Value::Object(message)) => Some(message),
+        Some(_) => bail!("Tron event field message must be an object"),
+        None => None,
+    };
+    let message_fields = message.unwrap_or(fields);
+
+    Ok(LegacyOrmPEvent::MessageAccepted {
+        metadata,
+        msg_hash: tron_hex_field(fields, &["msgHash", "messageHash"])?,
+        channel: tron_address_field(message_fields, &["channel"])?,
+        index: tron_uint_field(message_fields, &["index"])?,
+        from_chain_id: tron_uint_field(message_fields, &["fromChainId"])?,
+        from: tron_address_field(message_fields, &["from"])?,
+        to_chain_id: tron_uint_field(message_fields, &["toChainId"])?,
+        to: tron_address_field(message_fields, &["to"])?,
+        gas_limit: tron_uint_field(message_fields, &["gasLimit"])?,
+        encoded: tron_hex_field(message_fields, &["encoded"])?,
+    })
+}
+
+fn decode_tron_message_assigned(
+    metadata: ChainLogMetadata,
+    fields: &Map<String, Value>,
+) -> anyhow::Result<LegacyOrmPEvent> {
+    Ok(LegacyOrmPEvent::MessageAssigned {
+        metadata,
+        msg_hash: tron_hex_field(fields, &["msgHash", "messageHash"])?,
+        oracle: tron_address_field(fields, &["oracle"])?,
+        relayer: tron_address_field(fields, &["relayer"])?,
+        oracle_fee: tron_uint_field(fields, &["oracleFee"])?,
+        relayer_fee: tron_uint_field(fields, &["relayerFee"])?,
+        params: tron_hex_field(fields, &["params"])?,
+    })
+}
+
+fn decode_tron_message_dispatched(
+    metadata: ChainLogMetadata,
+    fields: &Map<String, Value>,
+) -> anyhow::Result<LegacyOrmPEvent> {
+    Ok(LegacyOrmPEvent::MessageDispatched {
+        target_chain_id: metadata.chain_id,
+        metadata,
+        msg_hash: tron_hex_field(fields, &["msgHash", "messageHash"])?,
+        dispatch_result: tron_bool_field(fields, &["dispatchResult"])?,
+    })
+}
+
+fn decode_tron_msgport_message_recv(
+    metadata: ChainLogMetadata,
+    fields: &Map<String, Value>,
+) -> anyhow::Result<LegacyOrmPEvent> {
+    Ok(LegacyOrmPEvent::MsgportMessageRecv {
+        metadata,
+        msg_id: tron_hex_field(fields, &["msgId", "messageId"])?,
+        result: tron_bool_field(fields, &["result"])?,
+        return_data: tron_hex_field(fields, &["returnData"])?,
+    })
+}
+
+fn decode_tron_msgport_message_sent(
+    metadata: ChainLogMetadata,
+    fields: &Map<String, Value>,
+) -> anyhow::Result<LegacyOrmPEvent> {
+    Ok(LegacyOrmPEvent::MsgportMessageSent {
+        metadata,
+        msg_id: tron_hex_field(fields, &["msgId", "messageId"])?,
+        from_dapp: tron_address_field(fields, &["fromDapp"])?,
+        to_chain_id: tron_uint_field(fields, &["toChainId"])?,
+        to_dapp: tron_address_field(fields, &["toDapp"])?,
+        message: tron_hex_field(fields, &["message"])?,
+        params: tron_hex_field(fields, &["params"])?,
+    })
+}
+
+fn decode_tron_signature_submittion(
+    metadata: ChainLogMetadata,
+    fields: &Map<String, Value>,
+) -> anyhow::Result<LegacyOrmPEvent> {
+    Ok(LegacyOrmPEvent::SignatureSubmittion {
+        metadata,
+        chain_id: tron_uint_field(fields, &["chainId"])?,
+        channel: tron_address_field(fields, &["channel"])?,
+        signer: tron_address_field(fields, &["signer"])?,
+        msg_index: tron_uint_field(fields, &["msgIndex"])?,
+        signature: tron_hex_field(fields, &["signature"])?,
+        data: tron_hex_field(fields, &["data"])?,
     })
 }
 
@@ -316,6 +486,85 @@ fn normalize_hex(value: &str) -> anyhow::Result<String> {
         "invalid hex value"
     );
     Ok(format!("0x{}", value.to_ascii_lowercase()))
+}
+
+fn optional_field<'a>(
+    fields: &'a Map<String, Value>,
+    names: &[&str],
+) -> anyhow::Result<Option<&'a Value>> {
+    for name in names {
+        if let Some(value) = fields.get(*name) {
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
+}
+
+fn required_field<'a>(fields: &'a Map<String, Value>, names: &[&str]) -> anyhow::Result<&'a Value> {
+    optional_field(fields, names)?.with_context(|| {
+        let name = names.first().copied().unwrap_or("unknown");
+        format!("Tron event field {name} is missing")
+    })
+}
+
+fn tron_hex_field(fields: &Map<String, Value>, names: &[&str]) -> anyhow::Result<String> {
+    let name = names.first().copied().unwrap_or("unknown");
+    let value = required_field(fields, names)?;
+    let value = value
+        .as_str()
+        .with_context(|| format!("Tron event field {name} must be a hex string"))?;
+    normalize_hex(value).with_context(|| format!("Tron event field {name} is invalid hex"))
+}
+
+fn tron_address_field(fields: &Map<String, Value>, names: &[&str]) -> anyhow::Result<String> {
+    let name = names.first().copied().unwrap_or("unknown");
+    let value = required_field(fields, names)?;
+    let value = value
+        .as_str()
+        .with_context(|| format!("Tron event field {name} must be an address string"))?;
+    normalize_tron_address(value)
+}
+
+fn tron_bool_field(fields: &Map<String, Value>, names: &[&str]) -> anyhow::Result<bool> {
+    let name = names.first().copied().unwrap_or("unknown");
+    match required_field(fields, names)? {
+        Value::Bool(value) => Ok(*value),
+        Value::String(value) if value == "true" => Ok(true),
+        Value::String(value) if value == "false" => Ok(false),
+        _ => bail!("Tron event field {name} must be a bool"),
+    }
+}
+
+fn tron_uint_field(fields: &Map<String, Value>, names: &[&str]) -> anyhow::Result<u128> {
+    let name = names.first().copied().unwrap_or("unknown");
+    match required_field(fields, names)? {
+        Value::Number(value) => value
+            .as_u64()
+            .map(u128::from)
+            .with_context(|| format!("Tron event field {name} must be an unsigned integer")),
+        Value::String(value) => value
+            .parse::<u128>()
+            .with_context(|| format!("Tron event field {name} must be an unsigned integer")),
+        _ => bail!("Tron event field {name} must be an unsigned integer"),
+    }
+}
+
+fn normalize_tron_address(value: &str) -> anyhow::Result<String> {
+    let value = value.trim();
+    ensure!(!value.is_empty(), "Tron address must not be empty");
+    if value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+        .map(|hex| hex.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .unwrap_or(false)
+        || (value.len() == 42
+            && value.starts_with("41")
+            && value.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    {
+        return Ok(value.to_ascii_lowercase());
+    }
+
+    Ok(value.to_owned())
 }
 
 fn decode_hex(value: &str) -> anyhow::Result<Vec<u8>> {

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -25,7 +25,9 @@ pub const SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC: &str =
     "0x8b3975e4768e70d323e926e2cef0676fc9a3250437d9b8f90b52c770f0d7545f";
 
 pub const PRODUCTION_EVM_CHAIN_IDS: &[u64] = &[1, 46, 137, 42161];
+pub const EVM_LOGS_DATASET: &str = "evm.logs";
 pub const TRON_CHAIN_ID: u64 = 728_126_428;
+pub const TRON_EVENTS_DATASET: &str = "tron.events";
 
 pub const TRON_MSGPORT_ADDRESS: &str = "0x2cd1867Fb8016f93710B6386f7f9F1D540A60812";
 pub const TRON_ORMP_ADDRESS: &str = "0x13b2211a7cA45Db2808F6dB05557ce5347e3634e";
@@ -146,8 +148,17 @@ pub fn default_tron_chain_config() -> anyhow::Result<ChainConfig> {
     })
 }
 
+pub fn chain_dataset(chain_id: u64) -> anyhow::Result<&'static str> {
+    if chain_id == TRON_CHAIN_ID {
+        return Ok(TRON_EVENTS_DATASET);
+    }
+
+    default_evm_chain_config(chain_id)?;
+    Ok(EVM_LOGS_DATASET)
+}
+
 pub fn plan_evm_log_queries(
-    dataset: &str,
+    _dataset: &str,
     chain: &ChainConfig,
     from_block: u64,
     to_block: u64,
@@ -177,7 +188,7 @@ pub fn plan_evm_log_queries(
     while next_from <= to_block {
         let range_end = next_from.saturating_add(max_range_len - 1).min(to_block);
         plans.push(PlannedDatalensLogQuery {
-            dataset: dataset.to_owned(),
+            dataset: EVM_LOGS_DATASET.to_owned(),
             query: DatalensLogQuery {
                 chain_id: chain.chain_id,
                 from_block: next_from,
@@ -198,7 +209,7 @@ pub fn plan_evm_log_queries(
 }
 
 pub fn plan_tron_event_queries(
-    dataset: &str,
+    _dataset: &str,
     chain: &ChainConfig,
     from_block: u64,
     to_block: u64,
@@ -224,7 +235,7 @@ pub fn plan_tron_event_queries(
     while next_from <= to_block {
         let range_end = next_from.saturating_add(max_range_len - 1).min(to_block);
         plans.push(PlannedDatalensLogQuery {
-            dataset: dataset.to_owned(),
+            dataset: TRON_EVENTS_DATASET.to_owned(),
             query: DatalensLogQuery {
                 chain_id: chain.chain_id,
                 from_block: next_from,

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -25,6 +25,19 @@ pub const SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC: &str =
     "0x8b3975e4768e70d323e926e2cef0676fc9a3250437d9b8f90b52c770f0d7545f";
 
 pub const PRODUCTION_EVM_CHAIN_IDS: &[u64] = &[1, 46, 137, 42161];
+pub const TRON_CHAIN_ID: u64 = 728_126_428;
+
+pub const TRON_MSGPORT_ADDRESS: &str = "0x2cd1867Fb8016f93710B6386f7f9F1D540A60812";
+pub const TRON_ORMP_ADDRESS: &str = "0x13b2211a7cA45Db2808F6dB05557ce5347e3634e";
+pub const TRON_SIGNATURE_PUB_ADDRESS: &str = "0x57Aa601A0377f5AB313C5A955ee874f5D495fC92";
+
+pub const TRON_HASH_IMPORTED_EVENT: &str = "HashImported";
+pub const TRON_MESSAGE_ACCEPTED_EVENT: &str = "MessageAccepted";
+pub const TRON_MESSAGE_ASSIGNED_EVENT: &str = "MessageAssigned";
+pub const TRON_MESSAGE_DISPATCHED_EVENT: &str = "MessageDispatched";
+pub const TRON_MESSAGE_RECV_EVENT: &str = "MessageRecv";
+pub const TRON_MESSAGE_SENT_EVENT: &str = "MessageSent";
+pub const TRON_SIGNATURE_SUBMITTION_EVENT: &str = "SignatureSubmittion";
 
 const DEFAULT_EVM_CHAINS: &[DefaultEvmChain] = &[
     DefaultEvmChain {
@@ -103,6 +116,36 @@ pub fn default_evm_chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
     })
 }
 
+pub fn default_chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
+    if chain_id == TRON_CHAIN_ID {
+        return default_tron_chain_config();
+    }
+
+    default_evm_chain_config(chain_id)
+        .map_err(|_| anyhow::anyhow!("unconfigured ORMP chain {chain_id}"))
+}
+
+pub fn default_tron_chain_config() -> anyhow::Result<ChainConfig> {
+    Ok(ChainConfig {
+        chain_id: TRON_CHAIN_ID,
+        start_block: 0,
+        contracts: vec![
+            TRON_MSGPORT_ADDRESS.to_owned(),
+            TRON_ORMP_ADDRESS.to_owned(),
+            TRON_SIGNATURE_PUB_ADDRESS.to_owned(),
+        ],
+        topics: vec![
+            TRON_MESSAGE_RECV_EVENT.to_owned(),
+            TRON_MESSAGE_SENT_EVENT.to_owned(),
+            TRON_HASH_IMPORTED_EVENT.to_owned(),
+            TRON_MESSAGE_ACCEPTED_EVENT.to_owned(),
+            TRON_MESSAGE_ASSIGNED_EVENT.to_owned(),
+            TRON_MESSAGE_DISPATCHED_EVENT.to_owned(),
+            TRON_SIGNATURE_SUBMITTION_EVENT.to_owned(),
+        ],
+    })
+}
+
 pub fn plan_evm_log_queries(
     dataset: &str,
     chain: &ChainConfig,
@@ -126,6 +169,53 @@ pub fn plan_evm_log_queries(
     ensure!(
         !chain.topics.is_empty(),
         "EVM log query planner requires at least one event topic"
+    );
+
+    let mut plans = Vec::new();
+    let mut next_from = from_block;
+
+    while next_from <= to_block {
+        let range_end = next_from.saturating_add(max_range_len - 1).min(to_block);
+        plans.push(PlannedDatalensLogQuery {
+            dataset: dataset.to_owned(),
+            query: DatalensLogQuery {
+                chain_id: chain.chain_id,
+                from_block: next_from,
+                to_block: range_end,
+                contracts: chain.contracts.clone(),
+                topics: chain.topics.clone(),
+                finality_mode,
+            },
+        });
+
+        if range_end == u64::MAX {
+            break;
+        }
+        next_from = range_end + 1;
+    }
+
+    Ok(plans)
+}
+
+pub fn plan_tron_event_queries(
+    dataset: &str,
+    chain: &ChainConfig,
+    from_block: u64,
+    to_block: u64,
+    max_range_len: u64,
+    finality_mode: FinalityMode,
+) -> anyhow::Result<Vec<PlannedDatalensLogQuery>> {
+    ensure!(
+        max_range_len > 0,
+        "max range length must be greater than zero"
+    );
+    ensure!(
+        from_block <= to_block,
+        "from block must be less than or equal to to block"
+    );
+    ensure!(
+        !chain.contracts.is_empty(),
+        "Tron event query planner requires at least one contract address"
     );
 
     let mut plans = Vec::new();

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -8,6 +8,7 @@ use crate::{
     database::EventWriter,
     datalens::{DatalensLogQuery, DatalensLogReader},
     decoder::EventDecoder,
+    planner::chain_dataset,
 };
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -58,16 +59,17 @@ where
         let mut report = RunnerReport::default();
 
         for chain in &self.config.enabled_chains {
+            let dataset = chain_dataset(chain.chain_id)?;
             let checkpoint = self
                 .checkpoints
-                .read_or_create(chain.chain_id, &self.config.dataset, chain.start_block)
+                .read_or_create(chain.chain_id, dataset, chain.start_block)
                 .await?;
             let range = plan_next_range(&checkpoint, self.config.batch_size)?;
 
             log::info!(
                 "querying ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={} batch_size={} contracts={} topics={} finality={}",
                 chain.chain_id,
-                self.config.dataset,
+                dataset,
                 range.from_block,
                 range.to_block,
                 self.config.batch_size,
@@ -97,13 +99,13 @@ where
                 .checked_add(1)
                 .context("checkpoint next block overflow")?;
             self.checkpoints
-                .advance(chain.chain_id, &self.config.dataset, next_block)
+                .advance(chain.chain_id, dataset, next_block)
                 .await?;
 
             log::info!(
                 "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true",
                 chain.chain_id,
-                self.config.dataset,
+                dataset,
                 range.from_block,
                 range.to_block,
                 result.logs.len(),

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -184,7 +184,7 @@ fn test_tron_native_graphql_request_uses_other_selector_shape() {
         chain_id: TRON_CHAIN_ID,
         from_block: 100,
         to_block: 110,
-        contracts: vec!["0x0000000000000000000000000000000000000000".to_owned()],
+        contracts: vec!["TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t".to_owned()],
         topics: vec!["MessageDispatched".to_owned(), "MessageAccepted".to_owned()],
         finality_mode: ormpindexer::config::FinalityMode::Durable,
     })
@@ -208,7 +208,7 @@ fn test_tron_native_graphql_request_uses_other_selector_shape() {
     assert_eq!(input["selector"]["other"]["kind"], "tron_events");
     assert_eq!(
         input["selector"]["other"]["canonicalKey"],
-        "contracts/410000000000000000000000000000000000000000/events/MessageAccepted+MessageDispatched"
+        "contracts/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t/events/MessageAccepted+MessageDispatched"
     );
     assert!(
         input["selector"]["other"]["fingerprint"]
@@ -221,6 +221,25 @@ fn test_tron_native_graphql_request_uses_other_selector_shape() {
         serde_json::json!({"kind": "block", "start": 100, "end": 110})
     );
     assert_eq!(input["finality"], "durable_only");
+}
+
+#[test]
+fn test_tron_native_graphql_request_rejects_invalid_contract_address() {
+    let error = native_graphql_request(&ormpindexer::datalens::DatalensLogQuery {
+        chain_id: TRON_CHAIN_ID,
+        from_block: 100,
+        to_block: 110,
+        contracts: vec!["not/a/tron/address".to_owned()],
+        topics: Vec::new(),
+        finality_mode: ormpindexer::config::FinalityMode::Durable,
+    })
+    .expect_err("invalid Tron address should fail");
+
+    assert!(
+        error
+            .to_string()
+            .contains("Tron contract address must be hex")
+    );
 }
 
 #[test]

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -1,4 +1,10 @@
-use ormpindexer::datalens::{DatalensLog, evm_chain_name, logs_from_native_query_payload};
+use ormpindexer::{
+    datalens::{
+        DatalensLog, evm_chain_name, logs_from_native_query_payload, native_graphql_request,
+        tron_chain_name,
+    },
+    planner::TRON_CHAIN_ID,
+};
 
 #[test]
 fn test_datalens_log_decodes_native_graphql_camel_case_response() {
@@ -107,7 +113,127 @@ fn test_native_query_rows_decode_with_context_metadata() {
 }
 
 #[test]
+fn test_tron_native_query_rows_decode_with_context_metadata() {
+    let logs = logs_from_native_query_payload(
+        &serde_json::json!({
+            "data": {
+                "query": {
+                    "rows": {
+                        "dataset_key": { "family": { "kind": "tron" }, "name": "events" },
+                        "rows": {
+                            "dataset": "events",
+                            "rows": [{
+                                "contract_address": "41ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD",
+                                "event_name": "MessageSent",
+                                "event_signature": "MessageSent(bytes32,address,uint256,address,bytes,bytes)",
+                                "indexed_fields": [],
+                                "non_indexed_fields": {
+                                    "msgId": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                                    "fromDapp": "0x0000000000000000000000000000000000000030",
+                                    "toChainId": "42161",
+                                    "toDapp": "0x0000000000000000000000000000000000000031",
+                                    "message": "0xaa",
+                                    "params": "0xbbcc"
+                                },
+                                "transaction_id": "trontx",
+                                "block_number": 123,
+                                "block_hash": "0xblock",
+                                "parent_hash": "0xparent",
+                                "block_timestamp": 456,
+                                "transaction_index": 2,
+                                "event_index": 3,
+                                "confirmed": true,
+                                "source": { "provider": "trongrid_contract_events" }
+                            }]
+                        }
+                    }
+                }
+            }
+        }),
+        TRON_CHAIN_ID,
+    )
+    .expect("decode native Tron query rows");
+
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].id.as_deref(), Some("728126428-123-trontx-3"));
+    assert_eq!(logs[0].chain_id, TRON_CHAIN_ID);
+    assert_eq!(logs[0].block_number, 123);
+    assert_eq!(logs[0].block_timestamp, Some(456));
+    assert_eq!(logs[0].transaction_hash, "trontx");
+    assert_eq!(logs[0].transaction_index, Some(2));
+    assert_eq!(logs[0].log_index, 3);
+    assert_eq!(
+        logs[0].address,
+        "41ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"
+    );
+    assert_eq!(logs[0].transaction_from, None);
+    assert_eq!(logs[0].event_name.as_deref(), Some("MessageSent"));
+    assert_eq!(
+        logs[0].event_signature.as_deref(),
+        Some("MessageSent(bytes32,address,uint256,address,bytes,bytes)")
+    );
+    assert_eq!(
+        logs[0].non_indexed_fields.as_ref().expect("decoded args")["toChainId"],
+        "42161"
+    );
+}
+
+#[test]
+fn test_tron_native_graphql_request_uses_other_selector_shape() {
+    let request = native_graphql_request(&ormpindexer::datalens::DatalensLogQuery {
+        chain_id: TRON_CHAIN_ID,
+        from_block: 100,
+        to_block: 110,
+        contracts: vec!["0x0000000000000000000000000000000000000000".to_owned()],
+        topics: vec!["MessageDispatched".to_owned(), "MessageAccepted".to_owned()],
+        finality_mode: ormpindexer::config::FinalityMode::Durable,
+    })
+    .expect("build Tron request");
+    let input = &request["variables"]["input"];
+
+    assert_eq!(
+        input["chain"]["family"],
+        serde_json::json!({"kind": "other", "other": "tron"})
+    );
+    assert_eq!(input["chain"]["configuredName"], "tron-mainnet");
+    assert_eq!(
+        input["chain"]["networkId"],
+        serde_json::json!({"numeric": TRON_CHAIN_ID})
+    );
+    assert_eq!(
+        input["datasetKey"],
+        serde_json::json!({"family": "tron", "name": "events"})
+    );
+    assert_eq!(input["selector"]["kind"], "other");
+    assert_eq!(input["selector"]["other"]["kind"], "tron_events");
+    assert_eq!(
+        input["selector"]["other"]["canonicalKey"],
+        "contracts/410000000000000000000000000000000000000000/events/MessageAccepted+MessageDispatched"
+    );
+    assert!(
+        input["selector"]["other"]["fingerprint"]
+            .as_str()
+            .expect("fingerprint")
+            .starts_with("tron-events/")
+    );
+    assert_eq!(
+        input["range"],
+        serde_json::json!({"kind": "block", "start": 100, "end": 110})
+    );
+    assert_eq!(input["finality"], "durable_only");
+}
+
+#[test]
 fn test_evm_chain_name_rejects_unknown_chain_ids() {
     assert_eq!(evm_chain_name(46).expect("darwinia chain name"), "darwinia");
     assert!(evm_chain_name(99_999).is_err());
+}
+
+#[test]
+fn test_tron_chain_name_rejects_unknown_chain_ids() {
+    assert_eq!(
+        tron_chain_name(TRON_CHAIN_ID).expect("tron mainnet"),
+        "tron-mainnet"
+    );
+    assert!(tron_chain_name(46).is_err());
 }

--- a/tests/datalens_planner.rs
+++ b/tests/datalens_planner.rs
@@ -4,7 +4,9 @@ use ormpindexer::{
     config::{FinalityMode, RuntimeConfig},
     planner::{
         PRODUCTION_EVM_CHAIN_IDS, SIGNATURE_PUB_ADDRESS, SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
-        default_evm_chain_config, plan_evm_log_queries,
+        TRON_CHAIN_ID, TRON_MESSAGE_ACCEPTED_EVENT, TRON_MESSAGE_DISPATCHED_EVENT,
+        default_chain_config, default_evm_chain_config, default_tron_chain_config,
+        plan_evm_log_queries, plan_tron_event_queries,
     },
 };
 
@@ -88,6 +90,57 @@ fn test_plan_evm_log_queries_splits_ranges_by_limit() {
 }
 
 #[test]
+fn test_tron_chain_default_config_and_query_plans_are_available() {
+    let chain = default_tron_chain_config().expect("tron mainnet");
+    let plans = plan_tron_event_queries(
+        "datalens-native",
+        &chain,
+        chain.start_block,
+        chain.start_block + 9,
+        100,
+        FinalityMode::Finalized,
+    )
+    .expect("tron query plans");
+
+    assert_eq!(chain.chain_id, TRON_CHAIN_ID);
+    assert!(!chain.contracts.is_empty());
+    assert!(
+        chain
+            .topics
+            .contains(&TRON_MESSAGE_ACCEPTED_EVENT.to_owned())
+    );
+    assert!(
+        chain
+            .topics
+            .contains(&TRON_MESSAGE_DISPATCHED_EVENT.to_owned())
+    );
+    assert_eq!(plans.len(), 1);
+    assert_eq!(plans[0].dataset, "datalens-native");
+    assert_eq!(plans[0].query.chain_id, TRON_CHAIN_ID);
+    assert_eq!(plans[0].query.from_block, chain.start_block);
+    assert_eq!(plans[0].query.to_block, chain.start_block + 9);
+    assert_eq!(plans[0].query.contracts, chain.contracts);
+    assert_eq!(plans[0].query.topics, chain.topics);
+}
+
+#[test]
+fn test_runtime_config_accepts_tron_chain_defaults() {
+    let env = BTreeMap::from([(
+        "ORMPINDEXER_ENABLED_CHAINS".to_owned(),
+        TRON_CHAIN_ID.to_string(),
+    )]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let tron = config.chain(TRON_CHAIN_ID).expect("tron chain");
+
+    assert_eq!(tron.chain_id, TRON_CHAIN_ID);
+    assert!(!tron.contracts.is_empty());
+    assert!(
+        tron.topics
+            .contains(&TRON_MESSAGE_ACCEPTED_EVENT.to_owned())
+    );
+}
+
+#[test]
 fn test_unknown_chain_returns_clear_error() {
     let error = default_evm_chain_config(999_999).expect_err("unknown chain");
 
@@ -96,6 +149,13 @@ fn test_unknown_chain_returns_clear_error() {
             .to_string()
             .contains("unconfigured ORMP EVM chain 999999")
     );
+}
+
+#[test]
+fn test_default_chain_config_rejects_unknown_chain() {
+    let error = default_chain_config(999_999).expect_err("unknown chain");
+
+    assert!(error.to_string().contains("unconfigured ORMP chain 999999"));
 }
 
 #[test]

--- a/tests/datalens_planner.rs
+++ b/tests/datalens_planner.rs
@@ -15,7 +15,7 @@ fn test_production_evm_chains_produce_default_query_plans() {
     for chain_id in PRODUCTION_EVM_CHAIN_IDS {
         let chain = default_evm_chain_config(*chain_id).expect("configured production chain");
         let plans = plan_evm_log_queries(
-            "datalens-native",
+            "evm.logs",
             &chain,
             chain.start_block,
             chain.start_block + 9,
@@ -25,7 +25,7 @@ fn test_production_evm_chains_produce_default_query_plans() {
         .expect("query plans");
 
         assert_eq!(plans.len(), 1);
-        assert_eq!(plans[0].dataset, "datalens-native");
+        assert_eq!(plans[0].dataset, "evm.logs");
         assert_eq!(plans[0].query.chain_id, *chain_id);
         assert_eq!(plans[0].query.from_block, chain.start_block);
         assert_eq!(plans[0].query.to_block, chain.start_block + 9);
@@ -66,15 +66,8 @@ fn test_darwinia_includes_signature_pub_but_other_defaults_do_not() {
 #[test]
 fn test_plan_evm_log_queries_splits_ranges_by_limit() {
     let chain = default_evm_chain_config(46).expect("darwinia");
-    let plans = plan_evm_log_queries(
-        "datalens-native",
-        &chain,
-        100,
-        220,
-        50,
-        FinalityMode::Durable,
-    )
-    .expect("split plans");
+    let plans = plan_evm_log_queries("ignored", &chain, 100, 220, 50, FinalityMode::Durable)
+        .expect("split plans");
     let ranges = plans
         .iter()
         .map(|plan| (plan.query.from_block, plan.query.to_block))
@@ -93,7 +86,7 @@ fn test_plan_evm_log_queries_splits_ranges_by_limit() {
 fn test_tron_chain_default_config_and_query_plans_are_available() {
     let chain = default_tron_chain_config().expect("tron mainnet");
     let plans = plan_tron_event_queries(
-        "datalens-native",
+        "ignored",
         &chain,
         chain.start_block,
         chain.start_block + 9,
@@ -115,7 +108,7 @@ fn test_tron_chain_default_config_and_query_plans_are_available() {
             .contains(&TRON_MESSAGE_DISPATCHED_EVENT.to_owned())
     );
     assert_eq!(plans.len(), 1);
-    assert_eq!(plans[0].dataset, "datalens-native");
+    assert_eq!(plans[0].dataset, "tron.events");
     assert_eq!(plans[0].query.chain_id, TRON_CHAIN_ID);
     assert_eq!(plans[0].query.from_block, chain.start_block);
     assert_eq!(plans[0].query.to_block, chain.start_block + 9);
@@ -125,10 +118,16 @@ fn test_tron_chain_default_config_and_query_plans_are_available() {
 
 #[test]
 fn test_runtime_config_accepts_tron_chain_defaults() {
-    let env = BTreeMap::from([(
-        "ORMPINDEXER_ENABLED_CHAINS".to_owned(),
-        TRON_CHAIN_ID.to_string(),
-    )]);
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_ENABLED_CHAINS".to_owned(),
+            TRON_CHAIN_ID.to_string(),
+        ),
+        (
+            format!("ORMPINDEXER_CHAIN_{TRON_CHAIN_ID}_START_BLOCK"),
+            "83200000".to_owned(),
+        ),
+    ]);
     let config = RuntimeConfig::from_env_map(&env).expect("config parses");
     let tron = config.chain(TRON_CHAIN_ID).expect("tron chain");
 
@@ -137,6 +136,22 @@ fn test_runtime_config_accepts_tron_chain_defaults() {
     assert!(
         tron.topics
             .contains(&TRON_MESSAGE_ACCEPTED_EVENT.to_owned())
+    );
+}
+
+#[test]
+fn test_runtime_config_requires_tron_start_block() {
+    let env = BTreeMap::from([(
+        "ORMPINDEXER_ENABLED_CHAINS".to_owned(),
+        TRON_CHAIN_ID.to_string(),
+    )]);
+
+    let error = RuntimeConfig::from_env_map(&env).expect_err("missing Tron start block fails");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ORMPINDEXER_CHAIN_728126428_START_BLOCK must be configured for Tron")
     );
 }
 

--- a/tests/datalens_planner.rs
+++ b/tests/datalens_planner.rs
@@ -156,6 +156,25 @@ fn test_runtime_config_requires_tron_start_block() {
 }
 
 #[test]
+fn test_runtime_config_does_not_use_global_start_block_for_tron() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_ENABLED_CHAINS".to_owned(),
+            TRON_CHAIN_ID.to_string(),
+        ),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+
+    let error = RuntimeConfig::from_env_map(&env).expect_err("global start block is ignored");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ORMPINDEXER_CHAIN_728126428_START_BLOCK must be configured for Tron")
+    );
+}
+
+#[test]
 fn test_unknown_chain_returns_clear_error() {
     let error = default_evm_chain_config(999_999).expect_err("unknown chain");
 

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -302,6 +302,10 @@ fn log(topic: &str, address: &str, data: Vec<u8>) -> DatalensLog {
         transaction_from: Some(address_hex(0x50)),
         topics: vec![topic.to_owned()],
         data: format!("0x{}", hex::encode(data)),
+        event_name: None,
+        event_signature: None,
+        indexed_fields: Vec::new(),
+        non_indexed_fields: None,
     }
 }
 

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -136,6 +136,10 @@ async fn test_runner_successful_batch_advances_checkpoint_to_next_range() {
         transaction_from: None,
         topics: vec!["0xaaa".to_owned()],
         data: "0x".to_owned(),
+        event_name: None,
+        event_signature: None,
+        indexed_fields: Vec::new(),
+        non_indexed_fields: None,
     }]);
     let runner = IndexerRunner::new(
         config,

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -162,10 +162,7 @@ async fn test_runner_successful_batch_advances_checkpoint_to_next_range() {
             checkpoints_advanced: 1,
         }
     );
-    assert_eq!(
-        checkpoints.next_block(46, "datalens-native").await.unwrap(),
-        15
-    );
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 15);
 }
 
 #[tokio::test]
@@ -196,10 +193,7 @@ async fn test_runner_empty_logs_still_advance_after_successful_query_and_write()
     let report = runner.run_once().await.expect("empty batch succeeds");
 
     assert_eq!(report.checkpoints_advanced, 1);
-    assert_eq!(
-        checkpoints.next_block(46, "datalens-native").await.unwrap(),
-        15
-    );
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 15);
 }
 
 #[tokio::test]
@@ -233,10 +227,7 @@ async fn test_runner_writer_failure_does_not_advance_checkpoint() {
         .expect_err("writer failure fails the batch");
 
     assert!(error.to_string().contains("write failed"));
-    assert_eq!(
-        checkpoints.next_block(46, "datalens-native").await.unwrap(),
-        10
-    );
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 10);
 }
 
 #[tokio::test]
@@ -281,14 +272,8 @@ async fn test_runner_reports_and_advances_multiple_chains() {
             checkpoints_advanced: 2,
         }
     );
-    assert_eq!(
-        checkpoints.next_block(1, "datalens-native").await.unwrap(),
-        15
-    );
-    assert_eq!(
-        checkpoints.next_block(46, "datalens-native").await.unwrap(),
-        25
-    );
+    assert_eq!(checkpoints.next_block(1, "evm.logs").await.unwrap(), 15);
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 25);
 }
 
 struct RecordingDatalensReader {

--- a/tests/tron_decoder.rs
+++ b/tests/tron_decoder.rs
@@ -1,0 +1,141 @@
+use ormpindexer::{
+    datalens::DatalensLog,
+    decoder::decode_tron_event,
+    planner::TRON_CHAIN_ID,
+    schema::{EventSource, LegacyOrmPEvent, MsgportMessageSentRow},
+};
+
+#[test]
+fn test_decode_tron_message_sent_preserves_legacy_fields() {
+    let log: DatalensLog = serde_json::from_value(serde_json::json!({
+        "id": "728126428-123-trontx-3",
+        "chainId": TRON_CHAIN_ID,
+        "blockNumber": 123,
+        "blockTimestamp": 456,
+        "transactionHash": "trontx",
+        "transactionIndex": 2,
+        "logIndex": 3,
+        "address": "41ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD",
+        "eventName": "MessageSent",
+        "eventSignature": "MessageSent(bytes32,address,uint256,address,bytes,bytes)",
+        "indexedFields": [],
+        "nonIndexedFields": {
+            "msgId": bytes_hex(0x33),
+            "fromDapp": "0x0000000000000000000000000000000000000030",
+            "toChainId": "42161",
+            "toDapp": "0x0000000000000000000000000000000000000031",
+            "message": "0xaa",
+            "params": "0xbbcc"
+        },
+        "topics": [],
+        "data": "0x"
+    }))
+    .expect("decode Tron Datalens log");
+
+    let event = decode_tron_event(&log).expect("decode Tron event");
+
+    assert_eq!(
+        event,
+        LegacyOrmPEvent::MsgportMessageSent {
+            metadata: ormpindexer::schema::ChainLogMetadata {
+                id: "728126428-123-trontx-3".to_owned(),
+                source: EventSource::Tron,
+                chain_id: TRON_CHAIN_ID.into(),
+                block_number: 123,
+                block_timestamp: 456,
+                transaction_hash: "trontx".to_owned(),
+                transaction_index: 2,
+                log_index: 3,
+                contract_address: "41abcdefabcdefabcdefabcdefabcdefabcdefabcd".to_owned(),
+                transaction_from: None,
+            },
+            msg_id: bytes_hex(0x33),
+            from_dapp: "0x0000000000000000000000000000000000000030".to_owned(),
+            to_chain_id: 42161,
+            to_dapp: "0x0000000000000000000000000000000000000031".to_owned(),
+            message: "0xaa".to_owned(),
+            params: "0xbbcc".to_owned(),
+        }
+    );
+
+    let row = MsgportMessageSentRow::from_event(event);
+    assert_eq!(row.chain_id, TRON_CHAIN_ID.into());
+    assert_eq!(row.from_chain_id, TRON_CHAIN_ID.into());
+    assert_eq!(row.transaction_from, None);
+    assert_eq!(
+        row.port_address,
+        "41abcdefabcdefabcdefabcdefabcdefabcdefabcd"
+    );
+}
+
+#[test]
+fn test_decode_tron_errors_are_explicit() {
+    let unsupported = DatalensLog {
+        event_name: Some("Transfer".to_owned()),
+        non_indexed_fields: Some(serde_json::json!({"value": "1"})),
+        ..tron_log()
+    };
+    assert!(
+        decode_tron_event(&unsupported)
+            .expect_err("unsupported event should fail")
+            .to_string()
+            .contains("unsupported ORMP Tron event name Transfer")
+    );
+
+    let raw_payload = DatalensLog {
+        event_name: Some("MessageSent".to_owned()),
+        non_indexed_fields: Some(serde_json::json!("0x1234")),
+        ..tron_log()
+    };
+    assert!(
+        decode_tron_event(&raw_payload)
+            .expect_err("raw payload should fail")
+            .to_string()
+            .contains("Tron event payload must be an object")
+    );
+
+    let missing_field = DatalensLog {
+        event_name: Some("MessageSent".to_owned()),
+        non_indexed_fields: Some(serde_json::json!({"msgId": bytes_hex(0x33)})),
+        ..tron_log()
+    };
+    assert!(
+        decode_tron_event(&missing_field)
+            .expect_err("missing field should fail")
+            .to_string()
+            .contains("Tron event field fromDapp is missing")
+    );
+}
+
+fn tron_log() -> DatalensLog {
+    DatalensLog {
+        id: Some("728126428-123-trontx-3".to_owned()),
+        chain_id: TRON_CHAIN_ID,
+        block_number: 123,
+        block_timestamp: Some(456),
+        transaction_hash: "trontx".to_owned(),
+        transaction_index: Some(2),
+        log_index: 3,
+        address: "41ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD".to_owned(),
+        transaction_from: None,
+        topics: Vec::new(),
+        data: "0x".to_owned(),
+        event_name: Some("MessageSent".to_owned()),
+        event_signature: Some(
+            "MessageSent(bytes32,address,uint256,address,bytes,bytes)".to_owned(),
+        ),
+        indexed_fields: Vec::new(),
+        non_indexed_fields: Some(serde_json::json!({
+            "msgId": bytes_hex(0x33),
+            "fromDapp": "0x0000000000000000000000000000000000000030",
+            "toChainId": "42161",
+            "toDapp": "0x0000000000000000000000000000000000000031",
+            "message": "0xaa",
+            "params": "0xbbcc"
+        })),
+    }
+}
+
+fn bytes_hex(value: u8) -> String {
+    format!("0x{}", hex::encode(vec![value; 32]))
+}


### PR DESCRIPTION
HBX-453\n\n## Summary\n- add Tron mainnet Datalens chain defaults and native query planning\n- parse tron.events rows into legacy-compatible Datalens metadata\n- decode supported named Tron event payloads only when non_indexed_fields is structured JSON, returning explicit errors for unsupported/raw shapes\n\n## Verification\n- cargo fmt --check\n- cargo build\n- cargo test