### PR TITLE
HBX-459 feat(ormpindexer): add GraphQL server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +86,142 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii_utils"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
+
+[[package]]
+name = "async-graphql"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1057a9f7ccf2404d94571dec3451ade1cb524790df6f1ada0d19c2a49f6b0f40"
+dependencies = [
+ "async-graphql-derive",
+ "async-graphql-parser",
+ "async-graphql-value",
+ "async-io",
+ "async-trait",
+ "asynk-strim",
+ "base64",
+ "bytes",
+ "fast_chemail",
+ "fnv",
+ "futures-util",
+ "handlebars",
+ "http",
+ "indexmap",
+ "mime",
+ "multer",
+ "num-traits",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "static_assertions_next",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "async-graphql-axum"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e37c5532e4b686acf45e7162bc93da91fc2c702fb0d465efc2c20c8f973795"
+dependencies = [
+ "async-graphql",
+ "axum",
+ "bytes",
+ "futures-util",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+]
+
+[[package]]
+name = "async-graphql-derive"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e6cbeadc8515e66450fba0985ce722192e28443697799988265d86304d7cc68"
+dependencies = [
+ "Inflector",
+ "async-graphql-parser",
+ "darling 0.23.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "async-graphql-parser"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64ef70f77a1c689111e52076da1cd18f91834bcb847de0a9171f83624b07fbf"
+dependencies = [
+ "async-graphql-value",
+ "pest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-graphql-value"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e3ef112905abea9dea592fc868a6873b10ebd3f983e83308f995d6284e9ba41"
+dependencies = [
+ "bytes",
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "asynk-strim"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52697735bdaac441a29391a9e97102c74c6ef0f9b60a40cf109b1b404e29d2f6"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +241,61 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -165,6 +362,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -326,6 +526,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +609,37 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -375,10 +681,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "etcetera"
@@ -447,6 +772,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast_chemail"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
+dependencies = [
+ "ascii_utils",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +814,12 @@ dependencies = [
  "futures-sink",
  "spin",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -541,6 +887,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +927,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -605,6 +973,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43ccdfe15a81ab0a8af639e90254227c9a46afd9c5f5b6ec7efaa345c4b0f00"
+dependencies = [
+ "derive_builder",
+ "log",
+ "num-order",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +1019,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -709,6 +1099,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +1117,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -850,6 +1247,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1319,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1015,6 +1420,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,6 +1462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,6 +1498,23 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -1123,6 +1563,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-modular"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9545315a0c41a7a32c6694f73ad2e927b8caf67180314d659bcba180a4daaa19"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1604,9 @@ name = "ormpindexer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-graphql",
+ "async-graphql-axum",
+ "axum",
  "clap",
  "ethabi",
  "hex",
@@ -1236,6 +1694,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1774,20 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1600,6 +2115,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +2221,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2007,6 +2546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_assertions_next"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2567,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2065,6 +2631,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -2197,6 +2776,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2844,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2338,10 +2944,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.100"
+async-graphql = "7.0.17"
+async-graphql-axum = "7.0.17"
+axum = "0.8.7"
 clap = { version = "4.6.1", features = ["derive"] }
 ethabi = "18.0.0"
 hex = "0.4.3"
@@ -16,6 +19,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = "0.10.9"
 sqlx = { version = "0.8.6", default-features = false, features = ["macros", "migrate", "postgres", "runtime-tokio-rustls"] }
-tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.52.3", features = ["macros", "net", "rt-multi-thread"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["ansi", "env-filter", "fmt"] }

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -1,0 +1,330 @@
+mod pagination;
+mod query;
+mod router;
+mod types;
+
+use async_graphql::{Context, Object, Result as GraphqlResult};
+use sqlx::PgPool;
+
+use self::query::*;
+use self::router::GraphqlState;
+use self::types::*;
+
+pub use router::{IndexerGraphqlSchema, build_router, build_schema};
+
+pub struct QueryRoot;
+
+#[Object(rename_fields = "camelCase")]
+impl QueryRoot {
+    async fn ormp_hash_imported_by_id(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+    ) -> GraphqlResult<Option<ORMPHashImported>> {
+        query_ormp_hash_imported_by_id(pool(ctx)?, id).await
+    }
+
+    async fn ormp_hash_importeds(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<Vec<ORMPHashImported>> {
+        query_ormp_hash_importeds(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn ormp_hash_importeds_page(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<ORMPHashImportedPage> {
+        query_ormp_hash_importeds_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn ormp_message_accepted_by_id(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+    ) -> GraphqlResult<Option<ORMPMessageAccepted>> {
+        query_ormp_message_accepted_by_id(pool(ctx)?, id).await
+    }
+
+    async fn ormp_message_accepteds(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<Vec<ORMPMessageAccepted>> {
+        query_ormp_message_accepteds(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn ormp_message_accepteds_page(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<ORMPMessageAcceptedPage> {
+        query_ormp_message_accepteds_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn ormp_message_assigned_by_id(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+    ) -> GraphqlResult<Option<ORMPMessageAssigned>> {
+        query_ormp_message_assigned_by_id(pool(ctx)?, id).await
+    }
+
+    async fn ormp_message_assigneds(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<Vec<ORMPMessageAssigned>> {
+        query_ormp_message_assigneds(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn ormp_message_assigneds_page(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<ORMPMessageAssignedPage> {
+        query_ormp_message_assigneds_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn ormp_message_dispatched_by_id(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+    ) -> GraphqlResult<Option<ORMPMessageDispatched>> {
+        query_ormp_message_dispatched_by_id(pool(ctx)?, id).await
+    }
+
+    async fn ormp_message_dispatcheds(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<Vec<ORMPMessageDispatched>> {
+        query_ormp_message_dispatcheds(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn ormp_message_dispatcheds_page(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<ORMPMessageDispatchedPage> {
+        query_ormp_message_dispatcheds_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn msgport_message_recv_by_id(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+    ) -> GraphqlResult<Option<MsgportMessageRecv>> {
+        query_msgport_message_recv_by_id(pool(ctx)?, id).await
+    }
+
+    async fn msgport_message_recvs(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<Vec<MsgportMessageRecv>> {
+        query_msgport_message_recvs(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn msgport_message_recvs_page(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<MsgportMessageRecvPage> {
+        query_msgport_message_recvs_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn msgport_message_sent_by_id(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+    ) -> GraphqlResult<Option<MsgportMessageSent>> {
+        query_msgport_message_sent_by_id(pool(ctx)?, id).await
+    }
+
+    async fn msgport_message_sents(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<Vec<MsgportMessageSent>> {
+        query_msgport_message_sents(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn msgport_message_sents_page(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<MsgportMessageSentPage> {
+        query_msgport_message_sents_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn signature_pub_signature_submittion_by_id(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+    ) -> GraphqlResult<Option<SignaturePubSignatureSubmittion>> {
+        query_signature_pub_signature_submittion_by_id(pool(ctx)?, id).await
+    }
+
+    async fn signature_pub_signature_submittions(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<Vec<SignaturePubSignatureSubmittion>> {
+        query_signature_pub_signature_submittions(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+
+    async fn signature_pub_signature_submittions_page(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<LegacyWhereInput>,
+        order_by: Option<Vec<LegacyOrderByInput>>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> GraphqlResult<SignaturePubSignatureSubmittionPage> {
+        query_signature_pub_signature_submittions_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            offset,
+            limit,
+        )
+        .await
+    }
+}
+
+fn pool<'a>(ctx: &'a Context<'_>) -> GraphqlResult<&'a PgPool> {
+    Ok(&ctx.data::<GraphqlState>()?.pool)
+}

--- a/src/graphql/pagination.rs
+++ b/src/graphql/pagination.rs
@@ -1,0 +1,15 @@
+use sqlx::{Postgres, QueryBuilder};
+
+pub(super) const DEFAULT_PAGE_LIMIT: i32 = 50;
+
+pub(super) fn page_args(offset: Option<i32>, limit: Option<i32>) -> (i32, i32) {
+    (
+        offset.unwrap_or_default().max(0),
+        limit.unwrap_or(DEFAULT_PAGE_LIMIT).max(0),
+    )
+}
+
+pub(super) fn push_page(query: &mut QueryBuilder<'_, Postgres>, offset: i32, limit: i32) {
+    query.push(" LIMIT ").push_bind(limit);
+    query.push(" OFFSET ").push_bind(offset);
+}

--- a/src/graphql/query.rs
+++ b/src/graphql/query.rs
@@ -1,0 +1,398 @@
+use async_graphql::Result as GraphqlResult;
+use sqlx::{FromRow, PgPool, Postgres, QueryBuilder};
+
+use super::pagination::{page_args, push_page};
+use super::types::*;
+
+const ORMP_HASH_IMPORTED_SELECT: &str = r#"
+    SELECT id, block_number::TEXT AS block_number, transaction_hash,
+      block_timestamp::TEXT AS block_timestamp, chain_id::TEXT AS chain_id,
+      src_chain_id::TEXT AS src_chain_id, target_chain_id::TEXT AS target_chain_id,
+      oracle, channel, msg_index::TEXT AS msg_index, hash
+    FROM ormp_hash_imported
+"#;
+const ORMP_MESSAGE_ACCEPTED_SELECT: &str = r#"
+    SELECT id, block_number::TEXT AS block_number, transaction_hash,
+      block_timestamp::TEXT AS block_timestamp, chain_id::TEXT AS chain_id,
+      log_index, msg_hash, channel, "index"::TEXT AS "index",
+      from_chain_id::TEXT AS from_chain_id, "from", to_chain_id::TEXT AS to_chain_id,
+      "to", gas_limit::TEXT AS gas_limit, encoded, oracle, oracle_assigned,
+      oracle_assigned_fee::TEXT AS oracle_assigned_fee, relayer, relayer_assigned,
+      relayer_assigned_fee::TEXT AS relayer_assigned_fee
+    FROM ormp_message_accepted
+"#;
+const ORMP_MESSAGE_ASSIGNED_SELECT: &str = r#"
+    SELECT id, block_number::TEXT AS block_number, transaction_hash,
+      block_timestamp::TEXT AS block_timestamp, chain_id::TEXT AS chain_id,
+      msg_hash, oracle, relayer, oracle_fee::TEXT AS oracle_fee,
+      relayer_fee::TEXT AS relayer_fee, params
+    FROM ormp_message_assigned
+"#;
+const ORMP_MESSAGE_DISPATCHED_SELECT: &str = r#"
+    SELECT id, block_number::TEXT AS block_number, transaction_hash,
+      block_timestamp::TEXT AS block_timestamp, chain_id::TEXT AS chain_id,
+      target_chain_id::TEXT AS target_chain_id, msg_hash, dispatch_result
+    FROM ormp_message_dispatched
+"#;
+const MSGPORT_MESSAGE_RECV_SELECT: &str = r#"
+    SELECT id, block_number::TEXT AS block_number, transaction_hash,
+      block_timestamp::TEXT AS block_timestamp, transaction_index, log_index,
+      chain_id::TEXT AS chain_id, port_address, msg_id, result, return_data
+    FROM msgport_message_recv
+"#;
+const MSGPORT_MESSAGE_SENT_SELECT: &str = r#"
+    SELECT id, block_number::TEXT AS block_number, transaction_hash,
+      block_timestamp::TEXT AS block_timestamp, transaction_index, log_index,
+      chain_id::TEXT AS chain_id, port_address, transaction_from,
+      from_chain_id::TEXT AS from_chain_id, msg_id, from_dapp,
+      to_chain_id::TEXT AS to_chain_id, to_dapp, message, params
+    FROM msgport_message_sent
+"#;
+const SIGNATURE_SUBMITTION_SELECT: &str = r#"
+    SELECT id, block_number::TEXT AS block_number, transaction_hash,
+      block_timestamp::TEXT AS block_timestamp, chain_id::TEXT AS chain_id,
+      channel, signer, msg_index::TEXT AS msg_index, signature, data
+    FROM signature_pub_signature_submittion
+"#;
+
+macro_rules! query_fns {
+    ($by_id:ident, $list:ident, $page:ident, $ty:ty, $page_ty:ty, $table:literal, $select:expr) => {
+        pub(super) async fn $by_id(pool: &PgPool, id: String) -> GraphqlResult<Option<$ty>> {
+            fetch_by_id(pool, $select, id).await
+        }
+
+        pub(super) async fn $list(
+            pool: &PgPool,
+            where_: Option<&LegacyWhereInput>,
+            order_by: Option<&[LegacyOrderByInput]>,
+            offset: Option<i32>,
+            limit: Option<i32>,
+        ) -> GraphqlResult<Vec<$ty>> {
+            let (offset, limit) = page_args(offset, limit);
+            if limit == 0 {
+                return Ok(Vec::new());
+            }
+            fetch_page(pool, $select, where_, order_by, offset, limit).await
+        }
+
+        pub(super) async fn $page(
+            pool: &PgPool,
+            where_: Option<&LegacyWhereInput>,
+            order_by: Option<&[LegacyOrderByInput]>,
+            offset: Option<i32>,
+            limit: Option<i32>,
+        ) -> GraphqlResult<$page_ty> {
+            let (offset, limit) = page_args(offset, limit);
+            let total_count = count_rows(pool, $table, where_).await?;
+            let items = if limit == 0 {
+                Vec::new()
+            } else {
+                fetch_page(pool, $select, where_, order_by, offset, limit).await?
+            };
+            Ok(<$page_ty>::new(total_count, offset, limit, items))
+        }
+    };
+}
+
+query_fns!(
+    query_ormp_hash_imported_by_id,
+    query_ormp_hash_importeds,
+    query_ormp_hash_importeds_page,
+    ORMPHashImported,
+    ORMPHashImportedPage,
+    "ormp_hash_imported",
+    ORMP_HASH_IMPORTED_SELECT
+);
+query_fns!(
+    query_ormp_message_accepted_by_id,
+    query_ormp_message_accepteds,
+    query_ormp_message_accepteds_page,
+    ORMPMessageAccepted,
+    ORMPMessageAcceptedPage,
+    "ormp_message_accepted",
+    ORMP_MESSAGE_ACCEPTED_SELECT
+);
+query_fns!(
+    query_ormp_message_assigned_by_id,
+    query_ormp_message_assigneds,
+    query_ormp_message_assigneds_page,
+    ORMPMessageAssigned,
+    ORMPMessageAssignedPage,
+    "ormp_message_assigned",
+    ORMP_MESSAGE_ASSIGNED_SELECT
+);
+query_fns!(
+    query_ormp_message_dispatched_by_id,
+    query_ormp_message_dispatcheds,
+    query_ormp_message_dispatcheds_page,
+    ORMPMessageDispatched,
+    ORMPMessageDispatchedPage,
+    "ormp_message_dispatched",
+    ORMP_MESSAGE_DISPATCHED_SELECT
+);
+query_fns!(
+    query_msgport_message_recv_by_id,
+    query_msgport_message_recvs,
+    query_msgport_message_recvs_page,
+    MsgportMessageRecv,
+    MsgportMessageRecvPage,
+    "msgport_message_recv",
+    MSGPORT_MESSAGE_RECV_SELECT
+);
+query_fns!(
+    query_msgport_message_sent_by_id,
+    query_msgport_message_sents,
+    query_msgport_message_sents_page,
+    MsgportMessageSent,
+    MsgportMessageSentPage,
+    "msgport_message_sent",
+    MSGPORT_MESSAGE_SENT_SELECT
+);
+query_fns!(
+    query_signature_pub_signature_submittion_by_id,
+    query_signature_pub_signature_submittions,
+    query_signature_pub_signature_submittions_page,
+    SignaturePubSignatureSubmittion,
+    SignaturePubSignatureSubmittionPage,
+    "signature_pub_signature_submittion",
+    SIGNATURE_SUBMITTION_SELECT
+);
+
+async fn fetch_by_id<T>(pool: &PgPool, select: &'static str, id: String) -> GraphqlResult<Option<T>>
+where
+    T: for<'row> FromRow<'row, sqlx::postgres::PgRow> + Send + Unpin,
+{
+    let mut query = QueryBuilder::<Postgres>::new(select);
+    query.push(" WHERE id = ").push_bind(id);
+
+    Ok(query.build_query_as().fetch_optional(pool).await?)
+}
+
+async fn fetch_page<T>(
+    pool: &PgPool,
+    select: &'static str,
+    where_: Option<&LegacyWhereInput>,
+    order_by: Option<&[LegacyOrderByInput]>,
+    offset: i32,
+    limit: i32,
+) -> GraphqlResult<Vec<T>>
+where
+    T: for<'row> FromRow<'row, sqlx::postgres::PgRow> + Send + Unpin,
+{
+    let mut query = QueryBuilder::<Postgres>::new(select);
+    push_where(&mut query, where_);
+    push_order_by(&mut query, order_by);
+    push_page(&mut query, offset, limit);
+
+    Ok(query.build_query_as().fetch_all(pool).await?)
+}
+
+async fn count_rows(
+    pool: &PgPool,
+    table: &'static str,
+    where_: Option<&LegacyWhereInput>,
+) -> GraphqlResult<i64> {
+    let mut query =
+        QueryBuilder::<Postgres>::new(format!("SELECT COUNT(*)::int8 AS total_count FROM {table}"));
+    push_where(&mut query, where_);
+    let (total_count,): (i64,) = query.build_query_as().fetch_one(pool).await?;
+    Ok(total_count)
+}
+
+fn push_where<'a>(query: &mut QueryBuilder<'a, Postgres>, where_: Option<&'a LegacyWhereInput>) {
+    let Some(where_) = where_ else {
+        return;
+    };
+    query.push(" WHERE ");
+    let mut has_condition = false;
+    push_where_group(query, where_, &mut has_condition);
+    if !has_condition {
+        query.push(" TRUE");
+    }
+}
+
+fn push_where_group<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    where_: &'a LegacyWhereInput,
+    has_condition: &mut bool,
+) {
+    macro_rules! text_cmp {
+        ($field:expr, $column:literal, $op:literal) => {
+            if let Some(value) = $field.as_ref() {
+                push_and(query, has_condition);
+                query.push($column).push($op).push_bind(value);
+            }
+        };
+    }
+    macro_rules! text_in {
+        ($field:expr, $column:literal, $negated:literal) => {
+            if let Some(values) = $field.as_ref() {
+                push_and(query, has_condition);
+                query.push($column);
+                if $negated {
+                    query.push(" NOT");
+                }
+                query.push(" IN (");
+                let mut separated = query.separated(", ");
+                for value in values {
+                    separated.push_bind(value);
+                }
+                separated.push_unseparated(")");
+            }
+        };
+    }
+    macro_rules! bigint_cmp {
+        ($field:expr, $column:literal, $op:literal) => {
+            if let Some(value) = $field.as_ref() {
+                push_and(query, has_condition);
+                query
+                    .push($column)
+                    .push($op)
+                    .push_bind(value.as_str())
+                    .push("::NUMERIC");
+            }
+        };
+    }
+    macro_rules! bigint_in {
+        ($field:expr, $column:literal) => {
+            if let Some(values) = $field.as_ref() {
+                push_and(query, has_condition);
+                query.push($column).push(" IN (");
+                let mut separated = query.separated(", ");
+                for value in values {
+                    separated
+                        .push_bind(value.as_str())
+                        .push_unseparated("::NUMERIC");
+                }
+                separated.push_unseparated(")");
+            }
+        };
+    }
+    macro_rules! int_cmp {
+        ($field:expr, $column:literal, $op:literal) => {
+            if let Some(value) = $field {
+                push_and(query, has_condition);
+                query.push($column).push($op).push_bind(value);
+            }
+        };
+    }
+
+    text_cmp!(where_.id_eq, "id", " = ");
+    text_cmp!(where_.id_not_eq, "id", " <> ");
+    text_in!(where_.id_in, "id", false);
+    text_in!(where_.id_not_in, "id", true);
+    bigint_cmp!(where_.block_number_eq, "block_number", " = ");
+    bigint_cmp!(where_.block_number_gt, "block_number", " > ");
+    bigint_cmp!(where_.block_number_gte, "block_number", " >= ");
+    bigint_cmp!(where_.block_number_lt, "block_number", " < ");
+    bigint_cmp!(where_.block_number_lte, "block_number", " <= ");
+    bigint_in!(where_.block_number_in, "block_number");
+    text_cmp!(where_.transaction_hash_eq, "transaction_hash", " = ");
+    text_in!(where_.transaction_hash_in, "transaction_hash", false);
+    bigint_cmp!(where_.block_timestamp_eq, "block_timestamp", " = ");
+    bigint_cmp!(where_.block_timestamp_gt, "block_timestamp", " > ");
+    bigint_cmp!(where_.block_timestamp_gte, "block_timestamp", " >= ");
+    bigint_cmp!(where_.block_timestamp_lt, "block_timestamp", " < ");
+    bigint_cmp!(where_.block_timestamp_lte, "block_timestamp", " <= ");
+    bigint_cmp!(where_.chain_id_eq, "chain_id", " = ");
+    bigint_in!(where_.chain_id_in, "chain_id");
+    int_cmp!(where_.log_index_eq, "log_index", " = ");
+    int_cmp!(where_.log_index_gt, "log_index", " > ");
+    int_cmp!(where_.log_index_gte, "log_index", " >= ");
+    int_cmp!(where_.log_index_lt, "log_index", " < ");
+    int_cmp!(where_.log_index_lte, "log_index", " <= ");
+    int_cmp!(where_.transaction_index_eq, "transaction_index", " = ");
+    text_cmp!(where_.msg_hash_eq, "msg_hash", " = ");
+    text_in!(where_.msg_hash_in, "msg_hash", false);
+    text_cmp!(where_.msg_id_eq, "msg_id", " = ");
+    text_in!(where_.msg_id_in, "msg_id", false);
+    text_cmp!(where_.hash_eq, "hash", " = ");
+    text_cmp!(where_.channel_eq, "channel", " = ");
+    text_cmp!(where_.oracle_eq, "oracle", " = ");
+    text_cmp!(where_.relayer_eq, "relayer", " = ");
+    text_cmp!(where_.signer_eq, "signer", " = ");
+    text_cmp!(where_.port_address_eq, "port_address", " = ");
+    text_cmp!(where_.from_eq, r#""from""#, " = ");
+    text_cmp!(where_.to_eq, r#""to""#, " = ");
+    text_cmp!(where_.from_dapp_eq, "from_dapp", " = ");
+    text_cmp!(where_.to_dapp_eq, "to_dapp", " = ");
+    bigint_cmp!(where_.from_chain_id_eq, "from_chain_id", " = ");
+    bigint_cmp!(where_.to_chain_id_eq, "to_chain_id", " = ");
+    bigint_cmp!(where_.src_chain_id_eq, "src_chain_id", " = ");
+    bigint_cmp!(where_.target_chain_id_eq, "target_chain_id", " = ");
+    bigint_cmp!(where_.msg_index_eq, "msg_index", " = ");
+
+    if let Some(groups) = where_.and.as_ref() {
+        push_logical_groups(query, has_condition, groups, " AND ");
+    }
+    if let Some(groups) = where_.or.as_ref() {
+        push_logical_groups(query, has_condition, groups, " OR ");
+    }
+}
+
+fn push_logical_groups<'a>(
+    query: &mut QueryBuilder<'a, Postgres>,
+    has_condition: &mut bool,
+    groups: &'a [LegacyWhereInput],
+    op: &'static str,
+) {
+    if groups.is_empty() {
+        return;
+    }
+    push_and(query, has_condition);
+    query.push("(");
+    let mut first = true;
+    for group in groups {
+        if first {
+            first = false;
+        } else {
+            query.push(op);
+        }
+        query.push("(");
+        let mut group_has_condition = false;
+        push_where_group(query, group, &mut group_has_condition);
+        if !group_has_condition {
+            query.push("TRUE");
+        }
+        query.push(")");
+    }
+    query.push(")");
+}
+
+fn push_and(query: &mut QueryBuilder<'_, Postgres>, has_condition: &mut bool) {
+    if *has_condition {
+        query.push(" AND ");
+    }
+    *has_condition = true;
+}
+
+fn push_order_by(query: &mut QueryBuilder<'_, Postgres>, order_by: Option<&[LegacyOrderByInput]>) {
+    let orders = order_by.unwrap_or(&[]);
+    query.push(" ORDER BY ");
+    if orders.is_empty() {
+        query.push("block_number ASC, id ASC");
+        return;
+    }
+    let mut separated = query.separated(", ");
+    for order in orders {
+        let (column, direction) = match order {
+            LegacyOrderByInput::IdAsc => ("id", "ASC"),
+            LegacyOrderByInput::IdDesc => ("id", "DESC"),
+            LegacyOrderByInput::BlockNumberAsc => ("block_number", "ASC"),
+            LegacyOrderByInput::BlockNumberDesc => ("block_number", "DESC"),
+            LegacyOrderByInput::BlockTimestampAsc => ("block_timestamp", "ASC"),
+            LegacyOrderByInput::BlockTimestampDesc => ("block_timestamp", "DESC"),
+            LegacyOrderByInput::ChainIdAsc => ("chain_id", "ASC"),
+            LegacyOrderByInput::ChainIdDesc => ("chain_id", "DESC"),
+            LegacyOrderByInput::LogIndexAsc => ("log_index", "ASC"),
+            LegacyOrderByInput::LogIndexDesc => ("log_index", "DESC"),
+            LegacyOrderByInput::TransactionIndexAsc => ("transaction_index", "ASC"),
+            LegacyOrderByInput::TransactionIndexDesc => ("transaction_index", "DESC"),
+            LegacyOrderByInput::MsgHashAsc => ("msg_hash", "ASC"),
+            LegacyOrderByInput::MsgHashDesc => ("msg_hash", "DESC"),
+            LegacyOrderByInput::MsgIdAsc => ("msg_id", "ASC"),
+            LegacyOrderByInput::MsgIdDesc => ("msg_id", "DESC"),
+        };
+        separated.push(format!("{column} {direction}"));
+    }
+}

--- a/src/graphql/router.rs
+++ b/src/graphql/router.rs
@@ -1,0 +1,66 @@
+use async_graphql::http::{GraphiQLPlugin, GraphiQLSource};
+use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use axum::{
+    Router,
+    extract::State,
+    response::{Html, IntoResponse},
+    routing::{get, post},
+};
+use sqlx::PgPool;
+
+use super::QueryRoot;
+
+pub type IndexerGraphqlSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
+
+pub fn build_schema(pool: PgPool) -> IndexerGraphqlSchema {
+    Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
+        .data(GraphqlState { pool })
+        .finish()
+}
+
+pub fn build_router(schema: IndexerGraphqlSchema) -> Router {
+    Router::new()
+        .route("/graphql", post(graphql_handler))
+        .route("/graphiql", get(graphql_graphiql))
+        .with_state(schema)
+}
+
+async fn graphql_handler(
+    State(schema): State<IndexerGraphqlSchema>,
+    request: GraphQLRequest,
+) -> GraphQLResponse {
+    schema.execute(request.into_inner()).await.into()
+}
+
+async fn graphql_graphiql() -> impl IntoResponse {
+    Html(
+        GraphiQLSource::build()
+            .endpoint("/graphql")
+            .version("3.9.0")
+            .title("ORMP Indexer GraphiQL")
+            .plugins(&[graphiql_explorer_plugin()])
+            .finish(),
+    )
+}
+
+fn graphiql_explorer_plugin<'a>() -> GraphiQLPlugin<'a> {
+    GraphiQLPlugin {
+        name: "GraphiQLPluginExplorer",
+        constructor: "GraphiQLPluginExplorer.explorerPlugin",
+        head_assets: Some(
+            r#"<link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer@3.0.0/dist/style.css" />"#,
+        ),
+        body_assets: Some(
+            r#"<script
+      src="https://unpkg.com/@graphiql/plugin-explorer@3.0.0/dist/index.umd.js"
+      crossorigin
+    ></script>"#,
+        ),
+        ..Default::default()
+    }
+}
+
+pub(super) struct GraphqlState {
+    pub(super) pool: PgPool,
+}

--- a/src/graphql/types.rs
+++ b/src/graphql/types.rs
@@ -1,0 +1,396 @@
+#![allow(clippy::upper_case_acronyms)]
+
+use async_graphql::{
+    Enum, InputObject, InputValueError, InputValueResult, Scalar, ScalarType, SimpleObject, Value,
+};
+use sqlx::{
+    Decode, FromRow, Postgres, Type,
+    encode::IsNull,
+    postgres::{PgArgumentBuffer, PgTypeInfo, PgValueRef},
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BigInt(String);
+
+impl BigInt {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for BigInt {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for BigInt {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+#[Scalar(name = "BigInt")]
+impl ScalarType for BigInt {
+    fn parse(value: Value) -> InputValueResult<Self> {
+        match value {
+            Value::Number(value) => Ok(Self(value.to_string())),
+            Value::String(value) => {
+                value
+                    .parse::<i128>()
+                    .map_err(|_| InputValueError::custom("BigInt must be an integer"))?;
+                Ok(Self(value))
+            }
+            _ => Err(InputValueError::expected_type(value)),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        Value::String(self.0.clone())
+    }
+}
+
+impl Type<Postgres> for BigInt {
+    fn type_info() -> PgTypeInfo {
+        <String as Type<Postgres>>::type_info()
+    }
+
+    fn compatible(ty: &PgTypeInfo) -> bool {
+        <String as Type<Postgres>>::compatible(ty)
+    }
+}
+
+impl<'r> Decode<'r, Postgres> for BigInt {
+    fn decode(value: PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
+        Ok(Self(<String as Decode<Postgres>>::decode(value)?))
+    }
+}
+
+impl<'q> sqlx::Encode<'q, Postgres> for BigInt {
+    fn encode_by_ref(
+        &self,
+        buf: &mut PgArgumentBuffer,
+    ) -> Result<IsNull, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        <String as sqlx::Encode<Postgres>>::encode_by_ref(&self.0, buf)
+    }
+}
+
+#[derive(Clone, Debug, Default, InputObject)]
+pub struct LegacyWhereInput {
+    #[graphql(name = "AND")]
+    pub and: Option<Vec<LegacyWhereInput>>,
+    #[graphql(name = "OR")]
+    pub or: Option<Vec<LegacyWhereInput>>,
+    #[graphql(name = "id_eq")]
+    pub id_eq: Option<String>,
+    #[graphql(name = "id_not_eq")]
+    pub id_not_eq: Option<String>,
+    #[graphql(name = "id_in")]
+    pub id_in: Option<Vec<String>>,
+    #[graphql(name = "id_not_in")]
+    pub id_not_in: Option<Vec<String>>,
+    #[graphql(name = "blockNumber_eq")]
+    pub block_number_eq: Option<BigInt>,
+    #[graphql(name = "blockNumber_gt")]
+    pub block_number_gt: Option<BigInt>,
+    #[graphql(name = "blockNumber_gte")]
+    pub block_number_gte: Option<BigInt>,
+    #[graphql(name = "blockNumber_lt")]
+    pub block_number_lt: Option<BigInt>,
+    #[graphql(name = "blockNumber_lte")]
+    pub block_number_lte: Option<BigInt>,
+    #[graphql(name = "blockNumber_in")]
+    pub block_number_in: Option<Vec<BigInt>>,
+    #[graphql(name = "transactionHash_eq")]
+    pub transaction_hash_eq: Option<String>,
+    #[graphql(name = "transactionHash_in")]
+    pub transaction_hash_in: Option<Vec<String>>,
+    #[graphql(name = "blockTimestamp_eq")]
+    pub block_timestamp_eq: Option<BigInt>,
+    #[graphql(name = "blockTimestamp_gt")]
+    pub block_timestamp_gt: Option<BigInt>,
+    #[graphql(name = "blockTimestamp_gte")]
+    pub block_timestamp_gte: Option<BigInt>,
+    #[graphql(name = "blockTimestamp_lt")]
+    pub block_timestamp_lt: Option<BigInt>,
+    #[graphql(name = "blockTimestamp_lte")]
+    pub block_timestamp_lte: Option<BigInt>,
+    #[graphql(name = "chainId_eq")]
+    pub chain_id_eq: Option<BigInt>,
+    #[graphql(name = "chainId_in")]
+    pub chain_id_in: Option<Vec<BigInt>>,
+    #[graphql(name = "logIndex_eq")]
+    pub log_index_eq: Option<i32>,
+    #[graphql(name = "logIndex_gt")]
+    pub log_index_gt: Option<i32>,
+    #[graphql(name = "logIndex_gte")]
+    pub log_index_gte: Option<i32>,
+    #[graphql(name = "logIndex_lt")]
+    pub log_index_lt: Option<i32>,
+    #[graphql(name = "logIndex_lte")]
+    pub log_index_lte: Option<i32>,
+    #[graphql(name = "transactionIndex_eq")]
+    pub transaction_index_eq: Option<i32>,
+    #[graphql(name = "msgHash_eq")]
+    pub msg_hash_eq: Option<String>,
+    #[graphql(name = "msgHash_in")]
+    pub msg_hash_in: Option<Vec<String>>,
+    #[graphql(name = "msgId_eq")]
+    pub msg_id_eq: Option<String>,
+    #[graphql(name = "msgId_in")]
+    pub msg_id_in: Option<Vec<String>>,
+    #[graphql(name = "hash_eq")]
+    pub hash_eq: Option<String>,
+    #[graphql(name = "channel_eq")]
+    pub channel_eq: Option<String>,
+    #[graphql(name = "oracle_eq")]
+    pub oracle_eq: Option<String>,
+    #[graphql(name = "relayer_eq")]
+    pub relayer_eq: Option<String>,
+    #[graphql(name = "signer_eq")]
+    pub signer_eq: Option<String>,
+    #[graphql(name = "portAddress_eq")]
+    pub port_address_eq: Option<String>,
+    #[graphql(name = "from_eq")]
+    pub from_eq: Option<String>,
+    #[graphql(name = "to_eq")]
+    pub to_eq: Option<String>,
+    #[graphql(name = "fromDapp_eq")]
+    pub from_dapp_eq: Option<String>,
+    #[graphql(name = "toDapp_eq")]
+    pub to_dapp_eq: Option<String>,
+    #[graphql(name = "fromChainId_eq")]
+    pub from_chain_id_eq: Option<BigInt>,
+    #[graphql(name = "toChainId_eq")]
+    pub to_chain_id_eq: Option<BigInt>,
+    #[graphql(name = "srcChainId_eq")]
+    pub src_chain_id_eq: Option<BigInt>,
+    #[graphql(name = "targetChainId_eq")]
+    pub target_chain_id_eq: Option<BigInt>,
+    #[graphql(name = "msgIndex_eq")]
+    pub msg_index_eq: Option<BigInt>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Enum, PartialEq)]
+pub enum LegacyOrderByInput {
+    #[graphql(name = "id_ASC")]
+    IdAsc,
+    #[graphql(name = "id_DESC")]
+    IdDesc,
+    #[graphql(name = "blockNumber_ASC")]
+    BlockNumberAsc,
+    #[graphql(name = "blockNumber_DESC")]
+    BlockNumberDesc,
+    #[graphql(name = "blockTimestamp_ASC")]
+    BlockTimestampAsc,
+    #[graphql(name = "blockTimestamp_DESC")]
+    BlockTimestampDesc,
+    #[graphql(name = "chainId_ASC")]
+    ChainIdAsc,
+    #[graphql(name = "chainId_DESC")]
+    ChainIdDesc,
+    #[graphql(name = "logIndex_ASC")]
+    LogIndexAsc,
+    #[graphql(name = "logIndex_DESC")]
+    LogIndexDesc,
+    #[graphql(name = "transactionIndex_ASC")]
+    TransactionIndexAsc,
+    #[graphql(name = "transactionIndex_DESC")]
+    TransactionIndexDesc,
+    #[graphql(name = "msgHash_ASC")]
+    MsgHashAsc,
+    #[graphql(name = "msgHash_DESC")]
+    MsgHashDesc,
+    #[graphql(name = "msgId_ASC")]
+    MsgIdAsc,
+    #[graphql(name = "msgId_DESC")]
+    MsgIdDesc,
+}
+
+#[derive(Clone, Debug, FromRow, SimpleObject)]
+#[graphql(name = "ORMPHashImported", rename_fields = "camelCase")]
+pub struct ORMPHashImported {
+    pub(super) id: String,
+    pub(super) block_number: BigInt,
+    pub(super) transaction_hash: String,
+    pub(super) block_timestamp: BigInt,
+    pub(super) chain_id: BigInt,
+    pub(super) src_chain_id: BigInt,
+    pub(super) target_chain_id: BigInt,
+    pub(super) oracle: String,
+    pub(super) channel: String,
+    pub(super) msg_index: BigInt,
+    pub(super) hash: String,
+}
+
+#[derive(Clone, Debug, FromRow, SimpleObject)]
+#[graphql(name = "ORMPMessageAccepted", rename_fields = "camelCase")]
+pub struct ORMPMessageAccepted {
+    pub(super) id: String,
+    pub(super) block_number: BigInt,
+    pub(super) transaction_hash: String,
+    pub(super) block_timestamp: BigInt,
+    pub(super) chain_id: BigInt,
+    pub(super) log_index: i32,
+    pub(super) msg_hash: String,
+    pub(super) channel: String,
+    pub(super) index: BigInt,
+    pub(super) from_chain_id: BigInt,
+    pub(super) from: String,
+    pub(super) to_chain_id: BigInt,
+    pub(super) to: String,
+    pub(super) gas_limit: BigInt,
+    pub(super) encoded: String,
+    pub(super) oracle: Option<String>,
+    pub(super) oracle_assigned: Option<bool>,
+    pub(super) oracle_assigned_fee: Option<BigInt>,
+    pub(super) relayer: Option<String>,
+    pub(super) relayer_assigned: Option<bool>,
+    pub(super) relayer_assigned_fee: Option<BigInt>,
+}
+
+#[derive(Clone, Debug, FromRow, SimpleObject)]
+#[graphql(name = "ORMPMessageAssigned", rename_fields = "camelCase")]
+pub struct ORMPMessageAssigned {
+    pub(super) id: String,
+    pub(super) block_number: BigInt,
+    pub(super) transaction_hash: String,
+    pub(super) block_timestamp: BigInt,
+    pub(super) chain_id: BigInt,
+    pub(super) msg_hash: String,
+    pub(super) oracle: String,
+    pub(super) relayer: String,
+    pub(super) oracle_fee: BigInt,
+    pub(super) relayer_fee: BigInt,
+    pub(super) params: String,
+}
+
+#[derive(Clone, Debug, FromRow, SimpleObject)]
+#[graphql(name = "ORMPMessageDispatched", rename_fields = "camelCase")]
+pub struct ORMPMessageDispatched {
+    pub(super) id: String,
+    pub(super) block_number: BigInt,
+    pub(super) transaction_hash: String,
+    pub(super) block_timestamp: BigInt,
+    pub(super) chain_id: BigInt,
+    pub(super) target_chain_id: BigInt,
+    pub(super) msg_hash: String,
+    pub(super) dispatch_result: bool,
+}
+
+#[derive(Clone, Debug, FromRow, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct MsgportMessageRecv {
+    pub(super) id: String,
+    pub(super) block_number: BigInt,
+    pub(super) transaction_hash: String,
+    pub(super) block_timestamp: BigInt,
+    pub(super) transaction_index: i32,
+    pub(super) log_index: i32,
+    pub(super) chain_id: BigInt,
+    pub(super) port_address: String,
+    pub(super) msg_id: String,
+    pub(super) result: bool,
+    pub(super) return_data: String,
+}
+
+#[derive(Clone, Debug, FromRow, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct MsgportMessageSent {
+    pub(super) id: String,
+    pub(super) block_number: BigInt,
+    pub(super) transaction_hash: String,
+    pub(super) block_timestamp: BigInt,
+    pub(super) transaction_index: i32,
+    pub(super) log_index: i32,
+    pub(super) chain_id: BigInt,
+    pub(super) port_address: String,
+    pub(super) transaction_from: Option<String>,
+    pub(super) from_chain_id: BigInt,
+    pub(super) msg_id: String,
+    pub(super) from_dapp: String,
+    pub(super) to_chain_id: BigInt,
+    pub(super) to_dapp: String,
+    pub(super) message: String,
+    pub(super) params: String,
+}
+
+#[derive(Clone, Debug, FromRow, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct SignaturePubSignatureSubmittion {
+    pub(super) id: String,
+    pub(super) block_number: BigInt,
+    pub(super) transaction_hash: String,
+    pub(super) block_timestamp: BigInt,
+    pub(super) chain_id: BigInt,
+    pub(super) channel: String,
+    pub(super) signer: String,
+    pub(super) msg_index: BigInt,
+    pub(super) signature: String,
+    pub(super) data: String,
+}
+
+macro_rules! page_type {
+    ($name:ident, $graphql_name:literal, $item:ty) => {
+        #[derive(Clone, Debug, SimpleObject)]
+        #[graphql(name = $graphql_name, rename_fields = "camelCase")]
+        pub struct $name {
+            pub(super) total_count: i64,
+            pub(super) offset: i32,
+            pub(super) limit: i32,
+            pub(super) items: Vec<$item>,
+        }
+
+        impl $name {
+            pub(super) fn new(
+                total_count: i64,
+                offset: i32,
+                limit: i32,
+                items: Vec<$item>,
+            ) -> Self {
+                Self {
+                    total_count,
+                    offset,
+                    limit,
+                    items,
+                }
+            }
+        }
+    };
+}
+
+page_type!(
+    ORMPHashImportedPage,
+    "ORMPHashImportedPage",
+    ORMPHashImported
+);
+page_type!(
+    ORMPMessageAcceptedPage,
+    "ORMPMessageAcceptedPage",
+    ORMPMessageAccepted
+);
+page_type!(
+    ORMPMessageAssignedPage,
+    "ORMPMessageAssignedPage",
+    ORMPMessageAssigned
+);
+page_type!(
+    ORMPMessageDispatchedPage,
+    "ORMPMessageDispatchedPage",
+    ORMPMessageDispatched
+);
+page_type!(
+    MsgportMessageRecvPage,
+    "MsgportMessageRecvPage",
+    MsgportMessageRecv
+);
+page_type!(
+    MsgportMessageSentPage,
+    "MsgportMessageSentPage",
+    MsgportMessageSent
+);
+page_type!(
+    SignaturePubSignatureSubmittionPage,
+    "SignaturePubSignatureSubmittionPage",
+    SignaturePubSignatureSubmittion
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod database;
 pub mod datalens;
 pub mod decoder;
+pub mod graphql;
 pub mod planner;
 pub mod runner;
 pub mod runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 
-use ormpindexer::runtime::{migrate, run};
+use ormpindexer::{
+    config::RuntimeConfig,
+    database,
+    graphql::{build_router, build_schema},
+    runtime::{migrate, run},
+};
 
 #[derive(Debug, Parser)]
 #[command(name = "ormpindexer")]
@@ -16,6 +21,10 @@ enum Command {
         #[arg(long)]
         once: bool,
     },
+    Serve {
+        #[arg(long, default_value = "0.0.0.0:8080")]
+        listen_addr: String,
+    },
     Migrate,
 }
 
@@ -26,8 +35,22 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Command::Run { once } => run(once).await,
+        Command::Serve { listen_addr } => serve(&listen_addr).await,
         Command::Migrate => migrate().await,
     }
+}
+
+async fn serve(listen_addr: &str) -> anyhow::Result<()> {
+    let database_url = RuntimeConfig::database_url_from_env()?;
+    let pool = database::connect(&database_url, 5).await?;
+    database::apply_migrations(&pool).await?;
+    let app = build_router(build_schema(pool));
+    let listener = tokio::net::TcpListener::bind(listen_addr)
+        .await
+        .with_context(|| format!("bind GraphQL server to {listen_addr}"))?;
+    axum::serve(listener, app)
+        .await
+        .context("serve GraphQL server")
 }
 
 fn init_logging() -> anyhow::Result<()> {

--- a/tests/graphql_server.rs
+++ b/tests/graphql_server.rs
@@ -1,0 +1,195 @@
+use async_graphql::Request;
+use serde_json::json;
+use sqlx::{PgPool, postgres::PgPoolOptions};
+
+use ormpindexer::{
+    database::{EventWriter, PostgresEventWriter, apply_migrations},
+    graphql::build_schema,
+    schema::{ADDRESS_ORACLE, ADDRESS_RELAYER, ChainLogMetadata, EventSource, LegacyOrmPEvent},
+};
+
+#[tokio::test]
+async fn test_graphql_schema_exposes_pages_without_connections() {
+    let pool = PgPoolOptions::new()
+        .connect_lazy("postgres://user:pass@localhost/ormpindexer")
+        .expect("lazy postgres pool");
+    let schema = build_schema(pool);
+    let sdl = schema.sdl();
+
+    for page_type in [
+        "type ORMPHashImportedPage",
+        "type ORMPMessageAcceptedPage",
+        "type ORMPMessageAssignedPage",
+        "type ORMPMessageDispatchedPage",
+        "type MsgportMessageRecvPage",
+        "type MsgportMessageSentPage",
+        "type SignaturePubSignatureSubmittionPage",
+    ] {
+        assert!(sdl.contains(page_type), "schema is missing {page_type}");
+    }
+    assert!(
+        !sdl.contains("Connection"),
+        "schema must not expose connection fields or types"
+    );
+    assert!(sdl.contains("scalar BigInt"), "schema must expose BigInt");
+    assert!(
+        sdl.contains("blockNumber: BigInt!"),
+        "legacy numeric fields must stay BigInt"
+    );
+    assert!(
+        sdl.contains("where: LegacyWhereInput"),
+        "list fields must accept OpenReader-style where filters"
+    );
+    assert!(
+        sdl.contains("orderBy: [LegacyOrderByInput!]"),
+        "list fields must accept OpenReader-style orderBy"
+    );
+}
+
+#[tokio::test]
+async fn test_graphql_queries_by_id_and_page_against_postgres() {
+    let Some(database_url) = test_database_url() else {
+        eprintln!("skipping GraphQL Postgres test; ORMPINDEXER_TEST_DATABASE_URL is not set");
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("connect test postgres");
+    apply_migrations(&pool).await.expect("apply migrations");
+    truncate_legacy_tables(&pool).await;
+    PostgresEventWriter::new(pool.clone())
+        .write_events(&legacy_events())
+        .await
+        .expect("write legacy events");
+
+    let schema = build_schema(pool);
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query {
+              ormpMessageAcceptedById(id: "0xaccepted") {
+                id
+                msgHash
+                blockNumber
+                gasLimit
+                oracleAssignedFee
+              }
+              ormpMessageAcceptedsPage(offset: 0, limit: 10) {
+                totalCount
+                offset
+                limit
+                items {
+                  id
+                  msgHash
+                  blockNumber
+                  gasLimit
+                  oracleAssignedFee
+                }
+              }
+              filtered: ormpMessageAccepteds(
+                where: { msgHash_eq: "0xaccepted", blockNumber_gte: "100" }
+                orderBy: [blockNumber_DESC]
+              ) {
+                id
+                blockNumber
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+    assert_eq!(
+        response.data.into_json().expect("GraphQL response JSON"),
+        json!({
+            "ormpMessageAcceptedById": {
+                "id": "0xaccepted",
+                "msgHash": "0xaccepted",
+                "blockNumber": "123",
+                "gasLimit": "500000",
+                "oracleAssignedFee": "11",
+            },
+            "ormpMessageAcceptedsPage": {
+                "totalCount": 1,
+                "offset": 0,
+                "limit": 10,
+                "items": [{
+                    "id": "0xaccepted",
+                    "msgHash": "0xaccepted",
+                    "blockNumber": "123",
+                    "gasLimit": "500000",
+                    "oracleAssignedFee": "11",
+                }],
+            },
+            "filtered": [{
+                "id": "0xaccepted",
+                "blockNumber": "123",
+            }],
+        })
+    );
+}
+
+fn legacy_events() -> Vec<LegacyOrmPEvent> {
+    vec![
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata("accepted-log"),
+            msg_hash: "0xaccepted".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 8,
+            from_chain_id: 1,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 46,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("assigned-log"),
+            msg_hash: "0xaccepted".to_owned(),
+            oracle: ADDRESS_ORACLE[0].to_owned(),
+            relayer: ADDRESS_RELAYER[0].to_owned(),
+            oracle_fee: 11,
+            relayer_fee: 22,
+            params: "0xparams".to_owned(),
+        },
+    ]
+}
+
+fn evm_metadata(id: &str) -> ChainLogMetadata {
+    ChainLogMetadata {
+        id: id.to_owned(),
+        source: EventSource::Evm,
+        chain_id: 46,
+        block_number: 123,
+        block_timestamp: 456,
+        transaction_hash: "0xtx".to_owned(),
+        transaction_index: 2,
+        log_index: 3,
+        contract_address: "0xport".to_owned(),
+        transaction_from: Some("0xsender".to_owned()),
+    }
+}
+
+async fn truncate_legacy_tables(pool: &PgPool) {
+    sqlx::query(
+        "TRUNCATE
+            ormp_hash_imported,
+            ormp_message_accepted,
+            ormp_message_assigned,
+            ormp_message_dispatched,
+            msgport_message_recv,
+            msgport_message_sent,
+            signature_pub_signature_submittion",
+    )
+    .execute(pool)
+    .await
+    .expect("truncate legacy tables");
+}
+
+fn test_database_url() -> Option<String> {
+    std::env::var("ORMPINDEXER_TEST_DATABASE_URL").ok()
+}

--- a/tests/legacy_parity.rs
+++ b/tests/legacy_parity.rs
@@ -240,10 +240,10 @@ fn evm_expected_rows() -> Vec<CompatibilityRow> {
 }
 
 fn tron_expected_rows() -> Vec<CompatibilityRow> {
-    let msg_hash = bytes_hex(0x11);
-    let hash = bytes_hex(0x22);
+    let msg_hash = bytes_hex(0x55);
+    let hash = bytes_hex(0x66);
     let msg_id = bytes_hex(0x33);
-    let dispatch_hash = bytes_hex(0x44);
+    let dispatch_hash = bytes_hex(0x77);
 
     let mut rows = vec![
         CompatibilityRow::OrmpHashImported(OrmpHashImportedRow {
@@ -505,7 +505,7 @@ fn tron_fixture_logs() -> Vec<DatalensLog> {
                 "chainId": "46",
                 "channel": "41BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
                 "msgIndex": "7",
-                "hash": bytes_hex(0x22)
+                "hash": bytes_hex(0x66)
             }),
         ),
         tron_log(
@@ -516,7 +516,7 @@ fn tron_fixture_logs() -> Vec<DatalensLog> {
             "tron-message-accepted",
             "MessageAccepted",
             serde_json::json!({
-                "msgHash": bytes_hex(0x11),
+                "msgHash": bytes_hex(0x55),
                 "message": {
                     "channel": "41CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
                     "index": "8",
@@ -537,7 +537,7 @@ fn tron_fixture_logs() -> Vec<DatalensLog> {
             "tron-message-assigned",
             "MessageAssigned",
             serde_json::json!({
-                "msgHash": bytes_hex(0x11),
+                "msgHash": bytes_hex(0x55),
                 "oracle": ormpindexer::schema::ADDRESS_ORACLE[0],
                 "relayer": ormpindexer::schema::ADDRESS_RELAYER[0],
                 "oracleFee": "9",
@@ -553,7 +553,7 @@ fn tron_fixture_logs() -> Vec<DatalensLog> {
             "tron-message-dispatched",
             "MessageDispatched",
             serde_json::json!({
-                "msgHash": bytes_hex(0x44),
+                "msgHash": bytes_hex(0x77),
                 "dispatchResult": true
             }),
         ),


### PR DESCRIPTION
## Summary
- add async-graphql server exposing legacy ORMP tables with by-id, list, and *Page root fields
- add GraphiQL playground at /graphiql and GraphQL endpoint at /graphql
- remove Connection-style schema surface by only exposing *Page pagination
- add GraphQL schema/query tests and fix parity fixtures to avoid cross-chain primary-key collisions

## Verification
- cargo build
- cargo test
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:32769/ormpindexer_test cargo test --test legacy_parity -- --nocapture
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:32769/ormpindexer_test cargo test --test postgres_writer -- --nocapture
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:32769/ormpindexer_test cargo test --test graphql_server -- --nocapture