### PR TITLE
perf(indexer): add Datalens retry and per-chain batches

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,10 @@ impl RuntimeConfig {
 
     pub fn from_env_map(env: &BTreeMap<String, String>) -> anyhow::Result<Self> {
         let start_block = optional_u64(env, "ORMPINDEXER_START_BLOCK")?;
+        let batch_size = optional_u64(env, "ORMPINDEXER_BATCH_SIZE")?.unwrap_or(1_000);
+        if batch_size == 0 {
+            bail!("ORMPINDEXER_BATCH_SIZE must be greater than zero");
+        }
         let chain_ids = required_list(env, "ORMPINDEXER_ENABLED_CHAINS")?
             .into_iter()
             .map(|value| {
@@ -51,17 +55,23 @@ impl RuntimeConfig {
 
         let enabled_chains = chain_ids
             .into_iter()
-            .map(|chain_id| ChainConfig::from_env_map(env, chain_id, start_block))
+            .map(|chain_id| ChainConfig::from_env_map(env, chain_id, start_block, batch_size))
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        let batch_size = optional_u64(env, "ORMPINDEXER_BATCH_SIZE")?.unwrap_or(1_000);
-        if batch_size == 0 {
-            bail!("ORMPINDEXER_BATCH_SIZE must be greater than zero");
-        }
         let warmup_chunk_size =
             optional_u64(env, "ORMPINDEXER_DATALENS_WARMUP_CHUNK_SIZE")?.unwrap_or(batch_size);
         if warmup_chunk_size == 0 {
             bail!("ORMPINDEXER_DATALENS_WARMUP_CHUNK_SIZE must be greater than zero");
+        }
+        let datalens_timeout_secs =
+            optional_u64(env, "ORMPINDEXER_DATALENS_TIMEOUT_SECS")?.unwrap_or(300);
+        if datalens_timeout_secs == 0 {
+            bail!("ORMPINDEXER_DATALENS_TIMEOUT_SECS must be greater than zero");
+        }
+        let datalens_query_max_attempts =
+            optional_u64(env, "ORMPINDEXER_DATALENS_QUERY_MAX_ATTEMPTS")?.unwrap_or(3);
+        if datalens_query_max_attempts == 0 {
+            bail!("ORMPINDEXER_DATALENS_QUERY_MAX_ATTEMPTS must be greater than zero");
         }
 
         Ok(Self {
@@ -71,6 +81,8 @@ impl RuntimeConfig {
                 application: optional_env(env, "ORMPINDEXER_DATALENS_APPLICATION")
                     .unwrap_or_else(|| "ormpindexer".to_owned()),
                 token: optional_env(env, "ORMPINDEXER_DATALENS_TOKEN").map(SecretString::new),
+                timeout: Duration::from_secs(datalens_timeout_secs),
+                query_max_attempts: datalens_query_max_attempts,
             },
             warmup: DatalensWarmupConfig {
                 enabled: optional_bool(env, "ORMPINDEXER_DATALENS_WARMUP_ENABLED")?
@@ -112,12 +124,15 @@ pub struct DatalensConfig {
     pub endpoint: String,
     pub application: String,
     pub token: Option<SecretString>,
+    pub timeout: Duration,
+    pub query_max_attempts: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChainConfig {
     pub chain_id: u64,
     pub start_block: u64,
+    pub batch_size: u64,
     pub contracts: Vec<String>,
     pub topics: Vec<String>,
 }
@@ -127,6 +142,7 @@ impl ChainConfig {
         env: &BTreeMap<String, String>,
         chain_id: u64,
         default_start_block: Option<u64>,
+        default_batch_size: u64,
     ) -> anyhow::Result<Self> {
         let prefix = format!("ORMPINDEXER_CHAIN_{chain_id}");
         let default = default_chain_config(chain_id)?;
@@ -141,10 +157,16 @@ impl ChainConfig {
                 .or(default_start_block)
                 .unwrap_or(default.start_block)
         };
+        let batch_size =
+            optional_u64(env, &format!("{prefix}_BATCH_SIZE"))?.unwrap_or(default_batch_size);
+        if batch_size == 0 {
+            bail!("{prefix}_BATCH_SIZE must be greater than zero");
+        }
 
         Ok(Self {
             chain_id,
             start_block,
+            batch_size,
             contracts: if contracts.is_empty() {
                 default.contracts
             } else {

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sha2::{Digest, Sha256};
+use tokio::time::sleep;
 
 use anyhow::Context;
 
@@ -75,10 +76,11 @@ pub struct DatalensHttpClient {
 
 impl DatalensHttpClient {
     pub fn new(config: DatalensConfig) -> Self {
-        Self {
-            config,
-            http: reqwest::Client::new(),
-        }
+        let http = reqwest::Client::builder()
+            .timeout(config.timeout)
+            .build()
+            .expect("build Datalens HTTP client");
+        Self { config, http }
     }
 
     fn native_graphql_endpoint(&self) -> String {
@@ -112,24 +114,106 @@ impl DatalensHttpClient {
         &self,
         request: DatalensWarmupSubmitRequest,
     ) -> anyhow::Result<WarmupSubmitResponse> {
-        let mut builder = self
-            .http
-            .post(self.warmup_tasks_endpoint())
-            .header("x-datalens-application", &self.config.application)
-            .json(&request);
-        if let Some(token) = &self.config.token {
-            builder = builder.bearer_auth(token.expose_secret());
-        }
-
-        let response = builder.send().await?;
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        if !status.is_success() {
-            anyhow::bail!("Datalens warmup submit failed with status {status}: {body}");
-        }
+        let body = self
+            .request_text_with_retries(
+                "Datalens warmup submit",
+                || {
+                    let mut builder = self
+                        .http
+                        .post(self.warmup_tasks_endpoint())
+                        .header("x-datalens-application", &self.config.application)
+                        .json(&request);
+                    if let Some(token) = &self.config.token {
+                        builder = builder.bearer_auth(token.expose_secret());
+                    }
+                    builder
+                },
+                |_| false,
+            )
+            .await?;
 
         let payload: WarmupSubmitApiResponse = serde_json::from_str(&body)?;
         Ok(payload.into_submit_response())
+    }
+
+    async fn request_text_with_retries<B, G>(
+        &self,
+        operation: &str,
+        mut build_request: B,
+        should_retry_body: G,
+    ) -> anyhow::Result<String>
+    where
+        B: FnMut() -> reqwest::RequestBuilder,
+        G: Fn(&str) -> bool,
+    {
+        for attempt in 1..=self.config.query_max_attempts {
+            let response = match build_request().send().await {
+                Ok(response) => response,
+                Err(error) => {
+                    if attempt < self.config.query_max_attempts {
+                        log::warn!(
+                            "{} send failed attempt={} max_attempts={} error={}",
+                            operation,
+                            attempt,
+                            self.config.query_max_attempts,
+                            error
+                        );
+                        sleep(datalens_retry_delay(attempt)).await;
+                        continue;
+                    }
+                    return Err(error).with_context(|| format!("{operation} send failed"));
+                }
+            };
+
+            let status = response.status();
+            let body = match response.text().await {
+                Ok(body) => body,
+                Err(error) => {
+                    if attempt < self.config.query_max_attempts {
+                        log::warn!(
+                            "{} body read failed attempt={} max_attempts={} error={}",
+                            operation,
+                            attempt,
+                            self.config.query_max_attempts,
+                            error
+                        );
+                        sleep(datalens_retry_delay(attempt)).await;
+                        continue;
+                    }
+                    return Err(error).with_context(|| format!("{operation} body read failed"));
+                }
+            };
+            if status.is_success() {
+                if should_retry_body(&body) && attempt < self.config.query_max_attempts {
+                    log::warn!(
+                        "{} returned retryable response attempt={} max_attempts={}",
+                        operation,
+                        attempt,
+                        self.config.query_max_attempts,
+                    );
+                    sleep(datalens_retry_delay(attempt)).await;
+                    continue;
+                }
+                return Ok(body);
+            }
+
+            if is_retryable_http_status(status) && attempt < self.config.query_max_attempts {
+                log::warn!(
+                    "{} failed with status {} attempt={} max_attempts={} body={}",
+                    operation,
+                    status,
+                    attempt,
+                    self.config.query_max_attempts,
+                    body
+                );
+                sleep(datalens_retry_delay(attempt)).await;
+                continue;
+            }
+
+            anyhow::bail!("{operation} failed with status {status}: {body}");
+        }
+
+        unreachable!("query_max_attempts is validated as greater than zero")
     }
 }
 
@@ -148,43 +232,49 @@ impl DatalensLogReader for DatalensHttpClient {
         chain_id: u64,
         finality_mode: FinalityMode,
     ) -> anyhow::Result<u64> {
-        let mut builder = self
-            .http
-            .get(self.chain_head_endpoint(chain_id, finality_mode)?)
-            .header("x-datalens-application", &self.config.application);
-        if let Some(token) = &self.config.token {
-            builder = builder.bearer_auth(token.expose_secret());
-        }
+        let endpoint = self.chain_head_endpoint(chain_id, finality_mode)?;
+        let body = self
+            .request_text_with_retries(
+                "Datalens chain head query",
+                || {
+                    let mut builder = self
+                        .http
+                        .get(&endpoint)
+                        .header("x-datalens-application", &self.config.application);
+                    if let Some(token) = &self.config.token {
+                        builder = builder.bearer_auth(token.expose_secret());
+                    }
+                    builder
+                },
+                |_| false,
+            )
+            .await?;
 
-        let response = builder.send().await?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("Datalens chain head query failed with status {status}: {body}");
-        }
-
-        let payload: ChainHeadResponse = response.json().await?;
+        let payload: ChainHeadResponse = serde_json::from_str(&body)?;
         Ok(payload.height)
     }
 
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult> {
         let request = native_graphql_request(&query)?;
-        let mut builder = self
-            .http
-            .post(self.native_graphql_endpoint())
-            .header("x-datalens-application", &self.config.application)
-            .json(&request);
-        if let Some(token) = &self.config.token {
-            builder = builder.bearer_auth(token.expose_secret());
-        }
-
-        let response = builder.send().await?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("Datalens log query failed with status {status}: {body}");
-        }
-        let payload: serde_json::Value = response.json().await?;
+        let endpoint = self.native_graphql_endpoint();
+        let body = self
+            .request_text_with_retries(
+                "Datalens log query",
+                || {
+                    let mut builder = self
+                        .http
+                        .post(&endpoint)
+                        .header("x-datalens-application", &self.config.application)
+                        .json(&request);
+                    if let Some(token) = &self.config.token {
+                        builder = builder.bearer_auth(token.expose_secret());
+                    }
+                    builder
+                },
+                body_has_retryable_graphql_errors,
+            )
+            .await?;
+        let payload: serde_json::Value = serde_json::from_str(&body)?;
         if let Some(errors) = payload.get("errors") {
             anyhow::bail!("Datalens log query returned errors: {errors}");
         }
@@ -192,6 +282,102 @@ impl DatalensLogReader for DatalensHttpClient {
         let logs = logs_from_native_query_payload(&payload, query.chain_id)?;
         Ok(DatalensLogQueryResult { logs })
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DatalensFailureKind {
+    ProviderLimit,
+    Transient,
+    Other,
+}
+
+pub fn classify_datalens_failure_message(message: &str) -> DatalensFailureKind {
+    let message = message.to_ascii_lowercase();
+    if message.contains("query returns too many logs")
+        || message.contains("too many logs")
+        || message.contains("narrow your filter")
+        || message.contains("provider limit")
+        || message.contains("range limit")
+        || message.contains("block range too large")
+        || message.contains("range too large")
+    {
+        return DatalensFailureKind::ProviderLimit;
+    }
+
+    if message.contains("timeout")
+        || message.contains("timed out")
+        || message.contains("provider_failure")
+        || message.contains("providerfailure")
+        || message.contains("rate-limit")
+        || message.contains("rate limit")
+        || message.contains("bad gateway")
+        || message.contains("service unavailable")
+        || message.contains("gateway timeout")
+    {
+        return DatalensFailureKind::Transient;
+    }
+
+    DatalensFailureKind::Other
+}
+
+fn body_has_retryable_graphql_errors(body: &str) -> bool {
+    let Ok(payload) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    let Some(errors) = payload.get("errors") else {
+        return false;
+    };
+    errors
+        .as_array()
+        .map(|errors| errors.iter().any(graphql_error_is_retryable))
+        .unwrap_or_else(|| graphql_error_is_retryable(errors))
+}
+
+fn graphql_error_is_retryable(error: &serde_json::Value) -> bool {
+    if let Some(message) = error.get("message").and_then(serde_json::Value::as_str) {
+        if matches!(
+            classify_datalens_failure_message(message),
+            DatalensFailureKind::Transient
+        ) {
+            return true;
+        }
+    }
+
+    let Some(extensions) = error.get("extensions") else {
+        return false;
+    };
+
+    if let Some(code) = extensions.get("code").and_then(serde_json::Value::as_str) {
+        if matches!(
+            classify_datalens_failure_message(code),
+            DatalensFailureKind::Transient
+        ) {
+            return true;
+        }
+    }
+
+    ["status", "statusCode", "httpStatus"]
+        .iter()
+        .filter_map(|key| extensions.get(*key))
+        .any(retryable_status_value)
+}
+
+fn retryable_status_value(value: &serde_json::Value) -> bool {
+    let status = value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|value| value.parse::<u64>().ok()));
+    matches!(status, Some(429 | 500..=599))
+}
+
+fn datalens_retry_delay(attempt: u64) -> std::time::Duration {
+    let millis = 250_u64.saturating_mul(1_u64 << attempt.saturating_sub(1).min(2));
+    std::time::Duration::from_millis(millis.min(1_000))
+}
+
+fn is_retryable_http_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+        || status.as_u16() == 524
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -553,4 +739,40 @@ pub fn tron_chain_name(chain_id: u64) -> anyhow::Result<&'static str> {
         TRON_CHAIN_ID => "tron-mainnet",
         _ => anyhow::bail!("unsupported Tron Datalens chain id: {chain_id}"),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_body_has_retryable_graphql_errors_checks_structured_status() {
+        let body = serde_json::json!({
+            "errors": [{
+                "message": "upstream provider failed",
+                "extensions": {
+                    "code": "PROVIDER_FAILURE",
+                    "status": 502
+                }
+            }]
+        })
+        .to_string();
+
+        assert!(body_has_retryable_graphql_errors(&body));
+    }
+
+    #[test]
+    fn test_body_has_retryable_graphql_errors_ignores_validation_numbers() {
+        let body = serde_json::json!({
+            "errors": [{
+                "message": "validation failed: limit must be at most 500",
+                "extensions": {
+                    "code": "BAD_USER_INPUT"
+                }
+            }]
+        })
+        .to_string();
+
+        assert!(!body_has_retryable_graphql_errors(&body));
+    }
 }

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -113,6 +113,7 @@ pub fn default_evm_chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
     Ok(ChainConfig {
         chain_id,
         start_block: default.start_block,
+        batch_size: 1_000,
         contracts: default_contracts(default.include_signature_pub),
         topics: default_topics(default.include_signature_pub),
     })
@@ -131,6 +132,7 @@ pub fn default_tron_chain_config() -> anyhow::Result<ChainConfig> {
     Ok(ChainConfig {
         chain_id: TRON_CHAIN_ID,
         start_block: 0,
+        batch_size: 1_000,
         contracts: vec![
             TRON_MSGPORT_ADDRESS.to_owned(),
             TRON_ORMP_ADDRESS.to_owned(),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use tokio::time::sleep;
 
 use anyhow::Context;
@@ -41,10 +43,15 @@ struct ChainRunReport {
     records_decoded: u64,
     records_written: u64,
     checkpoints_advanced: u64,
+    caught_up: bool,
 }
 
 trait RunReport {
     fn ranges_queried(&self) -> u64;
+
+    fn should_sleep_after_run(&self) -> bool {
+        self.ranges_queried() == 0
+    }
 }
 
 impl RunReport for RunnerReport {
@@ -56,6 +63,10 @@ impl RunReport for RunnerReport {
 impl RunReport for ChainRunReport {
     fn ranges_queried(&self) -> u64 {
         self.ranges_queried
+    }
+
+    fn should_sleep_after_run(&self) -> bool {
+        self.caught_up || self.ranges_queried == 0
     }
 }
 
@@ -103,21 +114,27 @@ where
     }
 
     async fn run_chain_loop(&self, chain: ChainConfig) -> anyhow::Result<()> {
+        let mut consecutive_failures = 0;
         loop {
             match self.run_chain_once(chain.clone()).await {
                 Ok(report) => {
+                    consecutive_failures = 0;
                     if should_sleep_after_run(&report) {
                         sleep(self.config.poll_interval).await;
                     }
                 }
                 Err(error) => {
+                    consecutive_failures += 1;
+                    let backoff = failure_backoff(self.config.poll_interval, consecutive_failures);
                     log::error!(
-                        "ORMP Datalens chain pass failed chain_id={} start_block={} error={:#}",
+                        "ORMP Datalens chain pass failed chain_id={} start_block={} consecutive_failures={} backoff_ms={} error={:#}",
                         chain.chain_id,
                         chain.start_block,
+                        consecutive_failures,
+                        backoff.as_millis(),
                         error
                     );
-                    sleep(self.config.poll_interval).await;
+                    sleep(backoff).await;
                 }
             }
         }
@@ -142,7 +159,7 @@ where
 
     async fn run_chain_once(&self, chain: ChainConfig) -> anyhow::Result<ChainRunReport> {
         let dataset = chain_dataset(chain.chain_id)?;
-        let checkpoint = self
+        let mut checkpoint = self
             .checkpoints
             .read_or_create(chain.chain_id, dataset, chain.start_block)
             .await
@@ -165,98 +182,115 @@ where
                 checkpoint.next_block,
                 target_block,
             );
-            return Ok(ChainRunReport::default());
+            return Ok(ChainRunReport {
+                caught_up: true,
+                ..ChainRunReport::default()
+            });
         }
 
-        let mut range = plan_next_range(&checkpoint, self.config.batch_size).with_context(|| {
-            format!(
-                "plan ORMP checkpoint range chain_id={} dataset={} checkpoint_next_block={} batch_size={}",
-                chain.chain_id, dataset, checkpoint.next_block, self.config.batch_size
-            )
-        })?;
-        range.to_block = range.to_block.min(target_block);
-
-        log_query_start(&chain, dataset, range, target_block, &self.config);
-
-        let result = self
-            .reader
-            .query_logs(DatalensLogQuery {
-                chain_id: chain.chain_id,
-                from_block: range.from_block,
-                to_block: range.to_block,
-                contracts: chain.contracts.clone(),
-                topics: chain.topics.clone(),
-                finality_mode: self.config.finality_mode,
-            })
-            .await
-            .with_context(|| {
+        let mut report = ChainRunReport::default();
+        while checkpoint.next_block <= target_block {
+            let mut range = plan_next_range(&checkpoint, chain.batch_size).with_context(|| {
                 format!(
-                    "query ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={}",
+                    "plan ORMP checkpoint range chain_id={} dataset={} checkpoint_next_block={} batch_size={}",
+                    chain.chain_id, dataset, checkpoint.next_block, chain.batch_size
+                )
+            })?;
+            range.to_block = range.to_block.min(target_block);
+
+            log_query_start(&chain, dataset, range, target_block, &self.config);
+
+            let batch_started = Instant::now();
+            let result = self
+                .reader
+                .query_logs(DatalensLogQuery {
+                    chain_id: chain.chain_id,
+                    from_block: range.from_block,
+                    to_block: range.to_block,
+                    contracts: chain.contracts.clone(),
+                    topics: chain.topics.clone(),
+                    finality_mode: self.config.finality_mode,
+                })
+                .await
+                .with_context(|| {
+                    format!(
+                        "query ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={}",
+                        chain.chain_id, dataset, range.from_block, range.to_block
+                    )
+                })?;
+            let mut events = Vec::new();
+            for log in &result.logs {
+                let topic0 = log
+                    .topics
+                    .first()
+                    .map(String::as_str)
+                    .unwrap_or("<missing>");
+                events.extend(self.decoder.decode(log).await.with_context(|| {
+                    format!(
+                        "decode ORMP Datalens log chain_id={} block_number={} transaction_hash={} log_index={} address={} topic0={}",
+                        log.chain_id,
+                        log.block_number,
+                        log.transaction_hash,
+                        log.log_index,
+                        log.address,
+                        topic0
+                    )
+                })?);
+            }
+            let written = self.writer.write_events(&events).await.with_context(|| {
+                format!(
+                    "write ORMP events chain_id={} dataset={} from_block={} to_block={}",
                     chain.chain_id, dataset, range.from_block, range.to_block
                 )
             })?;
-        let mut events = Vec::new();
-        for log in &result.logs {
-            let topic0 = log
-                .topics
-                .first()
-                .map(String::as_str)
-                .unwrap_or("<missing>");
-            events.extend(self.decoder.decode(log).await.with_context(|| {
+            let next_block = range.to_block.checked_add(1).with_context(|| {
                 format!(
-                    "decode ORMP Datalens log chain_id={} block_number={} transaction_hash={} log_index={} address={} topic0={}",
-                    log.chain_id,
-                    log.block_number,
-                    log.transaction_hash,
-                    log.log_index,
-                    log.address,
-                    topic0
-                )
-            })?);
-        }
-        let written = self.writer.write_events(&events).await.with_context(|| {
-            format!(
-                "write ORMP events chain_id={} dataset={} from_block={} to_block={}",
-                chain.chain_id, dataset, range.from_block, range.to_block
-            )
-        })?;
-        let next_block = range.to_block.checked_add(1).with_context(|| {
-            format!(
-                "ORMP checkpoint next block overflow chain_id={} dataset={} to_block={}",
-                chain.chain_id, dataset, range.to_block
-            )
-        })?;
-        self.checkpoints
-            .advance(chain.chain_id, dataset, next_block)
-            .await
-            .with_context(|| {
-                format!(
-                    "advance ORMP checkpoint chain_id={} dataset={} next_block={}",
-                    chain.chain_id, dataset, next_block
+                    "ORMP checkpoint next block overflow chain_id={} dataset={} to_block={}",
+                    chain.chain_id, dataset, range.to_block
                 )
             })?;
+            self.checkpoints
+                .advance(chain.chain_id, dataset, next_block)
+                .await
+                .with_context(|| {
+                    format!(
+                        "advance ORMP checkpoint chain_id={} dataset={} next_block={}",
+                        chain.chain_id, dataset, next_block
+                    )
+                })?;
 
-        log::info!(
-            "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} target_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true",
-            chain.chain_id,
-            dataset,
-            range.from_block,
-            range.to_block,
-            target_block,
-            result.logs.len(),
-            events.len(),
-            written,
-            next_block,
-        );
+            let progress = batch_progress(range, target_block, next_block, batch_started.elapsed());
+            log::info!(
+                "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} target_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true batch_blocks={} remaining_blocks={} batch_duration_ms={} current_rate_blocks_per_second={:.2} eta_seconds={}",
+                chain.chain_id,
+                dataset,
+                range.from_block,
+                range.to_block,
+                target_block,
+                result.logs.len(),
+                events.len(),
+                written,
+                next_block,
+                progress.batch_blocks,
+                progress.remaining_blocks,
+                progress.batch_duration_ms,
+                progress.current_rate_blocks_per_second,
+                progress.eta_seconds,
+            );
 
-        Ok(ChainRunReport {
-            chains_processed: 1,
-            ranges_queried: 1,
-            records_read: result.logs.len() as u64,
-            records_decoded: events.len() as u64,
-            records_written: written as u64,
-            checkpoints_advanced: 1,
-        })
+            report.ranges_queried += 1;
+            report.records_read += result.logs.len() as u64;
+            report.records_decoded += events.len() as u64;
+            report.records_written += written as u64;
+            report.checkpoints_advanced += 1;
+            checkpoint.next_block = next_block;
+        }
+
+        if report.ranges_queried > 0 {
+            report.chains_processed = 1;
+        }
+        report.caught_up = true;
+        Ok(report)
     }
 }
 
@@ -274,18 +308,65 @@ fn log_query_start(
         range.from_block,
         range.to_block,
         target_block,
-        config.batch_size,
+        chain.batch_size,
         chain.contracts.len(),
         chain.topics.len(),
         config.finality_mode.as_str(),
     );
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct BatchProgress {
+    batch_blocks: u64,
+    remaining_blocks: u64,
+    batch_duration_ms: u128,
+    current_rate_blocks_per_second: f64,
+    eta_seconds: u64,
+}
+
+fn batch_progress(
+    range: BlockRange,
+    target_block: u64,
+    next_block: u64,
+    duration: Duration,
+) -> BatchProgress {
+    let batch_blocks = range
+        .to_block
+        .saturating_sub(range.from_block)
+        .saturating_add(1);
+    let remaining_blocks = if next_block > target_block {
+        0
+    } else {
+        target_block.saturating_sub(next_block).saturating_add(1)
+    };
+    let elapsed_seconds = duration.as_secs_f64().max(0.001);
+    let current_rate_blocks_per_second = batch_blocks as f64 / elapsed_seconds;
+    let eta_seconds = if remaining_blocks == 0 {
+        0
+    } else {
+        (remaining_blocks as f64 / current_rate_blocks_per_second).ceil() as u64
+    };
+
+    BatchProgress {
+        batch_blocks,
+        remaining_blocks,
+        batch_duration_ms: duration.as_millis(),
+        current_rate_blocks_per_second,
+        eta_seconds,
+    }
+}
+
 fn should_sleep_after_run<R>(report: &R) -> bool
 where
     R: RunReport,
 {
-    report.ranges_queried() == 0
+    report.should_sleep_after_run()
+}
+
+fn failure_backoff(poll_interval: Duration, consecutive_failures: u64) -> Duration {
+    let multiplier = 1_u128 << consecutive_failures.saturating_sub(1).min(10);
+    let millis = poll_interval.as_millis().max(1).saturating_mul(multiplier);
+    Duration::from_millis(millis.min(60_000) as u64)
 }
 
 #[cfg(test)]
@@ -305,5 +386,23 @@ mod tests {
         };
 
         assert!(!should_sleep_after_run(&report));
+    }
+
+    #[test]
+    fn test_failure_backoff_grows_from_poll_interval_and_caps() {
+        let poll_interval = std::time::Duration::from_secs(2);
+
+        assert_eq!(
+            failure_backoff(poll_interval, 1),
+            std::time::Duration::from_secs(2)
+        );
+        assert_eq!(
+            failure_backoff(poll_interval, 2),
+            std::time::Duration::from_secs(4)
+        );
+        assert_eq!(
+            failure_backoff(poll_interval, 6),
+            std::time::Duration::from_secs(60)
+        );
     }
 }

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -1,7 +1,7 @@
 use ormpindexer::{
     datalens::{
-        DatalensLog, evm_chain_name, logs_from_native_query_payload, native_graphql_request,
-        tron_chain_name,
+        DatalensFailureKind, DatalensLog, classify_datalens_failure_message, evm_chain_name,
+        logs_from_native_query_payload, native_graphql_request, tron_chain_name,
     },
     planner::TRON_CHAIN_ID,
 };
@@ -296,4 +296,40 @@ fn test_tron_chain_name_rejects_unknown_chain_ids() {
         "tron-mainnet"
     );
     assert!(tron_chain_name(46).is_err());
+}
+
+#[test]
+fn test_datalens_failure_classifies_provider_limits() {
+    assert_eq!(
+        classify_datalens_failure_message("query returns too many logs, narrow your filter"),
+        DatalensFailureKind::ProviderLimit
+    );
+    assert_eq!(
+        classify_datalens_failure_message("provider range limit exceeded"),
+        DatalensFailureKind::ProviderLimit
+    );
+}
+
+#[test]
+fn test_datalens_failure_classifies_transient_errors() {
+    assert_eq!(
+        classify_datalens_failure_message("ProviderFailure: upstream returned 502"),
+        DatalensFailureKind::Transient
+    );
+    assert_eq!(
+        classify_datalens_failure_message("request timed out after 300 seconds"),
+        DatalensFailureKind::Transient
+    );
+    assert_eq!(
+        classify_datalens_failure_message("rate-limit 429"),
+        DatalensFailureKind::Transient
+    );
+}
+
+#[test]
+fn test_datalens_failure_classifies_other_errors() {
+    assert_eq!(
+        classify_datalens_failure_message("permission denied"),
+        DatalensFailureKind::Other
+    );
 }

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -30,6 +30,14 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
             "secret-token".to_owned(),
         ),
         (
+            "ORMPINDEXER_DATALENS_TIMEOUT_SECS".to_owned(),
+            "120".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_QUERY_MAX_ATTEMPTS".to_owned(),
+            "5".to_owned(),
+        ),
+        (
             "ORMPINDEXER_DATABASE_URL".to_owned(),
             "postgres://user:pass@localhost/ormp".to_owned(),
         ),
@@ -70,6 +78,10 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
             "2000".to_owned(),
         ),
         (
+            "ORMPINDEXER_CHAIN_46_BATCH_SIZE".to_owned(),
+            "50".to_owned(),
+        ),
+        (
             "ORMPINDEXER_CHAIN_46_CONTRACTS".to_owned(),
             "0x333".to_owned(),
         ),
@@ -80,6 +92,8 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
     assert_eq!(config.datalens.endpoint, "https://datalens.example");
     assert_eq!(config.datalens.application, "ormp-production");
     assert!(config.datalens.token.is_some());
+    assert_eq!(config.datalens.timeout, Duration::from_secs(120));
+    assert_eq!(config.datalens.query_max_attempts, 5);
     assert!(config.database_url.is_some());
     assert_eq!(config.enabled_chains.len(), 2);
     assert_eq!(config.batch_size, 250);
@@ -99,6 +113,8 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
         vec!["0xaaa", "0xbbb"]
     );
     assert_eq!(config.chain(46).expect("chain 46").start_block, 2000);
+    assert_eq!(config.chain(1).expect("chain 1").batch_size, 250);
+    assert_eq!(config.chain(46).expect("chain 46").batch_size, 50);
 }
 
 #[test]
@@ -123,6 +139,106 @@ fn test_runtime_config_from_env_map_reads_warmup_defaults() {
     assert!(!config.warmup.required);
     assert_eq!(config.warmup.chunk_size, 250);
     assert_eq!(config.warmup.end_block, None);
+}
+
+#[test]
+fn test_runtime_config_reads_datalens_retry_defaults() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+    ]);
+
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+
+    assert_eq!(config.datalens.timeout, Duration::from_secs(300));
+    assert_eq!(config.datalens.query_max_attempts, 3);
+    assert_eq!(config.batch_size, 1_000);
+    assert_eq!(config.chain(46).expect("chain 46").batch_size, 1_000);
+}
+
+#[test]
+fn test_runtime_config_rejects_zero_chain_batch_size() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_CHAIN_46_BATCH_SIZE".to_owned(), "0".to_owned()),
+    ]);
+
+    let error = RuntimeConfig::from_env_map(&env).expect_err("zero chain batch size is invalid");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ORMPINDEXER_CHAIN_46_BATCH_SIZE must be greater than zero")
+    );
+}
+
+#[test]
+fn test_runtime_config_rejects_zero_datalens_timeout() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        (
+            "ORMPINDEXER_DATALENS_TIMEOUT_SECS".to_owned(),
+            "0".to_owned(),
+        ),
+    ]);
+
+    let error = RuntimeConfig::from_env_map(&env).expect_err("zero timeout is invalid");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ORMPINDEXER_DATALENS_TIMEOUT_SECS must be greater than zero")
+    );
+}
+
+#[test]
+fn test_runtime_config_rejects_zero_datalens_query_max_attempts() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        (
+            "ORMPINDEXER_DATALENS_QUERY_MAX_ATTEMPTS".to_owned(),
+            "0".to_owned(),
+        ),
+    ]);
+
+    let error = RuntimeConfig::from_env_map(&env).expect_err("zero attempts is invalid");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ORMPINDEXER_DATALENS_QUERY_MAX_ATTEMPTS must be greater than zero")
+    );
 }
 
 #[test]
@@ -220,7 +336,8 @@ async fn test_runner_successful_batch_advances_checkpoint_to_next_range() {
         event_signature: None,
         indexed_fields: Vec::new(),
         non_indexed_fields: None,
-    }]);
+    }])
+    .with_head(46, 14);
     let runner = IndexerRunner::new(
         config,
         reader,
@@ -264,7 +381,7 @@ async fn test_runner_empty_logs_still_advance_after_successful_query_and_write()
     let checkpoints = InMemoryCheckpointStore::default();
     let runner = IndexerRunner::new(
         config,
-        RecordingDatalensReader::new(Vec::new()),
+        RecordingDatalensReader::new(Vec::new()).with_head(46, 14),
         checkpoints.clone(),
         NoopDecoder,
         DryRunEventWriter,
@@ -344,6 +461,47 @@ async fn test_runner_caps_query_range_at_datalens_head() {
 }
 
 #[tokio::test]
+async fn test_runner_processes_contiguous_ranges_until_caught_up() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let reader = RecordingDatalensReader::new(Vec::new()).with_head(46, 22);
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let report = runner.run_once().await.expect("backlog pass succeeds");
+
+    assert_eq!(report.ranges_queried, 3);
+    assert_eq!(report.checkpoints_advanced, 3);
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 23);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries
+            .iter()
+            .map(|query| (query.from_block, query.to_block))
+            .collect::<Vec<_>>(),
+        vec![(10, 14), (15, 19), (20, 22)]
+    );
+}
+
+#[tokio::test]
 async fn test_runner_writer_failure_does_not_advance_checkpoint() {
     let env = BTreeMap::from([
         (
@@ -362,7 +520,9 @@ async fn test_runner_writer_failure_does_not_advance_checkpoint() {
     let checkpoints = InMemoryCheckpointStore::default();
     let runner = IndexerRunner::new(
         config,
-        RecordingDatalensReader::new(Vec::new()),
+        RecordingDatalensReader::new(Vec::new())
+            .with_head(1, 14)
+            .with_head(46, 24),
         checkpoints.clone(),
         NoopDecoder,
         FailingEventWriter,
@@ -405,7 +565,9 @@ async fn test_runner_reports_and_advances_multiple_chains() {
     let checkpoints = InMemoryCheckpointStore::default();
     let runner = IndexerRunner::new(
         config,
-        RecordingDatalensReader::new(Vec::new()),
+        RecordingDatalensReader::new(Vec::new())
+            .with_head(1, 14)
+            .with_head(46, 24),
         checkpoints.clone(),
         NoopDecoder,
         DryRunEventWriter,
@@ -455,7 +617,10 @@ async fn test_runner_slow_chain_does_not_block_other_chain_checkpoint_progress()
         .expect("seed fast chain checkpoint");
     let runner = IndexerRunner::new(
         config,
-        RecordingDatalensReader::new(Vec::new()).with_query_delay(1, Duration::from_millis(300)),
+        RecordingDatalensReader::new(Vec::new())
+            .with_head(1, 14)
+            .with_head(46, 14)
+            .with_query_delay(1, Duration::from_millis(300)),
         checkpoints.clone(),
         NoopDecoder,
         DryRunEventWriter,


### PR DESCRIPTION
## Summary
- add per-chain batch size overrides for Datalens-backed chain runners
- add Datalens HTTP timeout, retry attempts, retryable error classification, and failure backoff
- drain contiguous ranges to the current Datalens head and log per-batch rate/ETA

## Testing
- cargo test

## Operational notes
- intended local runner settings after merge: use larger EVM default batch and smaller Tron chain batch
- Polygon still has a provider-side poison block around 57249359 that may need Datalens/RPC follow-up