### PR TITLE
fix(decoder): support indexed hash imported oracle

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -52,7 +52,7 @@ pub fn decode_evm_log(log: &DatalensLog) -> anyhow::Result<LegacyOrmPEvent> {
     let data = decode_hex(&log.data).context("decode EVM log data")?;
 
     match topic0.as_str() {
-        ORMP_HASH_IMPORTED_TOPIC => decode_hash_imported(metadata, &data),
+        ORMP_HASH_IMPORTED_TOPIC => decode_hash_imported(metadata, &log.topics, &data),
         ORMP_MESSAGE_ACCEPTED_TOPIC => decode_message_accepted(metadata, &log.topics, &data),
         ORMP_MESSAGE_ASSIGNED_TOPIC => decode_message_assigned(metadata, &log.topics, &data),
         ORMP_MESSAGE_DISPATCHED_TOPIC => decode_message_dispatched(metadata, &log.topics, &data),
@@ -255,8 +255,30 @@ fn decode_tron_signature_submittion(
 
 fn decode_hash_imported(
     metadata: ChainLogMetadata,
+    topics: &[String],
     data: &[u8],
 ) -> anyhow::Result<LegacyOrmPEvent> {
+    if topics.len() > 1 {
+        let mut tokens = decode_event(
+            &[
+                ParamType::Uint(256),
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::FixedBytes(32),
+            ],
+            data,
+        )?;
+        return Ok(LegacyOrmPEvent::HashImported {
+            target_chain_id: metadata.chain_id,
+            metadata,
+            oracle: topic_address(topics, 1, "oracle")?,
+            src_chain_id: token_uint(take(&mut tokens, "chainId")?)?,
+            channel: token_address(take(&mut tokens, "channel")?)?,
+            msg_index: token_uint(take(&mut tokens, "msgIndex")?)?,
+            hash: token_fixed_bytes(take(&mut tokens, "hash")?)?,
+        });
+    }
+
     let mut tokens = decode_event(
         &[
             ParamType::Address,

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -244,6 +244,32 @@ fn test_decode_native_graphql_log_preserves_metadata_in_legacy_row() {
 #[test]
 fn test_decode_evm_indexed_topics_preserves_legacy_fields() {
     let msg_hash = bytes32(0x44);
+    let hash_imported = DatalensLog {
+        topics: vec![ORMP_HASH_IMPORTED_TOPIC.to_owned(), address_topic(0x24)],
+        data: format!(
+            "0x{}",
+            hex::encode(encode(&[
+                Token::Uint(U256::from(46)),
+                Token::Address(address(0x21)),
+                Token::Uint(U256::from(7)),
+                Token::FixedBytes(msg_hash.clone()),
+            ]))
+        ),
+        ..log(ORMP_HASH_IMPORTED_TOPIC, ORMP_ADDRESS, Vec::new())
+    };
+    assert_eq!(
+        decode_evm_log(&hash_imported).expect("indexed HashImported decodes"),
+        LegacyOrmPEvent::HashImported {
+            metadata: metadata(ORMP_ADDRESS),
+            src_chain_id: 46,
+            target_chain_id: 1,
+            oracle: address_hex(0x24),
+            channel: address_hex(0x21),
+            msg_index: 7,
+            hash: bytes_hex(0x44),
+        }
+    );
+
     let accepted = DatalensLog {
         topics: vec![ORMP_MESSAGE_ACCEPTED_TOPIC.to_owned(), bytes_hex(0x44)],
         data: format!(


### PR DESCRIPTION
## Summary
- support HashImported logs where oracle is indexed in topic1 and the ABI data contains chainId/channel/msgIndex/hash
- add regression coverage for the indexed HashImported shape observed on Arbitrum

## Verification
- cargo fmt --check
- cargo test
- cargo build
