### PR TITLE
fix(indexer): address Datalens final review gaps

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,6 @@ use anyhow::{Context, bail};
 
 use crate::planner::{TRON_CHAIN_ID, default_chain_config};
 
-pub const DEFAULT_DATASET: &str = "datalens-native";
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RuntimeConfig {
     pub datalens: DatalensConfig,
@@ -14,7 +12,6 @@ pub struct RuntimeConfig {
     pub batch_size: u64,
     pub start_block: u64,
     pub finality_mode: FinalityMode,
-    pub dataset: String,
     pub poll_interval: Duration,
 }
 
@@ -70,8 +67,6 @@ impl RuntimeConfig {
                 .map(str::parse)
                 .transpose()?
                 .unwrap_or(FinalityMode::Finalized),
-            dataset: optional_env(env, "ORMPINDEXER_DATASET")
-                .unwrap_or_else(|| DEFAULT_DATASET.to_owned()),
             poll_interval: Duration::from_secs(
                 optional_u64(env, "ORMPINDEXER_POLL_INTERVAL_SECS")?.unwrap_or(30),
             ),
@@ -157,7 +152,7 @@ impl std::str::FromStr for FinalityMode {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
-            "finalized" | "safe" => Ok(Self::Finalized),
+            "finalized" => Ok(Self::Finalized),
             "durable" => Ok(Self::Durable),
             _ => bail!("ORMPINDEXER_FINALITY_MODE must be finalized or durable"),
         }

--- a/src/database.rs
+++ b/src/database.rs
@@ -160,7 +160,9 @@ async fn write_legacy_event(
             insert_hash_imported(tx, OrmpHashImportedRow::from_event(event)).await
         }
         LegacyOrmPEvent::MessageAccepted { .. } => {
-            insert_message_accepted(tx, OrmpMessageAcceptedRow::from_event(event)).await
+            let row = OrmpMessageAcceptedRow::from_event(event);
+            insert_message_accepted(tx, row.clone()).await?;
+            backfill_accepted_assignment(tx, &row, assignment_config).await
         }
         LegacyOrmPEvent::MessageAssigned { .. } => {
             let row = OrmpMessageAssignedRow::from_event(event);
@@ -357,6 +359,74 @@ async fn backfill_message_assignment(
     .context("backfill ormp_message_accepted assignment fields")?;
 
     Ok(())
+}
+
+async fn backfill_accepted_assignment(
+    tx: &mut Transaction<'_, Postgres>,
+    row: &OrmpMessageAcceptedRow,
+    assignment_config: &AssignmentConfig,
+) -> anyhow::Result<()> {
+    let assignments = sqlx::query_as::<_, OrmpMessageAssignedDbRow>(
+        "SELECT
+            id,
+            block_number::TEXT AS block_number,
+            transaction_hash,
+            block_timestamp::TEXT AS block_timestamp,
+            chain_id::TEXT AS chain_id,
+            msg_hash,
+            oracle,
+            relayer,
+            oracle_fee::TEXT AS oracle_fee,
+            relayer_fee::TEXT AS relayer_fee,
+            params
+         FROM ormp_message_assigned
+         WHERE msg_hash = $1
+         ORDER BY block_number ASC, id ASC",
+    )
+    .bind(&row.msg_hash)
+    .fetch_all(&mut **tx)
+    .await
+    .context("load existing ormp_message_assigned rows for accepted backfill")?;
+
+    for assignment in assignments {
+        let assignment = assignment.into_schema_row()?;
+        backfill_message_assignment(tx, &assignment, assignment_config).await?;
+    }
+
+    Ok(())
+}
+
+#[derive(sqlx::FromRow)]
+struct OrmpMessageAssignedDbRow {
+    id: String,
+    block_number: String,
+    transaction_hash: String,
+    block_timestamp: String,
+    chain_id: String,
+    msg_hash: String,
+    oracle: String,
+    relayer: String,
+    oracle_fee: String,
+    relayer_fee: String,
+    params: String,
+}
+
+impl OrmpMessageAssignedDbRow {
+    fn into_schema_row(self) -> anyhow::Result<OrmpMessageAssignedRow> {
+        Ok(OrmpMessageAssignedRow {
+            id: self.id,
+            block_number: self.block_number.parse()?,
+            transaction_hash: self.transaction_hash,
+            block_timestamp: self.block_timestamp.parse()?,
+            chain_id: self.chain_id.parse()?,
+            msg_hash: self.msg_hash,
+            oracle: self.oracle,
+            relayer: self.relayer,
+            oracle_fee: self.oracle_fee.parse()?,
+            relayer_fee: self.relayer_fee.parse()?,
+            params: self.params,
+        })
+    }
 }
 
 async fn insert_message_dispatched(

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -55,6 +55,9 @@ pub struct DatalensLogQueryResult {
 
 #[allow(async_fn_in_trait)]
 pub trait DatalensLogReader {
+    async fn latest_block(&self, chain_id: u64, finality_mode: FinalityMode)
+    -> anyhow::Result<u64>;
+
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult>;
 }
 
@@ -78,9 +81,46 @@ impl DatalensHttpClient {
             self.config.endpoint.trim_end_matches('/')
         )
     }
+
+    fn chain_head_endpoint(
+        &self,
+        chain_id: u64,
+        finality_mode: FinalityMode,
+    ) -> anyhow::Result<String> {
+        let chain_name = chain_name(chain_id)?;
+        Ok(format!(
+            "{}/v1/chains/{chain_name}/head?finality={}",
+            self.config.endpoint.trim_end_matches('/'),
+            chain_head_finality(finality_mode),
+        ))
+    }
 }
 
 impl DatalensLogReader for DatalensHttpClient {
+    async fn latest_block(
+        &self,
+        chain_id: u64,
+        finality_mode: FinalityMode,
+    ) -> anyhow::Result<u64> {
+        let mut builder = self
+            .http
+            .get(self.chain_head_endpoint(chain_id, finality_mode)?)
+            .header("x-datalens-application", &self.config.application);
+        if let Some(token) = &self.config.token {
+            builder = builder.bearer_auth(token.expose_secret());
+        }
+
+        let response = builder.send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Datalens chain head query failed with status {status}: {body}");
+        }
+
+        let payload: ChainHeadResponse = response.json().await?;
+        Ok(payload.height)
+    }
+
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult> {
         let request = native_graphql_request(&query)?;
         let mut builder = self
@@ -92,7 +132,12 @@ impl DatalensLogReader for DatalensHttpClient {
             builder = builder.bearer_auth(token.expose_secret());
         }
 
-        let response = builder.send().await?.error_for_status()?;
+        let response = builder.send().await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Datalens log query failed with status {status}: {body}");
+        }
         let payload: serde_json::Value = response.json().await?;
         if let Some(errors) = payload.get("errors") {
             anyhow::bail!("Datalens log query returned errors: {errors}");
@@ -101,6 +146,11 @@ impl DatalensLogReader for DatalensHttpClient {
         let logs = logs_from_native_query_payload(&payload, query.chain_id)?;
         Ok(DatalensLogQueryResult { logs })
     }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+struct ChainHeadResponse {
+    height: u64,
 }
 
 pub fn native_graphql_request(query: &DatalensLogQuery) -> anyhow::Result<serde_json::Value> {
@@ -430,8 +480,23 @@ fn topic_filters(topics: &[String]) -> Vec<Vec<String>> {
 
 fn native_finality(finality_mode: FinalityMode) -> &'static str {
     match finality_mode {
-        FinalityMode::Finalized => "finalized",
+        FinalityMode::Finalized => "durable_only",
         FinalityMode::Durable => "durable_only",
+    }
+}
+
+fn chain_head_finality(finality_mode: FinalityMode) -> &'static str {
+    match finality_mode {
+        FinalityMode::Finalized => "finalized",
+        FinalityMode::Durable => "finalized",
+    }
+}
+
+fn chain_name(chain_id: u64) -> anyhow::Result<&'static str> {
+    if chain_id == TRON_CHAIN_ID {
+        tron_chain_name(chain_id)
+    } else {
+        evm_chain_name(chain_id)
     }
 }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -53,11 +53,11 @@ pub fn decode_evm_log(log: &DatalensLog) -> anyhow::Result<LegacyOrmPEvent> {
 
     match topic0.as_str() {
         ORMP_HASH_IMPORTED_TOPIC => decode_hash_imported(metadata, &data),
-        ORMP_MESSAGE_ACCEPTED_TOPIC => decode_message_accepted(metadata, &data),
-        ORMP_MESSAGE_ASSIGNED_TOPIC => decode_message_assigned(metadata, &data),
-        ORMP_MESSAGE_DISPATCHED_TOPIC => decode_message_dispatched(metadata, &data),
-        MSGPORT_MESSAGE_RECV_TOPIC => decode_msgport_message_recv(metadata, &data),
-        MSGPORT_MESSAGE_SENT_TOPIC => decode_msgport_message_sent(metadata, &data),
+        ORMP_MESSAGE_ACCEPTED_TOPIC => decode_message_accepted(metadata, &log.topics, &data),
+        ORMP_MESSAGE_ASSIGNED_TOPIC => decode_message_assigned(metadata, &log.topics, &data),
+        ORMP_MESSAGE_DISPATCHED_TOPIC => decode_message_dispatched(metadata, &log.topics, &data),
+        MSGPORT_MESSAGE_RECV_TOPIC => decode_msgport_message_recv(metadata, &log.topics, &data),
+        MSGPORT_MESSAGE_SENT_TOPIC => decode_msgport_message_sent(metadata, &log.topics, &data),
         SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC => decode_signature_submittion(metadata, &data),
         _ => bail!("unsupported ORMP EVM event topic0 {topic0}"),
     }
@@ -280,8 +280,43 @@ fn decode_hash_imported(
 
 fn decode_message_accepted(
     metadata: ChainLogMetadata,
+    topics: &[String],
     data: &[u8],
 ) -> anyhow::Result<LegacyOrmPEvent> {
+    if topics.len() > 1 {
+        let mut tokens = decode_event(
+            &[ParamType::Tuple(vec![
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Uint(256),
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Bytes,
+            ])],
+            data,
+        )?;
+        let message = take(&mut tokens, "message")?;
+        let Token::Tuple(mut message) = message else {
+            bail!("message is not an ABI tuple");
+        };
+        ensure!(message.len() == 8, "message tuple must contain 8 fields");
+
+        return Ok(LegacyOrmPEvent::MessageAccepted {
+            metadata,
+            msg_hash: topic_fixed_bytes(topics, 1, "msgHash")?,
+            channel: token_address(take(&mut message, "message.channel")?)?,
+            index: token_uint(take(&mut message, "message.index")?)?,
+            from_chain_id: token_uint(take(&mut message, "message.fromChainId")?)?,
+            from: token_address(take(&mut message, "message.from")?)?,
+            to_chain_id: token_uint(take(&mut message, "message.toChainId")?)?,
+            to: token_address(take(&mut message, "message.to")?)?,
+            gas_limit: token_uint(take(&mut message, "message.gasLimit")?)?,
+            encoded: token_bytes(take(&mut message, "message.encoded")?)?,
+        });
+    }
+
     let mut tokens = decode_event(
         &[
             ParamType::FixedBytes(32),
@@ -321,8 +356,25 @@ fn decode_message_accepted(
 
 fn decode_message_assigned(
     metadata: ChainLogMetadata,
+    topics: &[String],
     data: &[u8],
 ) -> anyhow::Result<LegacyOrmPEvent> {
+    if topics.len() > 3 {
+        let mut tokens = decode_event(
+            &[ParamType::Uint(256), ParamType::Uint(256), ParamType::Bytes],
+            data,
+        )?;
+        return Ok(LegacyOrmPEvent::MessageAssigned {
+            metadata,
+            msg_hash: topic_fixed_bytes(topics, 1, "msgHash")?,
+            oracle: topic_address(topics, 2, "oracle")?,
+            relayer: topic_address(topics, 3, "relayer")?,
+            oracle_fee: token_uint(take(&mut tokens, "oracleFee")?)?,
+            relayer_fee: token_uint(take(&mut tokens, "relayerFee")?)?,
+            params: token_bytes(take(&mut tokens, "params")?)?,
+        });
+    }
+
     let mut tokens = decode_event(
         &[
             ParamType::FixedBytes(32),
@@ -347,8 +399,19 @@ fn decode_message_assigned(
 
 fn decode_message_dispatched(
     metadata: ChainLogMetadata,
+    topics: &[String],
     data: &[u8],
 ) -> anyhow::Result<LegacyOrmPEvent> {
+    if topics.len() > 1 {
+        let mut tokens = decode_event(&[ParamType::Bool], data)?;
+        return Ok(LegacyOrmPEvent::MessageDispatched {
+            target_chain_id: metadata.chain_id,
+            metadata,
+            msg_hash: topic_fixed_bytes(topics, 1, "msgHash")?,
+            dispatch_result: token_bool(take(&mut tokens, "dispatchResult")?)?,
+        });
+    }
+
     let mut tokens = decode_event(&[ParamType::FixedBytes(32), ParamType::Bool], data)?;
     Ok(LegacyOrmPEvent::MessageDispatched {
         target_chain_id: metadata.chain_id,
@@ -360,8 +423,19 @@ fn decode_message_dispatched(
 
 fn decode_msgport_message_recv(
     metadata: ChainLogMetadata,
+    topics: &[String],
     data: &[u8],
 ) -> anyhow::Result<LegacyOrmPEvent> {
+    if topics.len() > 1 {
+        let mut tokens = decode_event(&[ParamType::Bool, ParamType::Bytes], data)?;
+        return Ok(LegacyOrmPEvent::MsgportMessageRecv {
+            metadata,
+            msg_id: topic_fixed_bytes(topics, 1, "msgId")?,
+            result: token_bool(take(&mut tokens, "result")?)?,
+            return_data: token_bytes(take(&mut tokens, "returnData")?)?,
+        });
+    }
+
     let mut tokens = decode_event(
         &[ParamType::FixedBytes(32), ParamType::Bool, ParamType::Bytes],
         data,
@@ -376,8 +450,31 @@ fn decode_msgport_message_recv(
 
 fn decode_msgport_message_sent(
     metadata: ChainLogMetadata,
+    topics: &[String],
     data: &[u8],
 ) -> anyhow::Result<LegacyOrmPEvent> {
+    if topics.len() > 1 {
+        let mut tokens = decode_event(
+            &[
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Address,
+                ParamType::Bytes,
+                ParamType::Bytes,
+            ],
+            data,
+        )?;
+        return Ok(LegacyOrmPEvent::MsgportMessageSent {
+            metadata,
+            msg_id: topic_fixed_bytes(topics, 1, "msgId")?,
+            from_dapp: token_address(take(&mut tokens, "fromDapp")?)?,
+            to_chain_id: token_uint(take(&mut tokens, "toChainId")?)?,
+            to_dapp: token_address(take(&mut tokens, "toDapp")?)?,
+            message: token_bytes(take(&mut tokens, "message")?)?,
+            params: token_bytes(take(&mut tokens, "params")?)?,
+        });
+    }
+
     let mut tokens = decode_event(
         &[
             ParamType::FixedBytes(32),
@@ -473,6 +570,33 @@ fn token_uint(token: Token) -> anyhow::Result<u128> {
         }
         _ => bail!("ABI token is not uint"),
     }
+}
+
+fn topic_fixed_bytes(topics: &[String], index: usize, name: &str) -> anyhow::Result<String> {
+    let topic = topics
+        .get(index)
+        .with_context(|| format!("EVM indexed topic {name} is missing"))?;
+    let topic = normalize_hex(topic)?;
+    ensure!(
+        topic.len() == 66,
+        "EVM indexed topic {name} must be 32 bytes"
+    );
+    Ok(topic)
+}
+
+fn topic_address(topics: &[String], index: usize, name: &str) -> anyhow::Result<String> {
+    let topic = topics
+        .get(index)
+        .with_context(|| format!("EVM indexed topic {name} is missing"))?;
+    let topic = normalize_hex(topic)?;
+    let address = topic
+        .strip_prefix("0x")
+        .context("normalized topic is missing 0x prefix")?;
+    ensure!(
+        address.len() == 64,
+        "EVM indexed topic {name} must be 32 bytes"
+    );
+    Ok(format!("0x{}", &address[24..64]))
 }
 
 fn normalize_hex(value: &str) -> anyhow::Result<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use ormpindexer::{
     config::RuntimeConfig,
     database,
     graphql::{build_router, build_schema},
-    runtime::{migrate, run},
+    runtime::{migrate, run, run_with_server},
 };
 
 #[derive(Debug, Parser)]
@@ -20,6 +20,9 @@ enum Command {
     Run {
         #[arg(long)]
         once: bool,
+
+        #[arg(long, default_value = "0.0.0.0:8080")]
+        listen_addr: String,
     },
     Serve {
         #[arg(long, default_value = "0.0.0.0:8080")]
@@ -34,7 +37,13 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Command::Run { once } => run(once).await,
+        Command::Run { once, listen_addr } => {
+            if once {
+                run(true).await
+            } else {
+                run_with_server(&listen_addr).await
+            }
+        }
         Command::Serve { listen_addr } => serve(&listen_addr).await,
         Command::Migrate => migrate().await,
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -64,14 +64,34 @@ where
                 .checkpoints
                 .read_or_create(chain.chain_id, dataset, chain.start_block)
                 .await?;
-            let range = plan_next_range(&checkpoint, self.config.batch_size)?;
+            let target_block = self
+                .reader
+                .latest_block(chain.chain_id, self.config.finality_mode)
+                .await
+                .with_context(|| {
+                    format!("query Datalens chain head for chain {}", chain.chain_id)
+                })?;
+            if checkpoint.next_block > target_block {
+                log::info!(
+                    "skipping ORMP Datalens chain_id={} dataset={} checkpoint_next_block={} target_block={} checkpoint_ahead_of_target=true",
+                    chain.chain_id,
+                    dataset,
+                    checkpoint.next_block,
+                    target_block,
+                );
+                continue;
+            }
+
+            let mut range = plan_next_range(&checkpoint, self.config.batch_size)?;
+            range.to_block = range.to_block.min(target_block);
 
             log::info!(
-                "querying ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={} batch_size={} contracts={} topics={} finality={}",
+                "querying ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={} target_block={} batch_size={} contracts={} topics={} finality={}",
                 chain.chain_id,
                 dataset,
                 range.from_block,
                 range.to_block,
+                target_block,
                 self.config.batch_size,
                 chain.contracts.len(),
                 chain.topics.len(),
@@ -103,11 +123,12 @@ where
                 .await?;
 
             log::info!(
-                "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true",
+                "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} target_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true",
                 chain.chain_id,
                 dataset,
                 range.from_block,
                 range.to_block,
+                target_block,
                 result.logs.len(),
                 events.len(),
                 written,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -5,6 +5,7 @@ use crate::{
     database::{PostgresCheckpointStore, PostgresEventWriter, apply_migrations, connect},
     datalens::DatalensHttpClient,
     decoder::EvmEventDecoder,
+    graphql::{build_router, build_schema},
     runner::IndexerRunner,
 };
 
@@ -18,13 +19,12 @@ pub async fn run(run_once: bool) -> anyhow::Result<()> {
     apply_migrations(&pool).await?;
 
     log::info!(
-        "starting ORMP Datalens indexer endpoint={} application={} token_configured={} database_configured=true chains={} batch_size={} dataset={} finality={} dry_run=false",
+        "starting ORMP Datalens indexer endpoint={} application={} token_configured={} database_configured=true chains={} batch_size={} finality={} dry_run=false",
         config.datalens.endpoint,
         config.datalens.application,
         config.datalens.token.is_some(),
         config.enabled_chains.len(),
         config.batch_size,
-        config.dataset,
         config.finality_mode.as_str(),
     );
 
@@ -41,6 +41,47 @@ pub async fn run(run_once: bool) -> anyhow::Result<()> {
     } else {
         runner.run_loop().await?;
     }
+
+    Ok(())
+}
+
+pub async fn run_with_server(listen_addr: &str) -> anyhow::Result<()> {
+    let config = RuntimeConfig::from_env().context("load ORMP indexer runtime config")?;
+    let database_url = config
+        .database_url
+        .as_ref()
+        .context("ORMPINDEXER_DATABASE_URL must be configured for run")?;
+    let pool = connect(database_url, 5).await?;
+    apply_migrations(&pool).await?;
+
+    log::info!(
+        "starting ORMP Datalens indexer with GraphQL server endpoint={} application={} token_configured={} database_configured=true chains={} batch_size={} finality={} listen_addr={} dry_run=false",
+        config.datalens.endpoint,
+        config.datalens.application,
+        config.datalens.token.is_some(),
+        config.enabled_chains.len(),
+        config.batch_size,
+        config.finality_mode.as_str(),
+        listen_addr,
+    );
+
+    let runner = IndexerRunner::new(
+        config.clone(),
+        DatalensHttpClient::new(config.datalens.clone()),
+        PostgresCheckpointStore::new(pool.clone()),
+        EvmEventDecoder,
+        PostgresEventWriter::new(pool.clone()),
+    );
+    let app = build_router(build_schema(pool.clone()), pool);
+    let listener = tokio::net::TcpListener::bind(listen_addr)
+        .await
+        .with_context(|| format!("bind GraphQL server to {listen_addr}"))?;
+
+    tokio::try_join!(runner.run_loop(), async {
+        axum::serve(listener, app)
+            .await
+            .context("serve GraphQL server")
+    },)?;
 
     Ok(())
 }

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -224,6 +224,21 @@ fn test_tron_native_graphql_request_uses_other_selector_shape() {
 }
 
 #[test]
+fn test_evm_native_graphql_request_uses_datalens_finality_enum() {
+    let request = native_graphql_request(&ormpindexer::datalens::DatalensLogQuery {
+        chain_id: 42161,
+        from_block: 466_386_813,
+        to_block: 466_386_813,
+        contracts: vec!["0x2cd1867fb8016f93710b6386f7f9f1d540a60812".to_owned()],
+        topics: Vec::new(),
+        finality_mode: ormpindexer::config::FinalityMode::Finalized,
+    })
+    .expect("build EVM request");
+
+    assert_eq!(request["variables"]["input"]["finality"], "durable_only");
+}
+
+#[test]
 fn test_tron_native_graphql_request_rejects_invalid_contract_address() {
     let error = native_graphql_request(&ormpindexer::datalens::DatalensLogQuery {
         chain_id: TRON_CHAIN_ID,

--- a/tests/datalens_planner.rs
+++ b/tests/datalens_planner.rs
@@ -140,6 +140,30 @@ fn test_runtime_config_accepts_tron_chain_defaults() {
 }
 
 #[test]
+fn test_runtime_config_rejects_safe_finality_for_persistent_indexing() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_FINALITY_MODE".to_owned(), "safe".to_owned()),
+    ]);
+
+    let error = RuntimeConfig::from_env_map(&env).expect_err("safe mode is rejected");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ORMPINDEXER_FINALITY_MODE must be finalized or durable")
+    );
+}
+
+#[test]
 fn test_runtime_config_requires_tron_start_block() {
     let env = BTreeMap::from([(
         "ORMPINDEXER_ENABLED_CHAINS".to_owned(),

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -242,6 +242,100 @@ fn test_decode_native_graphql_log_preserves_metadata_in_legacy_row() {
 }
 
 #[test]
+fn test_decode_evm_indexed_topics_preserves_legacy_fields() {
+    let msg_hash = bytes32(0x44);
+    let accepted = DatalensLog {
+        topics: vec![ORMP_MESSAGE_ACCEPTED_TOPIC.to_owned(), bytes_hex(0x44)],
+        data: format!(
+            "0x{}",
+            hex::encode(encode(&[Token::Tuple(vec![
+                Token::Address(address(0x21)),
+                Token::Uint(U256::from(8)),
+                Token::Uint(U256::from(46)),
+                Token::Address(address(0x22)),
+                Token::Uint(U256::from(137)),
+                Token::Address(address(0x23)),
+                Token::Uint(U256::from(500_000)),
+                Token::Bytes(vec![0xab, 0xcd]),
+            ])]))
+        ),
+        ..log(ORMP_MESSAGE_ACCEPTED_TOPIC, ORMP_ADDRESS, Vec::new())
+    };
+    assert_eq!(
+        decode_evm_log(&accepted).expect("indexed MessageAccepted decodes"),
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: metadata(ORMP_ADDRESS),
+            msg_hash: bytes_hex(0x44),
+            channel: address_hex(0x21),
+            index: 8,
+            from_chain_id: 46,
+            from: address_hex(0x22),
+            to_chain_id: 137,
+            to: address_hex(0x23),
+            gas_limit: 500_000,
+            encoded: "0xabcd".to_owned(),
+        }
+    );
+
+    let assigned = DatalensLog {
+        topics: vec![
+            ORMP_MESSAGE_ASSIGNED_TOPIC.to_owned(),
+            bytes_hex(0x44),
+            address_topic(0x24),
+            address_topic(0x25),
+        ],
+        data: format!(
+            "0x{}",
+            hex::encode(encode(&[
+                Token::Uint(U256::from(9)),
+                Token::Uint(U256::from(10)),
+                Token::Bytes(vec![0x01, 0x02]),
+            ]))
+        ),
+        ..log(ORMP_MESSAGE_ASSIGNED_TOPIC, ORMP_ADDRESS, Vec::new())
+    };
+    assert_eq!(
+        decode_evm_log(&assigned).expect("indexed MessageAssigned decodes"),
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: metadata(ORMP_ADDRESS),
+            msg_hash: format!("0x{}", hex::encode(msg_hash)),
+            oracle: address_hex(0x24),
+            relayer: address_hex(0x25),
+            oracle_fee: 9,
+            relayer_fee: 10,
+            params: "0x0102".to_owned(),
+        }
+    );
+
+    let sent = DatalensLog {
+        topics: vec![MSGPORT_MESSAGE_SENT_TOPIC.to_owned(), bytes_hex(0x55)],
+        data: format!(
+            "0x{}",
+            hex::encode(encode(&[
+                Token::Address(address(0x30)),
+                Token::Uint(U256::from(42161)),
+                Token::Address(address(0x31)),
+                Token::Bytes(vec![0xaa]),
+                Token::Bytes(vec![0xbb, 0xcc]),
+            ]))
+        ),
+        ..log(MSGPORT_MESSAGE_SENT_TOPIC, MSGPORT_ADDRESS, Vec::new())
+    };
+    assert_eq!(
+        decode_evm_log(&sent).expect("indexed MessageSent decodes"),
+        LegacyOrmPEvent::MsgportMessageSent {
+            metadata: metadata(MSGPORT_ADDRESS),
+            msg_id: bytes_hex(0x55),
+            from_dapp: address_hex(0x30),
+            to_chain_id: 42161,
+            to_dapp: address_hex(0x31),
+            message: "0xaa".to_owned(),
+            params: "0xbbcc".to_owned(),
+        }
+    );
+}
+
+#[test]
 fn test_decode_errors_are_explicit() {
     let missing_topic = DatalensLog {
         topics: Vec::new(),
@@ -330,6 +424,10 @@ fn address(value: u64) -> H160 {
 
 fn address_hex(value: u64) -> String {
     format!("0x{}", hex::encode(address(value).as_bytes()))
+}
+
+fn address_topic(value: u64) -> String {
+    format!("0x{:0>64}", &address_hex(value)[2..])
 }
 
 fn bytes32(value: u8) -> Vec<u8> {

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -83,14 +83,32 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
         }])
         .await
         .expect("write accepted after assigned");
-    let late = sqlx::query_as::<_, (Option<String>, Option<String>)>(
-        "SELECT oracle, relayer FROM ormp_message_accepted WHERE id = $1",
+    let late = sqlx::query_as::<
+        _,
+        (
+            Option<String>,
+            Option<bool>,
+            Option<String>,
+            Option<String>,
+            Option<bool>,
+            Option<String>,
+        ),
+    >(
+        r#"SELECT oracle, oracle_assigned, oracle_assigned_fee::TEXT,
+                  relayer, relayer_assigned, relayer_assigned_fee::TEXT
+           FROM ormp_message_accepted
+           WHERE id = $1"#,
     )
     .bind("0xlate")
     .fetch_one(&pool)
     .await
     .expect("fetch late accepted row");
-    assert_eq!(late, (None, None));
+    assert_eq!(late.0.as_deref(), Some(ADDRESS_ORACLE[0]));
+    assert_eq!(late.1, Some(true));
+    assert_eq!(late.2.as_deref(), Some("55"));
+    assert_eq!(late.3.as_deref(), Some(ADDRESS_RELAYER[0]));
+    assert_eq!(late.4, Some(true));
+    assert_eq!(late.5.as_deref(), Some("66"));
 }
 
 fn legacy_events() -> Vec<LegacyOrmPEvent> {

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::BTreeMap};
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
 use ormpindexer::{
     checkpoint::{Checkpoint, InMemoryCheckpointStore, plan_next_range},
@@ -197,6 +197,72 @@ async fn test_runner_empty_logs_still_advance_after_successful_query_and_write()
 }
 
 #[tokio::test]
+async fn test_runner_skips_chain_when_checkpoint_is_ahead_of_datalens_head() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let reader = RecordingDatalensReader::new(Vec::new()).with_head(46, 9);
+    let runner = IndexerRunner::new(
+        config,
+        reader,
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let report = runner.run_once().await.expect("ahead checkpoint skips");
+
+    assert_eq!(report, RunnerReport::default());
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 10);
+}
+
+#[tokio::test]
+async fn test_runner_caps_query_range_at_datalens_head() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let reader = RecordingDatalensReader::new(Vec::new()).with_head(46, 12);
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let report = runner.run_once().await.expect("capped batch succeeds");
+
+    assert_eq!(report.checkpoints_advanced, 1);
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 13);
+    assert_eq!(reader.queries.borrow()[0].from_block, 10);
+    assert_eq!(reader.queries.borrow()[0].to_block, 12);
+}
+
+#[tokio::test]
 async fn test_runner_writer_failure_does_not_advance_checkpoint() {
     let env = BTreeMap::from([
         (
@@ -276,21 +342,37 @@ async fn test_runner_reports_and_advances_multiple_chains() {
     assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 25);
 }
 
+#[derive(Clone)]
 struct RecordingDatalensReader {
     logs: Vec<DatalensLog>,
-    queries: RefCell<Vec<DatalensLogQuery>>,
+    heads: BTreeMap<u64, u64>,
+    queries: Rc<RefCell<Vec<DatalensLogQuery>>>,
 }
 
 impl RecordingDatalensReader {
     fn new(logs: Vec<DatalensLog>) -> Self {
         Self {
             logs,
-            queries: RefCell::new(Vec::new()),
+            heads: BTreeMap::new(),
+            queries: Rc::new(RefCell::new(Vec::new())),
         }
+    }
+
+    fn with_head(mut self, chain_id: u64, head: u64) -> Self {
+        self.heads.insert(chain_id, head);
+        self
     }
 }
 
 impl DatalensLogReader for RecordingDatalensReader {
+    async fn latest_block(
+        &self,
+        chain_id: u64,
+        _finality_mode: FinalityMode,
+    ) -> anyhow::Result<u64> {
+        Ok(*self.heads.get(&chain_id).unwrap_or(&u64::MAX))
+    }
+
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult> {
         self.queries.borrow_mut().push(query);
         Ok(DatalensLogQueryResult {


### PR DESCRIPTION
## Summary
- Cap runner ranges by Datalens chain head and use Datalens native finality enums.
- Decode EVM indexed event parameters from topics for live ORMP logs.
- Run indexer and GraphQL/ops server together for the main run command.
- Remove misleading global dataset config and make accepted/assigned backfill order independent.

## Verification
- cargo fmt --check && cargo build && cargo test
- Local Datalens sync against Arbitrum block 466386813 wrote 3 events and advanced checkpoint to 466386814.
- Compared local accepted row with https://ormpindexer.ringdao.com/graphql for id 0xfdb7a1a17121192d5c692aba2a85d7f1ce5083387cc7f9cb665c0cd5b4414257: exact JSON match.
- Local GraphQL query returned the same row; schema introspection shows *Page types and no *Connection types.