### PR TITLE
feat(datalens): add startup warmup support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,11 +2,15 @@ use std::{collections::BTreeMap, env, fmt, time::Duration};
 
 use anyhow::{Context, bail};
 
-use crate::planner::{TRON_CHAIN_ID, default_chain_config};
+use crate::{
+    planner::{TRON_CHAIN_ID, default_chain_config},
+    warmup::DatalensWarmupConfig,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RuntimeConfig {
     pub datalens: DatalensConfig,
+    pub warmup: DatalensWarmupConfig,
     pub database_url: Option<SecretString>,
     pub enabled_chains: Vec<ChainConfig>,
     pub batch_size: u64,
@@ -50,6 +54,16 @@ impl RuntimeConfig {
             .map(|chain_id| ChainConfig::from_env_map(env, chain_id, start_block))
             .collect::<anyhow::Result<Vec<_>>>()?;
 
+        let batch_size = optional_u64(env, "ORMPINDEXER_BATCH_SIZE")?.unwrap_or(1_000);
+        if batch_size == 0 {
+            bail!("ORMPINDEXER_BATCH_SIZE must be greater than zero");
+        }
+        let warmup_chunk_size =
+            optional_u64(env, "ORMPINDEXER_DATALENS_WARMUP_CHUNK_SIZE")?.unwrap_or(batch_size);
+        if warmup_chunk_size == 0 {
+            bail!("ORMPINDEXER_DATALENS_WARMUP_CHUNK_SIZE must be greater than zero");
+        }
+
         Ok(Self {
             datalens: DatalensConfig {
                 endpoint: optional_env(env, "ORMPINDEXER_DATALENS_ENDPOINT")
@@ -58,9 +72,22 @@ impl RuntimeConfig {
                     .unwrap_or_else(|| "ormpindexer".to_owned()),
                 token: optional_env(env, "ORMPINDEXER_DATALENS_TOKEN").map(SecretString::new),
             },
+            warmup: DatalensWarmupConfig {
+                enabled: optional_bool(env, "ORMPINDEXER_DATALENS_WARMUP_ENABLED")?
+                    .unwrap_or(false),
+                ensure_on_startup: optional_bool(
+                    env,
+                    "ORMPINDEXER_DATALENS_WARMUP_ENSURE_ON_STARTUP",
+                )?
+                .unwrap_or(true),
+                required: optional_bool(env, "ORMPINDEXER_DATALENS_WARMUP_REQUIRED")?
+                    .unwrap_or(false),
+                chunk_size: warmup_chunk_size,
+                end_block: optional_u64(env, "ORMPINDEXER_DATALENS_WARMUP_END_BLOCK")?,
+            },
             database_url: optional_env(env, "ORMPINDEXER_DATABASE_URL").map(SecretString::new),
             enabled_chains,
-            batch_size: optional_u64(env, "ORMPINDEXER_BATCH_SIZE")?.unwrap_or(1_000),
+            batch_size,
             start_block: start_block.unwrap_or(0),
             finality_mode: optional_env(env, "ORMPINDEXER_FINALITY_MODE")
                 .as_deref()
@@ -190,6 +217,16 @@ fn optional_u64(env: &BTreeMap<String, String>, key: &str) -> anyhow::Result<Opt
             value
                 .parse::<u64>()
                 .with_context(|| format!("parse {key} as u64"))
+        })
+        .transpose()
+}
+
+fn optional_bool(env: &BTreeMap<String, String>, key: &str) -> anyhow::Result<Option<bool>> {
+    optional_env(env, key)
+        .map(|value| match value.as_str() {
+            "true" | "1" | "yes" => Ok(true),
+            "false" | "0" | "no" => Ok(false),
+            _ => bail!("{key} must be true or false"),
         })
         .transpose()
 }

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -4,6 +4,10 @@ use sha2::{Digest, Sha256};
 
 use crate::config::{DatalensConfig, FinalityMode};
 use crate::planner::TRON_CHAIN_ID;
+use crate::warmup::{
+    DatalensWarmupEnsurer, DatalensWarmupSubmitRequest, WarmupSubmitApiResponse,
+    WarmupSubmitResponse,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DatalensLogQuery {
@@ -82,6 +86,13 @@ impl DatalensHttpClient {
         )
     }
 
+    fn warmup_tasks_endpoint(&self) -> String {
+        format!(
+            "{}/v1/warmup/tasks",
+            self.config.endpoint.trim_end_matches('/')
+        )
+    }
+
     fn chain_head_endpoint(
         &self,
         chain_id: u64,
@@ -93,6 +104,39 @@ impl DatalensHttpClient {
             self.config.endpoint.trim_end_matches('/'),
             chain_head_finality(finality_mode),
         ))
+    }
+
+    pub async fn submit_warmup_task(
+        &self,
+        request: DatalensWarmupSubmitRequest,
+    ) -> anyhow::Result<WarmupSubmitResponse> {
+        let mut builder = self
+            .http
+            .post(self.warmup_tasks_endpoint())
+            .header("x-datalens-application", &self.config.application)
+            .json(&request);
+        if let Some(token) = &self.config.token {
+            builder = builder.bearer_auth(token.expose_secret());
+        }
+
+        let response = builder.send().await?;
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            anyhow::bail!("Datalens warmup submit failed with status {status}: {body}");
+        }
+
+        let payload: WarmupSubmitApiResponse = serde_json::from_str(&body)?;
+        Ok(payload.into_submit_response())
+    }
+}
+
+impl DatalensWarmupEnsurer for DatalensHttpClient {
+    async fn ensure_warmup_task(
+        &self,
+        request: DatalensWarmupSubmitRequest,
+    ) -> anyhow::Result<WarmupSubmitResponse> {
+        self.submit_warmup_task(request).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod planner;
 pub mod runner;
 pub mod runtime;
 pub mod schema;
+pub mod warmup;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -50,8 +50,10 @@ where
 {
     pub async fn run_loop(&self) -> anyhow::Result<()> {
         loop {
-            self.run_once().await?;
-            sleep(self.config.poll_interval).await;
+            let report = self.run_once().await?;
+            if should_sleep_after_run(&report) {
+                sleep(self.config.poll_interval).await;
+            }
         }
     }
 
@@ -144,5 +146,29 @@ where
         }
 
         Ok(report)
+    }
+}
+
+fn should_sleep_after_run(report: &RunnerReport) -> bool {
+    report.ranges_queried == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_should_sleep_after_run_when_no_ranges_queried() {
+        assert!(should_sleep_after_run(&RunnerReport::default()));
+    }
+
+    #[test]
+    fn test_should_not_sleep_after_run_when_backlog_advanced() {
+        let report = RunnerReport {
+            ranges_queried: 1,
+            ..RunnerReport::default()
+        };
+
+        assert!(!should_sleep_after_run(&report));
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,6 +7,7 @@ use crate::{
     decoder::EvmEventDecoder,
     graphql::{build_router, build_schema},
     runner::IndexerRunner,
+    warmup::ensure_startup_warmup,
 };
 
 pub async fn run(run_once: bool) -> anyhow::Result<()> {
@@ -28,10 +29,14 @@ pub async fn run(run_once: bool) -> anyhow::Result<()> {
         config.finality_mode.as_str(),
     );
 
+    let client = DatalensHttpClient::new(config.datalens.clone());
+    let checkpoints = PostgresCheckpointStore::new(pool.clone());
+    ensure_datalens_warmup_on_startup(&config, &checkpoints, &client).await?;
+
     let runner = IndexerRunner::new(
         config.clone(),
-        DatalensHttpClient::new(config.datalens.clone()),
-        PostgresCheckpointStore::new(pool.clone()),
+        client,
+        checkpoints,
         EvmEventDecoder,
         PostgresEventWriter::new(pool),
     );
@@ -65,10 +70,14 @@ pub async fn run_with_server(listen_addr: &str) -> anyhow::Result<()> {
         listen_addr,
     );
 
+    let client = DatalensHttpClient::new(config.datalens.clone());
+    let checkpoints = PostgresCheckpointStore::new(pool.clone());
+    ensure_datalens_warmup_on_startup(&config, &checkpoints, &client).await?;
+
     let runner = IndexerRunner::new(
         config.clone(),
-        DatalensHttpClient::new(config.datalens.clone()),
-        PostgresCheckpointStore::new(pool.clone()),
+        client,
+        checkpoints,
         EvmEventDecoder,
         PostgresEventWriter::new(pool.clone()),
     );
@@ -83,6 +92,15 @@ pub async fn run_with_server(listen_addr: &str) -> anyhow::Result<()> {
             .context("serve GraphQL server")
     },)?;
 
+    Ok(())
+}
+
+async fn ensure_datalens_warmup_on_startup(
+    config: &RuntimeConfig,
+    checkpoints: &PostgresCheckpointStore,
+    client: &DatalensHttpClient,
+) -> anyhow::Result<()> {
+    ensure_startup_warmup(config, checkpoints, client).await?;
     Ok(())
 }
 

--- a/src/warmup.rs
+++ b/src/warmup.rs
@@ -1,0 +1,252 @@
+use anyhow::ensure;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    checkpoint::CheckpointStore,
+    config::{ChainConfig, RuntimeConfig},
+    datalens::evm_chain_name,
+    planner::{EVM_LOGS_DATASET, TRON_CHAIN_ID, chain_dataset},
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensWarmupConfig {
+    pub enabled: bool,
+    pub ensure_on_startup: bool,
+    pub required: bool,
+    pub chunk_size: u64,
+    pub end_block: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DatalensWarmupEnsureOutcome {
+    Disabled,
+    SkippedNonEvm {
+        chain_id: u64,
+        dataset: String,
+    },
+    Failed {
+        chain_id: u64,
+        error: String,
+    },
+    Submitted {
+        chain_id: u64,
+        task_id: String,
+        created: bool,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DatalensWarmupSubmitRequest {
+    pub chain: WarmupChainIdentity,
+    pub dataset_key: String,
+    pub selector: WarmupSelector,
+    pub range_kind: WarmupRangeKind,
+    pub start: u64,
+    pub end: Option<u64>,
+    pub mode: String,
+    pub chunk_policy: WarmupChunkPolicy,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupChainIdentity {
+    pub family: String,
+    pub configured_name: String,
+    pub network_id: WarmupNetworkId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupNetworkId {
+    pub kind: String,
+    pub value: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupSelector {
+    pub kind: String,
+    pub value: WarmupEvmLogsSelector,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupEvmLogsSelector {
+    pub addresses: Vec<String>,
+    pub topics: Vec<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupRangeKind {
+    pub kind: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct WarmupChunkPolicy {
+    pub max_range_len: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WarmupSubmitResponse {
+    pub task_id: String,
+    pub created: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct WarmupSubmitApiResponse {
+    pub task_id: WarmupTaskIdResponse,
+    pub created: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum WarmupTaskIdResponse {
+    String(String),
+    Object { task_id: String },
+}
+
+impl WarmupSubmitApiResponse {
+    pub(crate) fn into_submit_response(self) -> WarmupSubmitResponse {
+        WarmupSubmitResponse {
+            task_id: self.task_id.into_string(),
+            created: self.created,
+        }
+    }
+}
+
+impl WarmupTaskIdResponse {
+    fn into_string(self) -> String {
+        match self {
+            Self::String(value) => value,
+            Self::Object { task_id } => task_id,
+        }
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait DatalensWarmupEnsurer {
+    async fn ensure_warmup_task(
+        &self,
+        request: DatalensWarmupSubmitRequest,
+    ) -> anyhow::Result<WarmupSubmitResponse>;
+}
+
+pub async fn ensure_startup_warmup<C, E>(
+    config: &RuntimeConfig,
+    checkpoints: &C,
+    ensurer: &E,
+) -> anyhow::Result<Vec<DatalensWarmupEnsureOutcome>>
+where
+    C: CheckpointStore,
+    E: DatalensWarmupEnsurer,
+{
+    if !config.warmup.enabled || !config.warmup.ensure_on_startup {
+        log::info!(
+            "Datalens follow_query warmup startup ensure disabled enabled={} ensure_on_startup={}",
+            config.warmup.enabled,
+            config.warmup.ensure_on_startup
+        );
+        return Ok(vec![DatalensWarmupEnsureOutcome::Disabled]);
+    }
+
+    let mut outcomes = Vec::new();
+    for chain in &config.enabled_chains {
+        let dataset = chain_dataset(chain.chain_id)?;
+        if chain.chain_id == TRON_CHAIN_ID || dataset != EVM_LOGS_DATASET {
+            log::info!(
+                "skipping Datalens follow_query warmup for non-EVM chain_id={} dataset={}",
+                chain.chain_id,
+                dataset
+            );
+            outcomes.push(DatalensWarmupEnsureOutcome::SkippedNonEvm {
+                chain_id: chain.chain_id,
+                dataset: dataset.to_owned(),
+            });
+            continue;
+        }
+
+        let checkpoint = checkpoints
+            .read_or_create(chain.chain_id, dataset, chain.start_block)
+            .await?;
+        let request = evm_warmup_request(config, chain, checkpoint.next_block)?;
+        match ensurer.ensure_warmup_task(request).await {
+            Ok(response) => {
+                log::info!(
+                    "Datalens follow_query warmup task ensured chain_id={} dataset={} checkpoint_next_block={} task_id={} created={}",
+                    chain.chain_id,
+                    dataset,
+                    checkpoint.next_block,
+                    response.task_id,
+                    response.created
+                );
+                outcomes.push(DatalensWarmupEnsureOutcome::Submitted {
+                    chain_id: chain.chain_id,
+                    task_id: response.task_id,
+                    created: response.created,
+                });
+            }
+            Err(error) if config.warmup.required => {
+                log::warn!(
+                    "Datalens follow_query warmup startup ensure failed; failing startup chain_id={} dataset={} required=true error={}",
+                    chain.chain_id,
+                    dataset,
+                    error
+                );
+                return Err(error);
+            }
+            Err(error) => {
+                log::warn!(
+                    "Datalens follow_query warmup startup ensure failed; continuing indexing chain_id={} dataset={} required=false error={}",
+                    chain.chain_id,
+                    dataset,
+                    error
+                );
+                outcomes.push(DatalensWarmupEnsureOutcome::Failed {
+                    chain_id: chain.chain_id,
+                    error: error.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(outcomes)
+}
+
+pub fn evm_warmup_request(
+    config: &RuntimeConfig,
+    chain: &ChainConfig,
+    start_block: u64,
+) -> anyhow::Result<DatalensWarmupSubmitRequest> {
+    ensure!(
+        !chain.contracts.is_empty(),
+        "Datalens warmup selector requires at least one EVM contract address"
+    );
+    ensure!(
+        !chain.topics.is_empty(),
+        "Datalens warmup selector requires at least one EVM event topic"
+    );
+
+    Ok(DatalensWarmupSubmitRequest {
+        chain: WarmupChainIdentity {
+            family: "Evm".to_owned(),
+            configured_name: evm_chain_name(chain.chain_id)?.to_owned(),
+            network_id: WarmupNetworkId {
+                kind: "numeric".to_owned(),
+                value: chain.chain_id,
+            },
+        },
+        dataset_key: EVM_LOGS_DATASET.to_owned(),
+        selector: WarmupSelector {
+            kind: "evm_logs".to_owned(),
+            value: WarmupEvmLogsSelector {
+                addresses: chain.contracts.clone(),
+                topics: vec![chain.topics.clone()],
+            },
+        },
+        range_kind: WarmupRangeKind {
+            kind: config.finality_mode.as_str().to_owned(),
+        },
+        start: start_block,
+        end: config.warmup.end_block,
+        mode: "follow_query".to_owned(),
+        chunk_policy: WarmupChunkPolicy {
+            max_range_len: config.warmup.chunk_size,
+        },
+    })
+}

--- a/src/warmup.rs
+++ b/src/warmup.rs
@@ -240,7 +240,7 @@ pub fn evm_warmup_request(
             },
         },
         range_kind: WarmupRangeKind {
-            kind: config.finality_mode.as_str().to_owned(),
+            kind: "block".to_owned(),
         },
         start: start_block,
         end: config.warmup.end_block,

--- a/tests/datalens_warmup.rs
+++ b/tests/datalens_warmup.rs
@@ -53,7 +53,7 @@ fn test_evm_warmup_request_uses_ormp_selector_and_checkpoint_start() {
                     "topics": [["0xaaa", "0xbbb"]]
                 }
             },
-            "range_kind": {"kind": "durable"},
+            "range_kind": {"kind": "block"},
             "start": 466386813,
             "end": null,
             "mode": "follow_query",

--- a/tests/datalens_warmup.rs
+++ b/tests/datalens_warmup.rs
@@ -1,0 +1,209 @@
+use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+
+use ormpindexer::{
+    checkpoint::InMemoryCheckpointStore,
+    config::{FinalityMode, RuntimeConfig},
+    warmup::{
+        DatalensWarmupEnsureOutcome, DatalensWarmupEnsurer, DatalensWarmupSubmitRequest,
+        WarmupSubmitResponse, ensure_startup_warmup, evm_warmup_request,
+    },
+};
+
+#[test]
+fn test_evm_warmup_request_uses_ormp_selector_and_checkpoint_start() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "42161".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "250".to_owned()),
+        ("ORMPINDEXER_FINALITY_MODE".to_owned(), "durable".to_owned()),
+        (
+            "ORMPINDEXER_CHAIN_42161_CONTRACTS".to_owned(),
+            "0x111,0x222".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_CHAIN_42161_TOPICS".to_owned(),
+            "0xaaa,0xbbb".to_owned(),
+        ),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let chain = config.chain(42161).expect("Arbitrum chain");
+
+    let request = evm_warmup_request(&config, chain, 466_386_813).expect("build request");
+
+    assert_eq!(
+        serde_json::to_value(request).expect("serialize request"),
+        serde_json::json!({
+            "chain": {
+                "family": "Evm",
+                "configured_name": "arbitrum",
+                "network_id": {"kind": "numeric", "value": 42161}
+            },
+            "dataset_key": "evm.logs",
+            "selector": {
+                "kind": "evm_logs",
+                "value": {
+                    "addresses": ["0x111", "0x222"],
+                    "topics": [["0xaaa", "0xbbb"]]
+                }
+            },
+            "range_kind": {"kind": "durable"},
+            "start": 466386813,
+            "end": null,
+            "mode": "follow_query",
+            "chunk_policy": {"max_range_len": 250}
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_startup_warmup_failure_continues_when_not_required() {
+    let config = warmup_config(false);
+    let checkpoints = InMemoryCheckpointStore::default();
+    let ensurer = FailingWarmupEnsurer;
+
+    let outcomes = ensure_startup_warmup(&config, &checkpoints, &ensurer)
+        .await
+        .expect("non-required warmup failure continues");
+
+    assert_eq!(
+        outcomes,
+        vec![DatalensWarmupEnsureOutcome::Failed {
+            chain_id: 46,
+            error: "submit failed".to_owned()
+        }]
+    );
+}
+
+#[tokio::test]
+async fn test_startup_warmup_failure_fails_when_required() {
+    let config = warmup_config(true);
+    let checkpoints = InMemoryCheckpointStore::default();
+    let ensurer = FailingWarmupEnsurer;
+
+    let error = ensure_startup_warmup(&config, &checkpoints, &ensurer)
+        .await
+        .expect_err("required warmup failure fails startup");
+
+    assert!(error.to_string().contains("submit failed"));
+}
+
+#[tokio::test]
+async fn test_startup_warmup_skips_tron() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_WARMUP_ENABLED".to_owned(),
+            "true".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_ENABLED_CHAINS".to_owned(),
+            "728126428".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_CHAIN_728126428_START_BLOCK".to_owned(),
+            "100".to_owned(),
+        ),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let ensurer = RecordingWarmupEnsurer::new(WarmupSubmitResponse {
+        task_id: "unused".to_owned(),
+        created: true,
+    });
+
+    let outcomes = ensure_startup_warmup(&config, &checkpoints, &ensurer)
+        .await
+        .expect("Tron warmup skips");
+
+    assert_eq!(
+        outcomes,
+        vec![DatalensWarmupEnsureOutcome::SkippedNonEvm {
+            chain_id: 728_126_428,
+            dataset: "tron.events".to_owned()
+        }]
+    );
+    assert!(ensurer.requests.borrow().is_empty());
+}
+
+fn warmup_config(required: bool) -> RuntimeConfig {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_WARMUP_ENABLED".to_owned(),
+            "true".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_WARMUP_REQUIRED".to_owned(),
+            required.to_string(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "250".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "1000".to_owned()),
+        (
+            "ORMPINDEXER_CHAIN_46_CONTRACTS".to_owned(),
+            "0x111".to_owned(),
+        ),
+        ("ORMPINDEXER_CHAIN_46_TOPICS".to_owned(), "0xaaa".to_owned()),
+    ]);
+
+    let mut config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    config.finality_mode = FinalityMode::Finalized;
+    config
+}
+
+struct FailingWarmupEnsurer;
+
+impl DatalensWarmupEnsurer for FailingWarmupEnsurer {
+    async fn ensure_warmup_task(
+        &self,
+        _request: DatalensWarmupSubmitRequest,
+    ) -> anyhow::Result<WarmupSubmitResponse> {
+        anyhow::bail!("submit failed");
+    }
+}
+
+#[derive(Clone)]
+struct RecordingWarmupEnsurer {
+    response: WarmupSubmitResponse,
+    requests: Rc<RefCell<Vec<DatalensWarmupSubmitRequest>>>,
+}
+
+impl RecordingWarmupEnsurer {
+    fn new(response: WarmupSubmitResponse) -> Self {
+        Self {
+            response,
+            requests: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+}
+
+impl DatalensWarmupEnsurer for RecordingWarmupEnsurer {
+    async fn ensure_warmup_task(
+        &self,
+        request: DatalensWarmupSubmitRequest,
+    ) -> anyhow::Result<WarmupSubmitResponse> {
+        self.requests.borrow_mut().push(request);
+        Ok(self.response.clone())
+    }
+}

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -34,6 +34,26 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
         ("ORMPINDEXER_START_BLOCK".to_owned(), "1000".to_owned()),
         ("ORMPINDEXER_FINALITY_MODE".to_owned(), "durable".to_owned()),
         (
+            "ORMPINDEXER_DATALENS_WARMUP_ENABLED".to_owned(),
+            "true".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_WARMUP_ENSURE_ON_STARTUP".to_owned(),
+            "false".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_WARMUP_REQUIRED".to_owned(),
+            "true".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_WARMUP_CHUNK_SIZE".to_owned(),
+            "500".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_WARMUP_END_BLOCK".to_owned(),
+            "9000".to_owned(),
+        ),
+        (
             "ORMPINDEXER_CHAIN_1_CONTRACTS".to_owned(),
             "0x111,0x222".to_owned(),
         ),
@@ -61,6 +81,11 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
     assert_eq!(config.batch_size, 250);
     assert_eq!(config.start_block, 1000);
     assert_eq!(config.finality_mode, FinalityMode::Durable);
+    assert!(config.warmup.enabled);
+    assert!(!config.warmup.ensure_on_startup);
+    assert!(config.warmup.required);
+    assert_eq!(config.warmup.chunk_size, 500);
+    assert_eq!(config.warmup.end_block, Some(9000));
     assert_eq!(
         config.chain(1).expect("chain 1").contracts,
         vec!["0x111", "0x222"]
@@ -70,6 +95,57 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
         vec!["0xaaa", "0xbbb"]
     );
     assert_eq!(config.chain(46).expect("chain 46").start_block, 2000);
+}
+
+#[test]
+fn test_runtime_config_from_env_map_reads_warmup_defaults() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "250".to_owned()),
+    ]);
+
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+
+    assert!(!config.warmup.enabled);
+    assert!(config.warmup.ensure_on_startup);
+    assert!(!config.warmup.required);
+    assert_eq!(config.warmup.chunk_size, 250);
+    assert_eq!(config.warmup.end_block, None);
+}
+
+#[test]
+fn test_runtime_config_rejects_zero_warmup_chunk_size() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        (
+            "ORMPINDEXER_DATALENS_WARMUP_CHUNK_SIZE".to_owned(),
+            "0".to_owned(),
+        ),
+    ]);
+
+    let error = RuntimeConfig::from_env_map(&env).expect_err("zero warmup chunk size is invalid");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ORMPINDEXER_DATALENS_WARMUP_CHUNK_SIZE must be greater than zero")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add startup Datalens warmup ensure for EVM ORMP chains using current contract/topic selectors and checkpoint start blocks
- submit follow_query warmup tasks to /v1/warmup/tasks with optional bearer auth, skipping Tron for now
- avoid sleeping between runner passes while backlog ranges are still advancing

## Verification
- cargo fmt --check
- cargo test
- cargo build

## Review
- spec compliance subagent: PASS
- code quality subagent: APPROVED
