### PR TITLE
HBX-455 feat(ormpindexer): add ops endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,6 +1617,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "tokio",
+ "tower",
  "tracing-log",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ sqlx = { version = "0.8.6", default-features = false, features = ["macros", "mig
 tokio = { version = "1.52.3", features = ["macros", "net", "rt-multi-thread"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["ansi", "env-filter", "fmt"] }
+
+[dev-dependencies]
+tower = { version = "0.5.2", features = ["util"] }

--- a/src/graphql/router.rs
+++ b/src/graphql/router.rs
@@ -2,14 +2,16 @@ use async_graphql::http::{GraphiQLPlugin, GraphiQLSource};
 use async_graphql::{EmptyMutation, EmptySubscription, Schema};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
-    Router,
+    Json, Router,
     extract::State,
+    http::{HeaderValue, StatusCode, header::CONTENT_TYPE},
     response::{Html, IntoResponse},
     routing::{get, post},
 };
 use sqlx::PgPool;
 
 use super::QueryRoot;
+use crate::ops;
 
 pub type IndexerGraphqlSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
@@ -19,18 +21,66 @@ pub fn build_schema(pool: PgPool) -> IndexerGraphqlSchema {
         .finish()
 }
 
-pub fn build_router(schema: IndexerGraphqlSchema) -> Router {
+pub fn build_router(schema: IndexerGraphqlSchema, pool: PgPool) -> Router {
     Router::new()
+        .route("/healthz", get(healthz_handler))
+        .route("/readyz", get(readyz_handler))
+        .route("/status", get(status_handler))
+        .route("/metrics", get(metrics_handler))
         .route("/graphql", post(graphql_handler))
         .route("/graphiql", get(graphql_graphiql))
-        .with_state(schema)
+        .with_state(HttpState { schema, pool })
 }
 
 async fn graphql_handler(
-    State(schema): State<IndexerGraphqlSchema>,
+    State(state): State<HttpState>,
     request: GraphQLRequest,
 ) -> GraphQLResponse {
-    schema.execute(request.into_inner()).await.into()
+    state.schema.execute(request.into_inner()).await.into()
+}
+
+async fn healthz_handler() -> impl IntoResponse {
+    (StatusCode::OK, "OK")
+}
+
+async fn readyz_handler(State(state): State<HttpState>) -> impl IntoResponse {
+    match ops::check_readiness(&state.pool).await {
+        Ok(()) => (StatusCode::OK, "READY").into_response(),
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("database not ready: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn status_handler(State(state): State<HttpState>) -> impl IntoResponse {
+    match ops::load_status(&state.pool).await {
+        Ok(status) => Json(status).into_response(),
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("status unavailable: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn metrics_handler(State(state): State<HttpState>) -> impl IntoResponse {
+    match ops::render_metrics(&state.pool).await {
+        Ok(metrics) => (
+            [(
+                CONTENT_TYPE,
+                HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
+            )],
+            metrics,
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            format!("metrics unavailable: {error}"),
+        )
+            .into_response(),
+    }
 }
 
 async fn graphql_graphiql() -> impl IntoResponse {
@@ -63,4 +113,10 @@ fn graphiql_explorer_plugin<'a>() -> GraphiQLPlugin<'a> {
 
 pub(super) struct GraphqlState {
     pub(super) pool: PgPool,
+}
+
+#[derive(Clone)]
+struct HttpState {
+    schema: IndexerGraphqlSchema,
+    pool: PgPool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod database;
 pub mod datalens;
 pub mod decoder;
 pub mod graphql;
+pub mod ops;
 pub mod planner;
 pub mod runner;
 pub mod runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn serve(listen_addr: &str) -> anyhow::Result<()> {
     let database_url = RuntimeConfig::database_url_from_env()?;
     let pool = database::connect(&database_url, 5).await?;
     database::apply_migrations(&pool).await?;
-    let app = build_router(build_schema(pool));
+    let app = build_router(build_schema(pool.clone()), pool);
     let listener = tokio::net::TcpListener::bind(listen_addr)
         .await
         .with_context(|| format!("bind GraphQL server to {listen_addr}"))?;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,195 @@
+use serde::Serialize;
+use sqlx::{FromRow, PgPool};
+
+const LEGACY_TABLES: &[&str] = &[
+    "ormp_hash_imported",
+    "ormp_message_accepted",
+    "ormp_message_assigned",
+    "ormp_message_dispatched",
+    "msgport_message_recv",
+    "msgport_message_sent",
+    "signature_pub_signature_submittion",
+];
+
+#[derive(Clone, Debug, Eq, PartialEq, FromRow, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckpointRow {
+    pub chain_id: String,
+    pub dataset: String,
+    pub next_block: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, FromRow, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChainProgressRow {
+    pub chain_id: String,
+    pub datasets: i64,
+    pub min_next_block: String,
+    pub max_next_block: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, FromRow, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DatasetProgressRow {
+    pub dataset: String,
+    pub chains: i64,
+    pub min_next_block: String,
+    pub max_next_block: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, FromRow)]
+pub struct LegacyTableRowCount {
+    pub table_name: String,
+    pub row_count: i64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusResponse {
+    pub checkpoints: Vec<CheckpointRow>,
+    pub progress: ProgressSummary,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgressSummary {
+    pub chains: Vec<ChainProgressRow>,
+    pub datasets: Vec<DatasetProgressRow>,
+}
+
+pub async fn check_readiness(pool: &PgPool) -> anyhow::Result<()> {
+    sqlx::query("SELECT 1").execute(pool).await?;
+    Ok(())
+}
+
+pub async fn load_status(pool: &PgPool) -> anyhow::Result<StatusResponse> {
+    let checkpoints = sqlx::query_as::<_, CheckpointRow>(
+        "SELECT
+            chain_id::TEXT AS chain_id,
+            dataset,
+            next_block::TEXT AS next_block,
+            updated_at::TEXT AS updated_at
+         FROM ormp_indexer_checkpoint
+         ORDER BY chain_id::NUMERIC, dataset",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let chains = sqlx::query_as::<_, ChainProgressRow>(
+        "SELECT
+            chain_id::TEXT AS chain_id,
+            COUNT(*)::BIGINT AS datasets,
+            MIN(next_block)::TEXT AS min_next_block,
+            MAX(next_block)::TEXT AS max_next_block,
+            MAX(updated_at)::TEXT AS updated_at
+         FROM ormp_indexer_checkpoint
+         GROUP BY chain_id
+         ORDER BY chain_id::NUMERIC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let datasets = sqlx::query_as::<_, DatasetProgressRow>(
+        "SELECT
+            dataset,
+            COUNT(*)::BIGINT AS chains,
+            MIN(next_block)::TEXT AS min_next_block,
+            MAX(next_block)::TEXT AS max_next_block,
+            MAX(updated_at)::TEXT AS updated_at
+         FROM ormp_indexer_checkpoint
+         GROUP BY dataset
+         ORDER BY dataset",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(StatusResponse {
+        checkpoints,
+        progress: ProgressSummary { chains, datasets },
+    })
+}
+
+pub async fn render_metrics(pool: &PgPool) -> anyhow::Result<String> {
+    let checkpoints = sqlx::query_as::<_, CheckpointRow>(
+        "SELECT
+            chain_id::TEXT AS chain_id,
+            dataset,
+            next_block::TEXT AS next_block,
+            updated_at::TEXT AS updated_at
+         FROM ormp_indexer_checkpoint
+         ORDER BY chain_id::NUMERIC, dataset",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let row_counts = sqlx::query_as::<_, LegacyTableRowCount>(
+        "SELECT table_name, row_count
+         FROM (
+           SELECT 'ormp_hash_imported'::TEXT AS table_name, COUNT(*)::BIGINT AS row_count FROM ormp_hash_imported
+           UNION ALL
+           SELECT 'ormp_message_accepted', COUNT(*)::BIGINT FROM ormp_message_accepted
+           UNION ALL
+           SELECT 'ormp_message_assigned', COUNT(*)::BIGINT FROM ormp_message_assigned
+           UNION ALL
+           SELECT 'ormp_message_dispatched', COUNT(*)::BIGINT FROM ormp_message_dispatched
+           UNION ALL
+           SELECT 'msgport_message_recv', COUNT(*)::BIGINT FROM msgport_message_recv
+           UNION ALL
+           SELECT 'msgport_message_sent', COUNT(*)::BIGINT FROM msgport_message_sent
+           UNION ALL
+           SELECT 'signature_pub_signature_submittion', COUNT(*)::BIGINT FROM signature_pub_signature_submittion
+         ) counts",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(format_metrics(&checkpoints, &row_counts))
+}
+
+fn format_metrics(checkpoints: &[CheckpointRow], row_counts: &[LegacyTableRowCount]) -> String {
+    let mut body = String::new();
+
+    body.push_str(
+        "# HELP ormp_indexer_checkpoint_next_block Next block recorded per chain and dataset.\n",
+    );
+    body.push_str("# TYPE ormp_indexer_checkpoint_next_block gauge\n");
+    for checkpoint in checkpoints {
+        body.push_str("ormp_indexer_checkpoint_next_block{chain_id=\"");
+        body.push_str(&escape_label_value(&checkpoint.chain_id));
+        body.push_str("\",dataset=\"");
+        body.push_str(&escape_label_value(&checkpoint.dataset));
+        body.push_str("\"} ");
+        body.push_str(&checkpoint.next_block);
+        body.push('\n');
+    }
+
+    body.push_str("# HELP ormp_indexer_checkpoint_rows Total checkpoint rows.\n");
+    body.push_str("# TYPE ormp_indexer_checkpoint_rows gauge\n");
+    body.push_str("ormp_indexer_checkpoint_rows ");
+    body.push_str(&checkpoints.len().to_string());
+    body.push('\n');
+
+    body.push_str("# HELP ormp_indexer_legacy_table_rows Legacy GraphQL table row counts.\n");
+    body.push_str("# TYPE ormp_indexer_legacy_table_rows gauge\n");
+    for table in LEGACY_TABLES {
+        let count = row_counts
+            .iter()
+            .find(|row| row.table_name == *table)
+            .map(|row| row.row_count)
+            .unwrap_or_default();
+        body.push_str("ormp_indexer_legacy_table_rows{table=\"");
+        body.push_str(table);
+        body.push_str("\"} ");
+        body.push_str(&count.to_string());
+        body.push('\n');
+    }
+
+    body
+}
+
+fn escape_label_value(value: &str) -> String {
+    value.replace('\\', r"\\").replace('"', "\\\"")
+}

--- a/tests/ops_endpoints.rs
+++ b/tests/ops_endpoints.rs
@@ -1,0 +1,243 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{HeaderMap, Request, StatusCode},
+};
+use serde_json::Value;
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use std::time::Duration;
+use tower::ServiceExt;
+
+use ormpindexer::{
+    database::{EventWriter, PostgresEventWriter, apply_migrations},
+    graphql::{build_router, build_schema},
+    schema::{ADDRESS_ORACLE, ADDRESS_RELAYER, ChainLogMetadata, EventSource, LegacyOrmPEvent},
+};
+
+#[tokio::test]
+async fn test_healthz_returns_ok_without_database_connectivity() {
+    let pool = unreachable_pool();
+    let app = build_router(build_schema(pool.clone()), pool);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/healthz")
+                .body(Body::empty())
+                .expect("healthz request"),
+        )
+        .await
+        .expect("healthz response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("healthz body"),
+        "OK"
+    );
+}
+
+#[tokio::test]
+async fn test_readyz_reports_service_unavailable_when_database_is_unreachable() {
+    let pool = unreachable_pool();
+    let app = build_router(build_schema(pool.clone()), pool);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/readyz")
+                .body(Body::empty())
+                .expect("readyz request"),
+        )
+        .await
+        .expect("readyz response");
+
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_status_and_metrics_expose_checkpoint_progress_from_postgres() {
+    let Some(database_url) = test_database_url() else {
+        eprintln!("skipping ops endpoint Postgres test; ORMPINDEXER_TEST_DATABASE_URL is not set");
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("connect test postgres");
+    apply_migrations(&pool).await.expect("apply migrations");
+    truncate_tables(&pool).await;
+    seed_checkpoint_rows(&pool).await;
+    PostgresEventWriter::new(pool.clone())
+        .write_events(&legacy_events())
+        .await
+        .expect("write legacy events");
+
+    let app = build_router(build_schema(pool.clone()), pool);
+
+    let status = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/status")
+                .body(Body::empty())
+                .expect("status request"),
+        )
+        .await
+        .expect("status response");
+
+    assert_eq!(status.status(), StatusCode::OK);
+    let status_json: Value = serde_json::from_slice(
+        &to_bytes(status.into_body(), usize::MAX)
+            .await
+            .expect("status body"),
+    )
+    .expect("status json");
+    assert_eq!(status_json["checkpoints"].as_array().map(Vec::len), Some(2));
+    assert_eq!(
+        status_json["progress"]["chains"].as_array().map(Vec::len),
+        Some(2)
+    );
+    assert_eq!(
+        status_json["progress"]["datasets"][0]["dataset"],
+        Value::String("datalens-native".to_owned())
+    );
+    assert_eq!(
+        status_json["progress"]["datasets"][0]["chains"],
+        Value::Number(2.into())
+    );
+    assert_eq!(
+        status_json["progress"]["datasets"][0]["minNextBlock"],
+        Value::String("123".to_owned())
+    );
+    assert_eq!(
+        status_json["progress"]["datasets"][0]["maxNextBlock"],
+        Value::String("456".to_owned())
+    );
+
+    let metrics = app
+        .oneshot(
+            Request::builder()
+                .uri("/metrics")
+                .body(Body::empty())
+                .expect("metrics request"),
+        )
+        .await
+        .expect("metrics response");
+
+    assert_eq!(metrics.status(), StatusCode::OK);
+    let metrics_headers = metrics.headers().clone();
+    let metrics_body = String::from_utf8(
+        to_bytes(metrics.into_body(), usize::MAX)
+            .await
+            .expect("metrics body")
+            .to_vec(),
+    )
+    .expect("utf8 metrics");
+    assert_eq!(
+        content_type(&metrics_headers),
+        Some("text/plain; version=0.0.4; charset=utf-8")
+    );
+    assert!(metrics_body.contains(
+        "ormp_indexer_checkpoint_next_block{chain_id=\"46\",dataset=\"datalens-native\"} 123"
+    ));
+    assert!(metrics_body.contains(
+        "ormp_indexer_checkpoint_next_block{chain_id=\"11155111\",dataset=\"datalens-native\"} 456"
+    ));
+    assert!(
+        metrics_body.contains("ormp_indexer_legacy_table_rows{table=\"ormp_message_accepted\"} 1")
+    );
+    assert!(
+        metrics_body.contains("ormp_indexer_legacy_table_rows{table=\"ormp_message_assigned\"} 1")
+    );
+}
+
+fn legacy_events() -> Vec<LegacyOrmPEvent> {
+    vec![
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata("accepted-log"),
+            msg_hash: "0xaccepted".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 8,
+            from_chain_id: 1,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 46,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("assigned-log"),
+            msg_hash: "0xaccepted".to_owned(),
+            oracle: ADDRESS_ORACLE[0].to_owned(),
+            relayer: ADDRESS_RELAYER[0].to_owned(),
+            oracle_fee: 11,
+            relayer_fee: 22,
+            params: "0xparams".to_owned(),
+        },
+    ]
+}
+
+fn evm_metadata(id: &str) -> ChainLogMetadata {
+    ChainLogMetadata {
+        id: id.to_owned(),
+        source: EventSource::Evm,
+        chain_id: 46,
+        block_number: 123,
+        block_timestamp: 456,
+        transaction_hash: "0xtx".to_owned(),
+        transaction_index: 2,
+        log_index: 3,
+        contract_address: "0xport".to_owned(),
+        transaction_from: Some("0xsender".to_owned()),
+    }
+}
+
+async fn seed_checkpoint_rows(pool: &PgPool) {
+    sqlx::query(
+        "INSERT INTO ormp_indexer_checkpoint (chain_id, dataset, next_block)
+         VALUES ($1::NUMERIC, $2, $3::NUMERIC), ($4::NUMERIC, $5, $6::NUMERIC)",
+    )
+    .bind("46")
+    .bind("datalens-native")
+    .bind("123")
+    .bind("11155111")
+    .bind("datalens-native")
+    .bind("456")
+    .execute(pool)
+    .await
+    .expect("seed checkpoints");
+}
+
+async fn truncate_tables(pool: &PgPool) {
+    sqlx::query(
+        "TRUNCATE
+            ormp_indexer_checkpoint,
+            ormp_hash_imported,
+            ormp_message_accepted,
+            ormp_message_assigned,
+            ormp_message_dispatched,
+            msgport_message_recv,
+            msgport_message_sent,
+            signature_pub_signature_submittion",
+    )
+    .execute(pool)
+    .await
+    .expect("truncate tables");
+}
+
+fn content_type(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+}
+
+fn unreachable_pool() -> PgPool {
+    PgPoolOptions::new()
+        .acquire_timeout(Duration::from_millis(250))
+        .connect_lazy("postgres://user:pass@127.0.0.1:1/ormpindexer?connect_timeout=1")
+        .expect("lazy postgres pool")
+}
+
+fn test_database_url() -> Option<String> {
+    std::env::var("ORMPINDEXER_TEST_DATABASE_URL").ok()
+}


### PR DESCRIPTION
## Summary
- add /healthz, /readyz, /status, and /metrics to the existing Axum GraphQL server
- expose checkpoint status summaries and Prometheus text metrics for checkpoints and legacy table row counts
- add router-level tests for health/readiness/status/metrics

## Verification
- cargo fmt --check
- cargo build
- cargo test
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:32771/ormpindexer_test cargo test --test ops_endpoints -- --nocapture
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:32771/ormpindexer_test cargo test --test graphql_server -- --nocapture
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:32771/ormpindexer_test cargo test --test legacy_parity -- --nocapture
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:32771/ormpindexer_test cargo test --test postgres_writer -- --nocapture