### PR TITLE
perf(indexer): run Datalens chains concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,6 +1609,7 @@ dependencies = [
  "axum",
  "clap",
  "ethabi",
+ "futures-util",
  "hex",
  "log",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ async-graphql-axum = "7.0.17"
 axum = "0.8.7"
 clap = { version = "4.6.1", features = ["derive"] }
 ethabi = "18.0.0"
+futures-util = "0.3.31"
 hex = "0.4.3"
 log = "0.4.30"
 reqwest = { version = "0.12.26", default-features = false, features = ["json", "rustls-tls"] }

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
 
+use anyhow::Context;
+
 use crate::config::{DatalensConfig, FinalityMode};
 use crate::planner::TRON_CHAIN_ID;
 use crate::warmup::{
@@ -241,19 +243,8 @@ pub fn logs_from_native_query_payload(
 }
 
 fn native_log_rows(rows: &serde_json::Value) -> anyhow::Result<Vec<NativeLogRow>> {
-    if rows.is_array() {
-        return Ok(serde_json::from_value(rows.clone())?);
-    }
-
-    if let Some(value) = rows.pointer("/rows/rows") {
-        return Ok(serde_json::from_value(value.clone())?);
-    }
-
-    if let Some(value) = rows.pointer("/rows") {
-        return Ok(serde_json::from_value(value.clone())?);
-    }
-
-    anyhow::bail!("Datalens native query response missing evm log rows")
+    let rows = native_rows(rows).context("Datalens native query response missing evm log rows")?;
+    Ok(serde_json::from_value(rows.clone())?)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -367,19 +358,17 @@ impl NativeTronEventRow {
 }
 
 fn native_tron_event_rows(rows: &serde_json::Value) -> anyhow::Result<Vec<NativeTronEventRow>> {
+    let rows =
+        native_rows(rows).context("Datalens native query response missing Tron event rows")?;
+    Ok(serde_json::from_value(rows.clone())?)
+}
+
+fn native_rows(rows: &serde_json::Value) -> Option<&serde_json::Value> {
     if rows.is_array() {
-        return Ok(serde_json::from_value(rows.clone())?);
+        return Some(rows);
     }
 
-    if let Some(value) = rows.pointer("/rows/rows") {
-        return Ok(serde_json::from_value(value.clone())?);
-    }
-
-    if let Some(value) = rows.pointer("/rows") {
-        return Ok(serde_json::from_value(value.clone())?);
-    }
-
-    anyhow::bail!("Datalens native query response missing Tron event rows")
+    rows.get("rows").and_then(native_rows)
 }
 
 fn evm_query_input(query: &DatalensLogQuery) -> anyhow::Result<serde_json::Value> {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, bail, ensure};
-use ethabi::{ParamType, Token, decode};
+use ethabi::{ParamType, Token, decode, ethereum_types::U256};
 use serde_json::{Map, Value};
 
 use crate::{
@@ -58,7 +58,9 @@ pub fn decode_evm_log(log: &DatalensLog) -> anyhow::Result<LegacyOrmPEvent> {
         ORMP_MESSAGE_DISPATCHED_TOPIC => decode_message_dispatched(metadata, &log.topics, &data),
         MSGPORT_MESSAGE_RECV_TOPIC => decode_msgport_message_recv(metadata, &log.topics, &data),
         MSGPORT_MESSAGE_SENT_TOPIC => decode_msgport_message_sent(metadata, &log.topics, &data),
-        SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC => decode_signature_submittion(metadata, &data),
+        SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC => {
+            decode_signature_submittion(metadata, &log.topics, &data)
+        }
         _ => bail!("unsupported ORMP EVM event topic0 {topic0}"),
     }
 }
@@ -521,8 +523,25 @@ fn decode_msgport_message_sent(
 
 fn decode_signature_submittion(
     metadata: ChainLogMetadata,
+    topics: &[String],
     data: &[u8],
 ) -> anyhow::Result<LegacyOrmPEvent> {
+    if topics.len() > 3 {
+        let mut tokens = decode_event(
+            &[ParamType::Uint(256), ParamType::Bytes, ParamType::Bytes],
+            data,
+        )?;
+        return Ok(LegacyOrmPEvent::SignatureSubmittion {
+            metadata,
+            chain_id: topic_uint(topics, 1, "chainId")?,
+            channel: topic_address(topics, 2, "channel")?,
+            signer: topic_address(topics, 3, "signer")?,
+            msg_index: token_uint(take(&mut tokens, "msgIndex")?)?,
+            signature: token_bytes(take(&mut tokens, "signature")?)?,
+            data: token_bytes(take(&mut tokens, "data")?)?,
+        });
+    }
+
     let mut tokens = decode_event(
         &[
             ParamType::Uint(256),
@@ -619,6 +638,24 @@ fn topic_address(topics: &[String], index: usize, name: &str) -> anyhow::Result<
         "EVM indexed topic {name} must be 32 bytes"
     );
     Ok(format!("0x{}", &address[24..64]))
+}
+
+fn topic_uint(topics: &[String], index: usize, name: &str) -> anyhow::Result<u128> {
+    let topic = topics
+        .get(index)
+        .with_context(|| format!("EVM indexed topic {name} is missing"))?;
+    let topic = normalize_hex(topic)?;
+    let value = U256::from_str_radix(
+        topic
+            .strip_prefix("0x")
+            .context("normalized topic is missing 0x prefix")?,
+        16,
+    )?;
+    ensure!(
+        value.bits() <= 128,
+        "EVM indexed topic {name} overflows u128"
+    );
+    Ok(value.as_u128())
 }
 
 fn normalize_hex(value: &str) -> anyhow::Result<String> {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,10 +1,11 @@
 use tokio::time::sleep;
 
 use anyhow::Context;
+use futures_util::{StreamExt, stream::FuturesUnordered};
 
 use crate::{
-    checkpoint::{CheckpointStore, plan_next_range},
-    config::RuntimeConfig,
+    checkpoint::{BlockRange, CheckpointStore, plan_next_range},
+    config::{ChainConfig, RuntimeConfig},
     database::EventWriter,
     datalens::{DatalensLogQuery, DatalensLogReader},
     decoder::EventDecoder,
@@ -19,6 +20,43 @@ pub struct RunnerReport {
     pub records_decoded: u64,
     pub records_written: u64,
     pub checkpoints_advanced: u64,
+}
+
+impl RunnerReport {
+    fn add_chain_report(&mut self, chain_report: ChainRunReport) {
+        self.chains_processed += chain_report.chains_processed;
+        self.ranges_queried += chain_report.ranges_queried;
+        self.records_read += chain_report.records_read;
+        self.records_decoded += chain_report.records_decoded;
+        self.records_written += chain_report.records_written;
+        self.checkpoints_advanced += chain_report.checkpoints_advanced;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct ChainRunReport {
+    chains_processed: u64,
+    ranges_queried: u64,
+    records_read: u64,
+    records_decoded: u64,
+    records_written: u64,
+    checkpoints_advanced: u64,
+}
+
+trait RunReport {
+    fn ranges_queried(&self) -> u64;
+}
+
+impl RunReport for RunnerReport {
+    fn ranges_queried(&self) -> u64 {
+        self.ranges_queried
+    }
+}
+
+impl RunReport for ChainRunReport {
+    fn ranges_queried(&self) -> u64 {
+        self.ranges_queried
+    }
 }
 
 pub struct IndexerRunner<R, C, D, W> {
@@ -49,8 +87,24 @@ where
     W: EventWriter,
 {
     pub async fn run_loop(&self) -> anyhow::Result<()> {
+        let mut runs = self
+            .config
+            .enabled_chains
+            .iter()
+            .cloned()
+            .map(|chain| self.run_chain_loop(chain))
+            .collect::<FuturesUnordered<_>>();
+
+        while let Some(result) = runs.next().await {
+            result?;
+        }
+
+        Ok(())
+    }
+
+    async fn run_chain_loop(&self, chain: ChainConfig) -> anyhow::Result<()> {
         loop {
-            let report = self.run_once().await?;
+            let report = self.run_chain_once(chain.clone()).await?;
             if should_sleep_after_run(&report) {
                 sleep(self.config.poll_interval).await;
             }
@@ -59,98 +113,167 @@ where
 
     pub async fn run_once(&self) -> anyhow::Result<RunnerReport> {
         let mut report = RunnerReport::default();
+        let mut runs = self
+            .config
+            .enabled_chains
+            .iter()
+            .cloned()
+            .map(|chain| self.run_chain_once(chain))
+            .collect::<FuturesUnordered<_>>();
 
-        for chain in &self.config.enabled_chains {
-            let dataset = chain_dataset(chain.chain_id)?;
-            let checkpoint = self
-                .checkpoints
-                .read_or_create(chain.chain_id, dataset, chain.start_block)
-                .await?;
-            let target_block = self
-                .reader
-                .latest_block(chain.chain_id, self.config.finality_mode)
-                .await
-                .with_context(|| {
-                    format!("query Datalens chain head for chain {}", chain.chain_id)
-                })?;
-            if checkpoint.next_block > target_block {
-                log::info!(
-                    "skipping ORMP Datalens chain_id={} dataset={} checkpoint_next_block={} target_block={} checkpoint_ahead_of_target=true",
-                    chain.chain_id,
-                    dataset,
-                    checkpoint.next_block,
-                    target_block,
-                );
-                continue;
-            }
-
-            let mut range = plan_next_range(&checkpoint, self.config.batch_size)?;
-            range.to_block = range.to_block.min(target_block);
-
-            log::info!(
-                "querying ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={} target_block={} batch_size={} contracts={} topics={} finality={}",
-                chain.chain_id,
-                dataset,
-                range.from_block,
-                range.to_block,
-                target_block,
-                self.config.batch_size,
-                chain.contracts.len(),
-                chain.topics.len(),
-                self.config.finality_mode.as_str(),
-            );
-
-            let result = self
-                .reader
-                .query_logs(DatalensLogQuery {
-                    chain_id: chain.chain_id,
-                    from_block: range.from_block,
-                    to_block: range.to_block,
-                    contracts: chain.contracts.clone(),
-                    topics: chain.topics.clone(),
-                    finality_mode: self.config.finality_mode,
-                })
-                .await?;
-            let mut events = Vec::new();
-            for log in &result.logs {
-                events.extend(self.decoder.decode(log).await?);
-            }
-            let written = self.writer.write_events(&events).await?;
-            let next_block = range
-                .to_block
-                .checked_add(1)
-                .context("checkpoint next block overflow")?;
-            self.checkpoints
-                .advance(chain.chain_id, dataset, next_block)
-                .await?;
-
-            log::info!(
-                "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} target_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true",
-                chain.chain_id,
-                dataset,
-                range.from_block,
-                range.to_block,
-                target_block,
-                result.logs.len(),
-                events.len(),
-                written,
-                next_block,
-            );
-
-            report.chains_processed += 1;
-            report.ranges_queried += 1;
-            report.records_read += result.logs.len() as u64;
-            report.records_decoded += events.len() as u64;
-            report.records_written += written as u64;
-            report.checkpoints_advanced += 1;
+        while let Some(chain_report) = runs.next().await {
+            report.add_chain_report(chain_report?);
         }
 
         Ok(report)
     }
+
+    async fn run_chain_once(&self, chain: ChainConfig) -> anyhow::Result<ChainRunReport> {
+        let dataset = chain_dataset(chain.chain_id)?;
+        let checkpoint = self
+            .checkpoints
+            .read_or_create(chain.chain_id, dataset, chain.start_block)
+            .await
+            .with_context(|| {
+                format!(
+                    "read or create ORMP checkpoint chain_id={} dataset={} start_block={}",
+                    chain.chain_id, dataset, chain.start_block
+                )
+            })?;
+        let target_block = self
+            .reader
+            .latest_block(chain.chain_id, self.config.finality_mode)
+            .await
+            .with_context(|| format!("query Datalens chain head for chain {}", chain.chain_id))?;
+        if checkpoint.next_block > target_block {
+            log::info!(
+                "skipping ORMP Datalens chain_id={} dataset={} checkpoint_next_block={} target_block={} checkpoint_ahead_of_target=true",
+                chain.chain_id,
+                dataset,
+                checkpoint.next_block,
+                target_block,
+            );
+            return Ok(ChainRunReport::default());
+        }
+
+        let mut range = plan_next_range(&checkpoint, self.config.batch_size).with_context(|| {
+            format!(
+                "plan ORMP checkpoint range chain_id={} dataset={} checkpoint_next_block={} batch_size={}",
+                chain.chain_id, dataset, checkpoint.next_block, self.config.batch_size
+            )
+        })?;
+        range.to_block = range.to_block.min(target_block);
+
+        log_query_start(&chain, dataset, range, target_block, &self.config);
+
+        let result = self
+            .reader
+            .query_logs(DatalensLogQuery {
+                chain_id: chain.chain_id,
+                from_block: range.from_block,
+                to_block: range.to_block,
+                contracts: chain.contracts.clone(),
+                topics: chain.topics.clone(),
+                finality_mode: self.config.finality_mode,
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "query ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={}",
+                    chain.chain_id, dataset, range.from_block, range.to_block
+                )
+            })?;
+        let mut events = Vec::new();
+        for log in &result.logs {
+            let topic0 = log
+                .topics
+                .first()
+                .map(String::as_str)
+                .unwrap_or("<missing>");
+            events.extend(self.decoder.decode(log).await.with_context(|| {
+                format!(
+                    "decode ORMP Datalens log chain_id={} block_number={} transaction_hash={} log_index={} address={} topic0={}",
+                    log.chain_id,
+                    log.block_number,
+                    log.transaction_hash,
+                    log.log_index,
+                    log.address,
+                    topic0
+                )
+            })?);
+        }
+        let written = self.writer.write_events(&events).await.with_context(|| {
+            format!(
+                "write ORMP events chain_id={} dataset={} from_block={} to_block={}",
+                chain.chain_id, dataset, range.from_block, range.to_block
+            )
+        })?;
+        let next_block = range.to_block.checked_add(1).with_context(|| {
+            format!(
+                "ORMP checkpoint next block overflow chain_id={} dataset={} to_block={}",
+                chain.chain_id, dataset, range.to_block
+            )
+        })?;
+        self.checkpoints
+            .advance(chain.chain_id, dataset, next_block)
+            .await
+            .with_context(|| {
+                format!(
+                    "advance ORMP checkpoint chain_id={} dataset={} next_block={}",
+                    chain.chain_id, dataset, next_block
+                )
+            })?;
+
+        log::info!(
+            "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} target_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true",
+            chain.chain_id,
+            dataset,
+            range.from_block,
+            range.to_block,
+            target_block,
+            result.logs.len(),
+            events.len(),
+            written,
+            next_block,
+        );
+
+        Ok(ChainRunReport {
+            chains_processed: 1,
+            ranges_queried: 1,
+            records_read: result.logs.len() as u64,
+            records_decoded: events.len() as u64,
+            records_written: written as u64,
+            checkpoints_advanced: 1,
+        })
+    }
 }
 
-fn should_sleep_after_run(report: &RunnerReport) -> bool {
-    report.ranges_queried == 0
+fn log_query_start(
+    chain: &ChainConfig,
+    dataset: &str,
+    range: BlockRange,
+    target_block: u64,
+    config: &RuntimeConfig,
+) {
+    log::info!(
+        "querying ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={} target_block={} batch_size={} contracts={} topics={} finality={}",
+        chain.chain_id,
+        dataset,
+        range.from_block,
+        range.to_block,
+        target_block,
+        config.batch_size,
+        chain.contracts.len(),
+        chain.topics.len(),
+        config.finality_mode.as_str(),
+    );
+}
+
+fn should_sleep_after_run<R>(report: &R) -> bool
+where
+    R: RunReport,
+{
+    report.ranges_queried() == 0
 }
 
 #[cfg(test)]

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -179,6 +179,32 @@ fn test_tron_native_query_rows_decode_with_context_metadata() {
 }
 
 #[test]
+fn test_tron_native_query_rows_decode_nested_empty_adapter_response() {
+    let logs = logs_from_native_query_payload(
+        &serde_json::json!({
+            "data": {
+                "query": {
+                    "rows": {
+                        "dataset_key": { "family": { "Other": "tron" }, "name": "events" },
+                        "rows": {
+                            "dataset": "adapter_json",
+                            "rows": {
+                                "dataset_key": { "family": { "Other": "tron" }, "name": "events" },
+                                "rows": []
+                            }
+                        }
+                    }
+                }
+            }
+        }),
+        TRON_CHAIN_ID,
+    )
+    .expect("decode nested empty Tron adapter response");
+
+    assert!(logs.is_empty());
+}
+
+#[test]
 fn test_tron_native_graphql_request_uses_other_selector_shape() {
     let request = native_graphql_request(&ormpindexer::datalens::DatalensLogQuery {
         chain_id: TRON_CHAIN_ID,

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -359,6 +359,40 @@ fn test_decode_evm_indexed_topics_preserves_legacy_fields() {
             params: "0xbbcc".to_owned(),
         }
     );
+
+    let submittion = DatalensLog {
+        topics: vec![
+            SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC.to_owned(),
+            uint_topic(46),
+            address_topic(0x40),
+            address_topic(0x41),
+        ],
+        data: format!(
+            "0x{}",
+            hex::encode(encode(&[
+                Token::Uint(U256::from(12)),
+                Token::Bytes(vec![0xde, 0xad]),
+                Token::Bytes(vec![0xbe, 0xef]),
+            ]))
+        ),
+        ..log(
+            SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
+            SIGNATURE_PUB_ADDRESS,
+            Vec::new(),
+        )
+    };
+    assert_eq!(
+        decode_evm_log(&submittion).expect("indexed SignatureSubmittion decodes"),
+        LegacyOrmPEvent::SignatureSubmittion {
+            metadata: metadata(SIGNATURE_PUB_ADDRESS),
+            chain_id: 46,
+            channel: address_hex(0x40),
+            signer: address_hex(0x41),
+            msg_index: 12,
+            signature: "0xdead".to_owned(),
+            data: "0xbeef".to_owned(),
+        }
+    );
 }
 
 #[test]
@@ -454,6 +488,10 @@ fn address_hex(value: u64) -> String {
 
 fn address_topic(value: u64) -> String {
     format!("0x{:0>64}", &address_hex(value)[2..])
+}
+
+fn uint_topic(value: u64) -> String {
+    format!("0x{value:0>64x}")
 }
 
 fn bytes32(value: u8) -> Vec<u8> {

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -1,7 +1,11 @@
-use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use ormpindexer::{
-    checkpoint::{Checkpoint, InMemoryCheckpointStore, plan_next_range},
+    checkpoint::{Checkpoint, CheckpointStore, InMemoryCheckpointStore, plan_next_range},
     config::{FinalityMode, RuntimeConfig},
     database::{DryRunEventWriter, EventWriter},
     datalens::{DatalensLog, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader},
@@ -334,8 +338,9 @@ async fn test_runner_caps_query_range_at_datalens_head() {
 
     assert_eq!(report.checkpoints_advanced, 1);
     assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 13);
-    assert_eq!(reader.queries.borrow()[0].from_block, 10);
-    assert_eq!(reader.queries.borrow()[0].to_block, 12);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(queries[0].from_block, 10);
+    assert_eq!(queries[0].to_block, 12);
 }
 
 #[tokio::test]
@@ -368,7 +373,12 @@ async fn test_runner_writer_failure_does_not_advance_checkpoint() {
         .await
         .expect_err("writer failure fails the batch");
 
-    assert!(error.to_string().contains("write failed"));
+    let error_chain = format!("{error:#}");
+    assert!(
+        error_chain
+            .contains("write ORMP events chain_id=46 dataset=evm.logs from_block=10 to_block=14")
+    );
+    assert!(error_chain.contains("write failed"));
     assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 10);
 }
 
@@ -418,11 +428,68 @@ async fn test_runner_reports_and_advances_multiple_chains() {
     assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 25);
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_runner_slow_chain_does_not_block_other_chain_checkpoint_progress() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "1,46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    checkpoints
+        .read_or_create(1, "evm.logs", 10)
+        .await
+        .expect("seed slow chain checkpoint");
+    checkpoints
+        .read_or_create(46, "evm.logs", 10)
+        .await
+        .expect("seed fast chain checkpoint");
+    let runner = IndexerRunner::new(
+        config,
+        RecordingDatalensReader::new(Vec::new()).with_query_delay(1, Duration::from_millis(300)),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let run = tokio::spawn(async move { runner.run_once().await });
+    let deadline = Instant::now() + Duration::from_millis(100);
+    loop {
+        if checkpoints.next_block(46, "evm.logs").await.unwrap() == 15 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "fast chain checkpoint was not advanced before slow chain completed"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+
+    let report = run
+        .await
+        .expect("runner task joins")
+        .expect("multi-chain pass succeeds");
+
+    assert_eq!(report.checkpoints_advanced, 2);
+    assert_eq!(checkpoints.next_block(1, "evm.logs").await.unwrap(), 15);
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 15);
+}
+
 #[derive(Clone)]
 struct RecordingDatalensReader {
     logs: Vec<DatalensLog>,
     heads: BTreeMap<u64, u64>,
-    queries: Rc<RefCell<Vec<DatalensLogQuery>>>,
+    query_delays: BTreeMap<u64, Duration>,
+    queries: Arc<Mutex<Vec<DatalensLogQuery>>>,
 }
 
 impl RecordingDatalensReader {
@@ -430,12 +497,18 @@ impl RecordingDatalensReader {
         Self {
             logs,
             heads: BTreeMap::new(),
-            queries: Rc::new(RefCell::new(Vec::new())),
+            query_delays: BTreeMap::new(),
+            queries: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     fn with_head(mut self, chain_id: u64, head: u64) -> Self {
         self.heads.insert(chain_id, head);
+        self
+    }
+
+    fn with_query_delay(mut self, chain_id: u64, delay: Duration) -> Self {
+        self.query_delays.insert(chain_id, delay);
         self
     }
 }
@@ -450,7 +523,10 @@ impl DatalensLogReader for RecordingDatalensReader {
     }
 
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult> {
-        self.queries.borrow_mut().push(query);
+        if let Some(delay) = self.query_delays.get(&query.chain_id) {
+            tokio::time::sleep(*delay).await;
+        }
+        self.queries.lock().expect("queries lock").push(query);
         Ok(DatalensLogQueryResult {
             logs: self.logs.clone(),
         })


### PR DESCRIPTION
## Summary
- run ORMP Datalens chains independently in the continuous runner instead of serializing every chain behind one loop
- keep run-once concurrent and aggregate per-chain reports
- add chain/dataset/range context to concurrent runner errors
- handle nested native Datalens rows and indexed SignatureSubmittion decoding needed by current live data

## Tests
- cargo fmt --check
- cargo test

## Notes
- Tron warmup behavior is intentionally unchanged.
- Local comparison runner should use ORMPINDEXER_BATCH_SIZE=1000, matching the normal runtime default instead of the temporary debug value 1.
