### PR TITLE
fix(runner): split retryable Datalens ranges

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -9,7 +9,10 @@ use crate::{
     checkpoint::{BlockRange, CheckpointStore, plan_next_range},
     config::{ChainConfig, RuntimeConfig},
     database::EventWriter,
-    datalens::{DatalensLogQuery, DatalensLogReader},
+    datalens::{
+        DatalensFailureKind, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader,
+        classify_datalens_failure_message,
+    },
     decoder::EventDecoder,
     planner::chain_dataset,
 };
@@ -44,6 +47,16 @@ struct ChainRunReport {
     records_written: u64,
     checkpoints_advanced: u64,
     caught_up: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct ProcessedRangeReport {
+    next_block: u64,
+    ranges_queried: u64,
+    records_read: u64,
+    records_decoded: u64,
+    records_written: u64,
+    checkpoints_advanced: u64,
 }
 
 trait RunReport {
@@ -198,92 +211,15 @@ where
             })?;
             range.to_block = range.to_block.min(target_block);
 
-            log_query_start(&chain, dataset, range, target_block, &self.config);
-
-            let batch_started = Instant::now();
-            let result = self
-                .reader
-                .query_logs(DatalensLogQuery {
-                    chain_id: chain.chain_id,
-                    from_block: range.from_block,
-                    to_block: range.to_block,
-                    contracts: chain.contracts.clone(),
-                    topics: chain.topics.clone(),
-                    finality_mode: self.config.finality_mode,
-                })
-                .await
-                .with_context(|| {
-                    format!(
-                        "query ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={}",
-                        chain.chain_id, dataset, range.from_block, range.to_block
-                    )
-                })?;
-            let mut events = Vec::new();
-            for log in &result.logs {
-                let topic0 = log
-                    .topics
-                    .first()
-                    .map(String::as_str)
-                    .unwrap_or("<missing>");
-                events.extend(self.decoder.decode(log).await.with_context(|| {
-                    format!(
-                        "decode ORMP Datalens log chain_id={} block_number={} transaction_hash={} log_index={} address={} topic0={}",
-                        log.chain_id,
-                        log.block_number,
-                        log.transaction_hash,
-                        log.log_index,
-                        log.address,
-                        topic0
-                    )
-                })?);
-            }
-            let written = self.writer.write_events(&events).await.with_context(|| {
-                format!(
-                    "write ORMP events chain_id={} dataset={} from_block={} to_block={}",
-                    chain.chain_id, dataset, range.from_block, range.to_block
-                )
-            })?;
-            let next_block = range.to_block.checked_add(1).with_context(|| {
-                format!(
-                    "ORMP checkpoint next block overflow chain_id={} dataset={} to_block={}",
-                    chain.chain_id, dataset, range.to_block
-                )
-            })?;
-            self.checkpoints
-                .advance(chain.chain_id, dataset, next_block)
-                .await
-                .with_context(|| {
-                    format!(
-                        "advance ORMP checkpoint chain_id={} dataset={} next_block={}",
-                        chain.chain_id, dataset, next_block
-                    )
-                })?;
-
-            let progress = batch_progress(range, target_block, next_block, batch_started.elapsed());
-            log::info!(
-                "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} target_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true batch_blocks={} remaining_blocks={} batch_duration_ms={} current_rate_blocks_per_second={:.2} eta_seconds={}",
-                chain.chain_id,
-                dataset,
-                range.from_block,
-                range.to_block,
-                target_block,
-                result.logs.len(),
-                events.len(),
-                written,
-                next_block,
-                progress.batch_blocks,
-                progress.remaining_blocks,
-                progress.batch_duration_ms,
-                progress.current_rate_blocks_per_second,
-                progress.eta_seconds,
-            );
-
-            report.ranges_queried += 1;
-            report.records_read += result.logs.len() as u64;
-            report.records_decoded += events.len() as u64;
-            report.records_written += written as u64;
-            report.checkpoints_advanced += 1;
-            checkpoint.next_block = next_block;
+            let range_report = self
+                .process_range_with_splitting(&chain, dataset, range, target_block)
+                .await?;
+            report.ranges_queried += range_report.ranges_queried;
+            report.records_read += range_report.records_read;
+            report.records_decoded += range_report.records_decoded;
+            report.records_written += range_report.records_written;
+            report.checkpoints_advanced += range_report.checkpoints_advanced;
+            checkpoint.next_block = range_report.next_block;
         }
 
         if report.ranges_queried > 0 {
@@ -292,6 +228,198 @@ where
         report.caught_up = true;
         Ok(report)
     }
+
+    async fn process_range_with_splitting(
+        &self,
+        chain: &ChainConfig,
+        dataset: &str,
+        range: BlockRange,
+        target_block: u64,
+    ) -> anyhow::Result<ProcessedRangeReport> {
+        let mut pending = vec![range];
+        let mut report = ProcessedRangeReport::default();
+
+        while let Some(range) = pending.pop() {
+            log_query_start(chain, dataset, range, target_block, &self.config);
+            let batch_started = Instant::now();
+            let result = match self.query_range_once(chain, dataset, range).await {
+                Ok(result) => result,
+                Err(error) => {
+                    if can_split_datalens_query_failure(&error, range) {
+                        let (left, right) = split_range(range);
+                        log::warn!(
+                            "splitting ORMP Datalens range after retryable failure chain_id={} dataset={} from_block={} to_block={} left_from_block={} left_to_block={} right_from_block={} right_to_block={} error={:#}",
+                            chain.chain_id,
+                            dataset,
+                            range.from_block,
+                            range.to_block,
+                            left.from_block,
+                            left.to_block,
+                            right.from_block,
+                            right.to_block,
+                            error
+                        );
+                        pending.push(right);
+                        pending.push(left);
+                        continue;
+                    }
+
+                    return Err(error);
+                }
+            };
+
+            let range_report = self
+                .process_successful_range(
+                    chain,
+                    dataset,
+                    range,
+                    target_block,
+                    batch_started,
+                    result,
+                )
+                .await?;
+            report.next_block = range_report.next_block;
+            report.ranges_queried += range_report.ranges_queried;
+            report.records_read += range_report.records_read;
+            report.records_decoded += range_report.records_decoded;
+            report.records_written += range_report.records_written;
+            report.checkpoints_advanced += range_report.checkpoints_advanced;
+        }
+
+        Ok(report)
+    }
+
+    async fn query_range_once(
+        &self,
+        chain: &ChainConfig,
+        dataset: &str,
+        range: BlockRange,
+    ) -> anyhow::Result<DatalensLogQueryResult> {
+        self.reader
+            .query_logs(DatalensLogQuery {
+                chain_id: chain.chain_id,
+                from_block: range.from_block,
+                to_block: range.to_block,
+                contracts: chain.contracts.clone(),
+                topics: chain.topics.clone(),
+                finality_mode: self.config.finality_mode,
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "query ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={}",
+                    chain.chain_id, dataset, range.from_block, range.to_block
+                )
+            })
+    }
+
+    async fn process_successful_range(
+        &self,
+        chain: &ChainConfig,
+        dataset: &str,
+        range: BlockRange,
+        target_block: u64,
+        batch_started: Instant,
+        result: DatalensLogQueryResult,
+    ) -> anyhow::Result<ProcessedRangeReport> {
+        let mut events = Vec::new();
+        for log in &result.logs {
+            let topic0 = log
+                .topics
+                .first()
+                .map(String::as_str)
+                .unwrap_or("<missing>");
+            events.extend(self.decoder.decode(log).await.with_context(|| {
+                format!(
+                    "decode ORMP Datalens log chain_id={} block_number={} transaction_hash={} log_index={} address={} topic0={}",
+                    log.chain_id,
+                    log.block_number,
+                    log.transaction_hash,
+                    log.log_index,
+                    log.address,
+                    topic0
+                )
+            })?);
+        }
+        let written = self.writer.write_events(&events).await.with_context(|| {
+            format!(
+                "write ORMP events chain_id={} dataset={} from_block={} to_block={}",
+                chain.chain_id, dataset, range.from_block, range.to_block
+            )
+        })?;
+        let next_block = range.to_block.checked_add(1).with_context(|| {
+            format!(
+                "ORMP checkpoint next block overflow chain_id={} dataset={} to_block={}",
+                chain.chain_id, dataset, range.to_block
+            )
+        })?;
+        self.checkpoints
+            .advance(chain.chain_id, dataset, next_block)
+            .await
+            .with_context(|| {
+                format!(
+                    "advance ORMP checkpoint chain_id={} dataset={} next_block={}",
+                    chain.chain_id, dataset, next_block
+                )
+            })?;
+
+        let progress = batch_progress(range, target_block, next_block, batch_started.elapsed());
+        log::info!(
+            "ORMP Datalens batch completed chain_id={} dataset={} from_block={} to_block={} target_block={} records_count={} decoded_count={} written_count={} checkpoint_next_block={} checkpoint_advanced=true batch_blocks={} remaining_blocks={} batch_duration_ms={} current_rate_blocks_per_second={:.2} eta_seconds={}",
+            chain.chain_id,
+            dataset,
+            range.from_block,
+            range.to_block,
+            target_block,
+            result.logs.len(),
+            events.len(),
+            written,
+            next_block,
+            progress.batch_blocks,
+            progress.remaining_blocks,
+            progress.batch_duration_ms,
+            progress.current_rate_blocks_per_second,
+            progress.eta_seconds,
+        );
+
+        Ok(ProcessedRangeReport {
+            next_block,
+            ranges_queried: 1,
+            records_read: result.logs.len() as u64,
+            records_decoded: events.len() as u64,
+            records_written: written as u64,
+            checkpoints_advanced: 1,
+        })
+    }
+}
+
+fn can_split_datalens_query_failure(error: &anyhow::Error, range: BlockRange) -> bool {
+    if range.from_block >= range.to_block {
+        return false;
+    }
+
+    let error = format!("{error:#}");
+    let failure_kind = classify_datalens_failure_message(&error);
+    if matches!(failure_kind, DatalensFailureKind::ProviderLimit) {
+        return true;
+    }
+
+    matches!(failure_kind, DatalensFailureKind::Transient)
+        && (error.contains("provider_failure") || error.contains("providerfailure"))
+}
+
+fn split_range(range: BlockRange) -> (BlockRange, BlockRange) {
+    let midpoint = range.from_block + (range.to_block - range.from_block) / 2;
+    (
+        BlockRange {
+            from_block: range.from_block,
+            to_block: midpoint,
+        },
+        BlockRange {
+            from_block: midpoint + 1,
+            to_block: range.to_block,
+        },
+    )
 }
 
 fn log_query_start(

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -502,6 +502,232 @@ async fn test_runner_processes_contiguous_ranges_until_caught_up() {
 }
 
 #[tokio::test]
+async fn test_runner_splits_retryable_datalens_range_failure_and_advances_children_in_order() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "4".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let reader = RecordingDatalensReader::new(Vec::new())
+        .with_head(46, 13)
+        .with_range_query_failure(46, 10, 13, "provider_failure: upstream returned 524");
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let report = runner.run_once().await.expect("split batch succeeds");
+
+    assert_eq!(report.ranges_queried, 2);
+    assert_eq!(report.checkpoints_advanced, 2);
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 14);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries
+            .iter()
+            .map(|query| (query.from_block, query.to_block))
+            .collect::<Vec<_>>(),
+        vec![(10, 13), (10, 11), (12, 13)]
+    );
+}
+
+#[tokio::test]
+async fn test_runner_stops_checkpoint_at_retryable_single_block_failure_after_left_child_succeeds()
+{
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "4".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let reader = RecordingDatalensReader::new(Vec::new())
+        .with_head(46, 13)
+        .with_range_query_failure(46, 10, 13, "provider_failure: upstream returned 524")
+        .with_range_query_failure(46, 12, 13, "provider range limit exceeded")
+        .with_range_query_failure(46, 12, 12, "provider_failure: upstream returned 524");
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let error = runner
+        .run_once()
+        .await
+        .expect_err("single block failure stops the chain pass");
+
+    let error_chain = format!("{error:#}");
+    assert!(error_chain.contains("from_block=12 to_block=12"));
+    assert!(error_chain.contains("provider_failure"));
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 12);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries
+            .iter()
+            .map(|query| (query.from_block, query.to_block))
+            .collect::<Vec<_>>(),
+        vec![(10, 13), (10, 11), (12, 13), (12, 12)]
+    );
+}
+
+#[tokio::test]
+async fn test_runner_does_not_split_non_retryable_datalens_failure() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "4".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let reader = RecordingDatalensReader::new(Vec::new())
+        .with_head(46, 13)
+        .with_range_query_failure(46, 10, 13, "permission denied");
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let error = runner
+        .run_once()
+        .await
+        .expect_err("non-retryable failure stops the chain pass");
+
+    assert!(format!("{error:#}").contains("permission denied"));
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 10);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries
+            .iter()
+            .map(|query| (query.from_block, query.to_block))
+            .collect::<Vec<_>>(),
+        vec![(10, 13)]
+    );
+}
+
+#[tokio::test]
+async fn test_runner_does_not_split_downstream_timeout_failure() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "4".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let reader = RecordingDatalensReader::new(Vec::new()).with_head(46, 13);
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        FailingEventWriterWithMessage("database timeout"),
+    );
+
+    let error = runner
+        .run_once()
+        .await
+        .expect_err("downstream timeout failure stops without split");
+
+    assert!(format!("{error:#}").contains("database timeout"));
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 10);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries
+            .iter()
+            .map(|query| (query.from_block, query.to_block))
+            .collect::<Vec<_>>(),
+        vec![(10, 13)]
+    );
+}
+
+#[tokio::test]
+async fn test_runner_does_not_split_generic_transient_datalens_failure() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "4".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    let reader = RecordingDatalensReader::new(Vec::new())
+        .with_head(46, 13)
+        .with_range_query_failure(46, 10, 13, "request timed out after 60 seconds");
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let error = runner
+        .run_once()
+        .await
+        .expect_err("generic transient failure stops without split");
+
+    assert!(format!("{error:#}").contains("request timed out"));
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 10);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries
+            .iter()
+            .map(|query| (query.from_block, query.to_block))
+            .collect::<Vec<_>>(),
+        vec![(10, 13)]
+    );
+}
+
+#[tokio::test]
 async fn test_runner_writer_failure_does_not_advance_checkpoint() {
     let env = BTreeMap::from([
         (
@@ -709,6 +935,7 @@ struct RecordingDatalensReader {
     heads: BTreeMap<u64, u64>,
     query_delays: BTreeMap<u64, Duration>,
     query_failures: BTreeMap<u64, String>,
+    range_query_failures: BTreeMap<(u64, u64, u64), String>,
     queries: Arc<Mutex<Vec<DatalensLogQuery>>>,
 }
 
@@ -719,6 +946,7 @@ impl RecordingDatalensReader {
             heads: BTreeMap::new(),
             query_delays: BTreeMap::new(),
             query_failures: BTreeMap::new(),
+            range_query_failures: BTreeMap::new(),
             queries: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -737,6 +965,18 @@ impl RecordingDatalensReader {
         self.query_failures.insert(chain_id, error.to_owned());
         self
     }
+
+    fn with_range_query_failure(
+        mut self,
+        chain_id: u64,
+        from_block: u64,
+        to_block: u64,
+        error: &str,
+    ) -> Self {
+        self.range_query_failures
+            .insert((chain_id, from_block, to_block), error.to_owned());
+        self
+    }
 }
 
 impl DatalensLogReader for RecordingDatalensReader {
@@ -752,10 +992,19 @@ impl DatalensLogReader for RecordingDatalensReader {
         if let Some(delay) = self.query_delays.get(&query.chain_id) {
             tokio::time::sleep(*delay).await;
         }
+        self.queries
+            .lock()
+            .expect("queries lock")
+            .push(query.clone());
+        if let Some(error) =
+            self.range_query_failures
+                .get(&(query.chain_id, query.from_block, query.to_block))
+        {
+            anyhow::bail!("{error}");
+        }
         if let Some(error) = self.query_failures.get(&query.chain_id) {
             anyhow::bail!("{error}");
         }
-        self.queries.lock().expect("queries lock").push(query);
         Ok(DatalensLogQueryResult {
             logs: self.logs.clone(),
         })
@@ -767,5 +1016,13 @@ struct FailingEventWriter;
 impl EventWriter for FailingEventWriter {
     async fn write_events(&self, _events: &[LegacyOrmPEvent]) -> anyhow::Result<usize> {
         anyhow::bail!("write failed");
+    }
+}
+
+struct FailingEventWriterWithMessage(&'static str);
+
+impl EventWriter for FailingEventWriterWithMessage {
+    async fn write_events(&self, _events: &[LegacyOrmPEvent]) -> anyhow::Result<usize> {
+        anyhow::bail!(self.0);
     }
 }


### PR DESCRIPTION
## Summary
- Split retryable Datalens range failures into ordered child ranges instead of failing the whole configured batch.
- Preserve checkpoint correctness by writing and advancing each child range only after it succeeds.
- Add runtime tests for retryable split success, single-block retryable failure checkpoint stop, and non-retryable errors.

## Tests
- cargo fmt
- cargo test