### PR TITLE
fix(schema): restore legacy event row ids

### DIFF
--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -31,6 +31,8 @@ pub struct DatalensLog {
     pub chain_id: u64,
     #[serde(alias = "block_number")]
     pub block_number: u64,
+    #[serde(default, alias = "block_hash")]
+    pub block_hash: Option<String>,
     #[serde(default, alias = "block_timestamp")]
     pub block_timestamp: Option<u64>,
     #[serde(alias = "transaction_hash")]
@@ -439,6 +441,8 @@ struct NativeLogRow {
     id: Option<String>,
     block_number: u64,
     #[serde(default)]
+    block_hash: Option<String>,
+    #[serde(default)]
     block_timestamp: Option<u64>,
     transaction_hash: String,
     transaction_index: i32,
@@ -463,6 +467,7 @@ impl NativeLogRow {
             id: Some(id),
             chain_id,
             block_number: self.block_number,
+            block_hash: self.block_hash,
             block_timestamp: self.block_timestamp,
             transaction_hash: self.transaction_hash,
             transaction_index: Some(self.transaction_index),
@@ -494,6 +499,8 @@ struct NativeTronEventRow {
     non_indexed_fields: Option<serde_json::Value>,
     transaction_id: String,
     block_number: u64,
+    #[serde(default)]
+    block_hash: Option<String>,
     block_timestamp: u64,
     transaction_index: i32,
     event_index: u64,
@@ -527,6 +534,7 @@ impl NativeTronEventRow {
             id: Some(id),
             chain_id,
             block_number: self.block_number,
+            block_hash: self.block_hash,
             block_timestamp: Some(self.block_timestamp),
             transaction_hash: self.transaction_id,
             transaction_index: Some(self.transaction_index),

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -74,6 +74,7 @@ fn evm_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
         source: EventSource::Evm,
         chain_id: log.chain_id.into(),
         block_number: log.block_number.into(),
+        block_hash: log.block_hash.clone(),
         block_timestamp: log
             .block_timestamp
             .context("EVM log is missing block timestamp")?
@@ -128,6 +129,7 @@ fn tron_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
         source: EventSource::Tron,
         chain_id: log.chain_id.into(),
         block_number: log.block_number.into(),
+        block_hash: log.block_hash.clone(),
         block_timestamp: log
             .block_timestamp
             .context("Tron event is missing block timestamp")?

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -57,12 +57,31 @@ pub struct ChainLogMetadata {
     pub source: EventSource,
     pub chain_id: u128,
     pub block_number: u128,
+    pub block_hash: Option<String>,
     pub block_timestamp: u128,
     pub transaction_hash: String,
     pub transaction_index: i32,
     pub log_index: i32,
     pub contract_address: String,
     pub transaction_from: Option<String>,
+}
+
+fn legacy_event_log_id(metadata: &ChainLogMetadata) -> String {
+    let Some(block_hash) = metadata.block_hash.as_deref() else {
+        return metadata.id.clone();
+    };
+    let block_hash = block_hash
+        .strip_prefix("0x")
+        .or_else(|| block_hash.strip_prefix("0X"))
+        .unwrap_or(block_hash);
+    let block_hash_prefix = block_hash
+        .get(..block_hash.len().min(5))
+        .unwrap_or(block_hash)
+        .to_ascii_lowercase();
+    format!(
+        "{:010}-{}-{:06}",
+        metadata.block_number, block_hash_prefix, metadata.log_index
+    )
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -415,7 +434,7 @@ impl MsgportMessageRecvRow {
                 result,
                 return_data,
             } => Self {
-                id: metadata.id,
+                id: legacy_event_log_id(&metadata),
                 block_number: metadata.block_number,
                 transaction_hash: metadata.transaction_hash,
                 block_timestamp: metadata.block_timestamp,
@@ -464,7 +483,7 @@ impl MsgportMessageSentRow {
                 message,
                 params,
             } => Self {
-                id: metadata.id,
+                id: legacy_event_log_id(&metadata),
                 block_number: metadata.block_number,
                 transaction_hash: metadata.transaction_hash,
                 block_timestamp: metadata.block_timestamp,
@@ -512,7 +531,7 @@ impl SignaturePubSignatureSubmittionRow {
                 signature,
                 data,
             } => Self {
-                id: metadata.id,
+                id: legacy_event_log_id(&metadata),
                 block_number: metadata.block_number,
                 transaction_hash: metadata.transaction_hash,
                 block_timestamp: metadata.block_timestamp,

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -102,6 +102,7 @@ fn test_native_query_rows_decode_with_context_metadata() {
     assert_eq!(logs[0].id.as_deref(), Some("46-123-0xtx-3"));
     assert_eq!(logs[0].chain_id, 46);
     assert_eq!(logs[0].block_number, 123);
+    assert_eq!(logs[0].block_hash.as_deref(), Some("0xblock"));
     assert_eq!(logs[0].block_timestamp, Some(456));
     assert_eq!(logs[0].transaction_hash, "0xtx");
     assert_eq!(logs[0].transaction_index, Some(2));
@@ -158,6 +159,7 @@ fn test_tron_native_query_rows_decode_with_context_metadata() {
     assert_eq!(logs[0].id.as_deref(), Some("728126428-123-trontx-3"));
     assert_eq!(logs[0].chain_id, TRON_CHAIN_ID);
     assert_eq!(logs[0].block_number, 123);
+    assert_eq!(logs[0].block_hash.as_deref(), Some("0xblock"));
     assert_eq!(logs[0].block_timestamp, Some(456));
     assert_eq!(logs[0].transaction_hash, "trontx");
     assert_eq!(logs[0].transaction_index, Some(2));

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -202,6 +202,7 @@ fn test_decode_native_graphql_log_preserves_metadata_in_legacy_row() {
         "id": "46-888-7",
         "chainId": 46,
         "blockNumber": 888,
+        "blockHash": "0x6de65e4800000000000000000000000000000000000000000000000000000000",
         "blockTimestamp": 1_800_000_000_000_u64,
         "transactionHash": bytes_hex(0xaa).to_ascii_uppercase(),
         "transactionIndex": 9,
@@ -225,7 +226,7 @@ fn test_decode_native_graphql_log_preserves_metadata_in_legacy_row() {
 
     let row = MsgportMessageSentRow::from_event(decode_evm_log(&log).expect("decode EVM event"));
 
-    assert_eq!(row.id, "46-888-7");
+    assert_eq!(row.id, "0000000888-6de65-000007");
     assert_eq!(row.chain_id, 46);
     assert_eq!(row.block_number, 888);
     assert_eq!(row.block_timestamp, 1_800_000_000_000);
@@ -448,6 +449,7 @@ fn log(topic: &str, address: &str, data: Vec<u8>) -> DatalensLog {
         id: Some("1-100-0".to_owned()),
         chain_id: 1,
         block_number: 100,
+        block_hash: None,
         block_timestamp: Some(1_700_000_000_000),
         transaction_hash: bytes_hex(0xaa),
         transaction_index: Some(2),
@@ -469,6 +471,7 @@ fn metadata(address: &str) -> ormpindexer::schema::ChainLogMetadata {
         source: EventSource::Evm,
         chain_id: 1,
         block_number: 100,
+        block_hash: None,
         block_timestamp: 1_700_000_000_000,
         transaction_hash: bytes_hex(0xaa),
         transaction_index: 2,

--- a/tests/graphql_server.rs
+++ b/tests/graphql_server.rs
@@ -165,6 +165,7 @@ fn evm_metadata(id: &str) -> ChainLogMetadata {
         source: EventSource::Evm,
         chain_id: 46,
         block_number: 123,
+        block_hash: None,
         block_timestamp: 456,
         transaction_hash: "0xtx".to_owned(),
         transaction_index: 2,

--- a/tests/legacy_parity.rs
+++ b/tests/legacy_parity.rs
@@ -192,7 +192,7 @@ fn evm_expected_rows() -> Vec<CompatibilityRow> {
             dispatch_result: true,
         }),
         CompatibilityRow::MsgportMessageRecv(MsgportMessageRecvRow {
-            id: "1-104-7".to_owned(),
+            id: "0000000104-eeeee-000007".to_owned(),
             block_number: 104,
             transaction_hash: bytes_hex(0xee),
             block_timestamp: 1_700_000_000_004,
@@ -205,7 +205,7 @@ fn evm_expected_rows() -> Vec<CompatibilityRow> {
             return_data: "0xff".to_owned(),
         }),
         CompatibilityRow::MsgportMessageSent(MsgportMessageSentRow {
-            id: "1-105-8".to_owned(),
+            id: "0000000105-efefe-000008".to_owned(),
             block_number: 105,
             transaction_hash: bytes_hex(0xef),
             block_timestamp: 1_700_000_000_005,
@@ -223,7 +223,7 @@ fn evm_expected_rows() -> Vec<CompatibilityRow> {
             params: "0xbbcc".to_owned(),
         }),
         CompatibilityRow::SignatureSubmittion(SignaturePubSignatureSubmittionRow {
-            id: "1-106-9".to_owned(),
+            id: "0000000106-f0f0f-000009".to_owned(),
             block_number: 106,
             transaction_hash: bytes_hex(0xf0),
             block_timestamp: 1_700_000_000_006,
@@ -306,7 +306,7 @@ fn tron_expected_rows() -> Vec<CompatibilityRow> {
             dispatch_result: true,
         }),
         CompatibilityRow::MsgportMessageRecv(MsgportMessageRecvRow {
-            id: "728126428-124-tron-message-recv-7".to_owned(),
+            id: "0000000124-tron--000007".to_owned(),
             block_number: 124,
             transaction_hash: "tron-message-recv".to_owned(),
             block_timestamp: 456_004,
@@ -319,7 +319,7 @@ fn tron_expected_rows() -> Vec<CompatibilityRow> {
             return_data: "0xff".to_owned(),
         }),
         CompatibilityRow::MsgportMessageSent(MsgportMessageSentRow {
-            id: "728126428-123-trontx-3".to_owned(),
+            id: "0000000123-tront-000003".to_owned(),
             block_number: 123,
             transaction_hash: "trontx".to_owned(),
             block_timestamp: 456,
@@ -337,7 +337,7 @@ fn tron_expected_rows() -> Vec<CompatibilityRow> {
             params: "0xbbcc".to_owned(),
         }),
         CompatibilityRow::SignatureSubmittion(SignaturePubSignatureSubmittionRow {
-            id: "728126428-126-tron-signature-submittion-9".to_owned(),
+            id: "0000000126-tron--000009".to_owned(),
             block_number: 126,
             transaction_hash: "tron-signature-submittion".to_owned(),
             block_timestamp: 456_006,
@@ -574,6 +574,7 @@ fn tron_fixture_logs() -> Vec<DatalensLog> {
             "id": "728126428-123-trontx-3",
             "chainId": TRON_CHAIN_ID,
             "blockNumber": 123,
+            "blockHash": "trontx",
             "blockTimestamp": 456,
             "transactionHash": "trontx",
             "transactionIndex": 2,
@@ -626,6 +627,7 @@ fn tron_log(
         "id": id,
         "chainId": TRON_CHAIN_ID,
         "blockNumber": block_number,
+        "blockHash": transaction_hash,
         "blockTimestamp": 456_000 + block_number - 120,
         "transactionHash": transaction_hash,
         "transactionIndex": transaction_index,
@@ -655,6 +657,7 @@ fn evm_log(
         id: Some(id.to_owned()),
         chain_id: 1,
         block_number,
+        block_hash: Some(transaction_hash.clone()),
         block_timestamp: Some(1_700_000_000_000 + block_number - 100),
         transaction_hash,
         transaction_index: Some(transaction_index),

--- a/tests/ops_endpoints.rs
+++ b/tests/ops_endpoints.rs
@@ -183,6 +183,7 @@ fn evm_metadata(id: &str) -> ChainLogMetadata {
         source: EventSource::Evm,
         chain_id: 46,
         block_number: 123,
+        block_hash: None,
         block_timestamp: 456,
         transaction_hash: "0xtx".to_owned(),
         transaction_index: 2,

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -200,6 +200,7 @@ fn evm_metadata(id: &str) -> ChainLogMetadata {
         source: EventSource::Evm,
         chain_id: 46,
         block_number: 123,
+        block_hash: None,
         block_timestamp: 456,
         transaction_hash: "0xtx".to_owned(),
         transaction_index: 2,

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -330,6 +330,7 @@ async fn test_runner_successful_batch_advances_checkpoint_to_next_range() {
         id: Some("46-0xtx-1".to_owned()),
         chain_id: 46,
         block_number: 12,
+        block_hash: None,
         block_timestamp: Some(1_700_000_000_000),
         transaction_hash: "0xtx".to_owned(),
         transaction_index: Some(0),

--- a/tests/schema_compatibility.rs
+++ b/tests/schema_compatibility.rs
@@ -77,8 +77,41 @@ fn test_assigned_backfills_accepted_when_configured_addresses_match() {
 
 #[test]
 fn test_msgport_sent_and_recv_preserve_event_metadata() {
+    let sent_metadata = ChainLogMetadata {
+        id: "42161-466386813-0x0f1e4961852aada25e6fda15c4883c7512e2f14c584e0d0917b03d9758682a57-14"
+            .to_owned(),
+        source: EventSource::Evm,
+        chain_id: 42161,
+        block_number: 466_386_813,
+        block_hash: Some(
+            "0x5bcb00ac00000000000000000000000000000000000000000000000000000000".to_owned(),
+        ),
+        block_timestamp: 456,
+        transaction_hash: "0x0f1e4961852aada25e6fda15c4883c7512e2f14c584e0d0917b03d9758682a57"
+            .to_owned(),
+        transaction_index: 2,
+        log_index: 14,
+        contract_address: "0xport".to_owned(),
+        transaction_from: Some("0xsender".to_owned()),
+    };
+    let recv_metadata = ChainLogMetadata {
+        id: "728126428-9989983-trontx6b95f-4".to_owned(),
+        source: EventSource::Tron,
+        chain_id: 728_126_428,
+        block_number: 9_989_983,
+        block_hash: Some(
+            "0x6b95f000000000000000000000000000000000000000000000000000000000000".to_owned(),
+        ),
+        block_timestamp: 654,
+        transaction_hash: "0x368465dbe681b2cbdd7d16e8de578f12b6e30cd604aef11a28f0fccbccae169a"
+            .to_owned(),
+        transaction_index: 9,
+        log_index: 4,
+        contract_address: "0xtronport".to_owned(),
+        transaction_from: None,
+    };
     let sent = MsgportMessageSentRow::from_event(LegacyOrmPEvent::MsgportMessageSent {
-        metadata: evm_metadata("sent-log"),
+        metadata: sent_metadata,
         msg_id: "0xmsgid".to_owned(),
         from_dapp: "0xfromdapp".to_owned(),
         to_chain_id: 728_126_428,
@@ -87,29 +120,47 @@ fn test_msgport_sent_and_recv_preserve_event_metadata() {
         params: "0xparams".to_owned(),
     });
     let recv = MsgportMessageRecvRow::from_event(LegacyOrmPEvent::MsgportMessageRecv {
-        metadata: tron_metadata("recv-log"),
+        metadata: recv_metadata,
         msg_id: "0xmsgid".to_owned(),
         result: true,
         return_data: "0xreturn".to_owned(),
     });
 
-    assert_eq!(sent.id, "sent-log");
+    assert_eq!(sent.id, "0466386813-5bcb0-000014");
     assert_eq!(sent.from_chain_id, sent.chain_id);
     assert_eq!(sent.transaction_index, 2);
-    assert_eq!(sent.log_index, 3);
+    assert_eq!(sent.log_index, 14);
     assert_eq!(sent.transaction_from.as_deref(), Some("0xsender"));
 
-    assert_eq!(recv.id, "recv-log");
+    assert_eq!(recv.id, "0009989983-6b95f-000004");
     assert_eq!(recv.transaction_index, 9);
-    assert_eq!(recv.log_index, 5);
+    assert_eq!(recv.log_index, 4);
     assert_eq!(recv.port_address, "0xtronport");
 }
 
 #[test]
-fn test_signature_submittion_uses_event_id_and_event_payload_fields() {
+fn test_signature_submittion_uses_legacy_event_id_and_event_payload_fields() {
     let row =
         SignaturePubSignatureSubmittionRow::from_event(LegacyOrmPEvent::SignatureSubmittion {
-            metadata: evm_metadata("sig-log"),
+            metadata: ChainLogMetadata {
+                id: "46-12054798-0x2a8dcfc8999ca0173b3e27b850e5cfe81d02f4ef6db4501221b384f88a46de65-1"
+                    .to_owned(),
+                source: EventSource::Evm,
+                chain_id: 46,
+                block_number: 12_054_798,
+                block_hash: Some(
+                    "0x6de65e4800000000000000000000000000000000000000000000000000000000"
+                        .to_owned(),
+                ),
+                block_timestamp: 456,
+                transaction_hash:
+                    "0x2a8dcfc8999ca0173b3e27b850e5cfe81d02f4ef6db4501221b384f88a4bd947"
+                        .to_owned(),
+                transaction_index: 2,
+                log_index: 1,
+                contract_address: "0xport".to_owned(),
+                transaction_from: Some("0xsender".to_owned()),
+            },
             chain_id: 46,
             channel: "0xchannel".to_owned(),
             signer: "0xsigner".to_owned(),
@@ -118,9 +169,12 @@ fn test_signature_submittion_uses_event_id_and_event_payload_fields() {
             data: "0xdata".to_owned(),
         });
 
-    assert_eq!(row.id, "sig-log");
-    assert_eq!(row.block_number, 123);
-    assert_eq!(row.transaction_hash, "0xtx");
+    assert_eq!(row.id, "0012054798-6de65-000001");
+    assert_eq!(row.block_number, 12_054_798);
+    assert_eq!(
+        row.transaction_hash,
+        "0x2a8dcfc8999ca0173b3e27b850e5cfe81d02f4ef6db4501221b384f88a4bd947"
+    );
     assert_eq!(row.chain_id, 46);
     assert_eq!(row.msg_index, 99);
     assert_eq!(row.signature, "0xsig");
@@ -173,26 +227,12 @@ fn evm_metadata(id: &str) -> ChainLogMetadata {
         source: EventSource::Evm,
         chain_id: 46,
         block_number: 123,
+        block_hash: None,
         block_timestamp: 456,
         transaction_hash: "0xtx".to_owned(),
         transaction_index: 2,
         log_index: 3,
         contract_address: "0xport".to_owned(),
         transaction_from: Some("0xsender".to_owned()),
-    }
-}
-
-fn tron_metadata(id: &str) -> ChainLogMetadata {
-    ChainLogMetadata {
-        id: id.to_owned(),
-        source: EventSource::Tron,
-        chain_id: 728_126_428,
-        block_number: 987,
-        block_timestamp: 654,
-        transaction_hash: "0xtrontx".to_owned(),
-        transaction_index: 9,
-        log_index: 5,
-        contract_address: "0xtronport".to_owned(),
-        transaction_from: None,
     }
 }

--- a/tests/tron_decoder.rs
+++ b/tests/tron_decoder.rs
@@ -11,6 +11,7 @@ fn test_decode_tron_message_sent_preserves_legacy_fields() {
         "id": "728126428-123-trontx-3",
         "chainId": TRON_CHAIN_ID,
         "blockNumber": 123,
+        "blockHash": "0x9c64f37100000000000000000000000000000000000000000000000000000000",
         "blockTimestamp": 456,
         "transactionHash": "trontx",
         "transactionIndex": 2,
@@ -42,6 +43,9 @@ fn test_decode_tron_message_sent_preserves_legacy_fields() {
                 source: EventSource::Tron,
                 chain_id: TRON_CHAIN_ID.into(),
                 block_number: 123,
+                block_hash: Some(
+                    "0x9c64f37100000000000000000000000000000000000000000000000000000000".to_owned(),
+                ),
                 block_timestamp: 456,
                 transaction_hash: "trontx".to_owned(),
                 transaction_index: 2,
@@ -59,6 +63,7 @@ fn test_decode_tron_message_sent_preserves_legacy_fields() {
     );
 
     let row = MsgportMessageSentRow::from_event(event);
+    assert_eq!(row.id, "0000000123-9c64f-000003");
     assert_eq!(row.chain_id, TRON_CHAIN_ID.into());
     assert_eq!(row.from_chain_id, TRON_CHAIN_ID.into());
     assert_eq!(row.transaction_from, None);
@@ -112,6 +117,7 @@ fn tron_log() -> DatalensLog {
         id: Some("728126428-123-trontx-3".to_owned()),
         chain_id: TRON_CHAIN_ID,
         block_number: 123,
+        block_hash: None,
         block_timestamp: Some(456),
         transaction_hash: "trontx".to_owned(),
         transaction_index: Some(2),


### PR DESCRIPTION
## Summary
- add legacy event-log ID generation for Subsquid-compatible rows
- apply the legacy ID format to `msgport_message_sent`, `msgport_message_recv`, and `signature_pub_signature_submittion`
- keep ORMP message accepted IDs as `msgHash` and leave other ORMP row ID behavior unchanged

## Compatibility reason
Old GraphQL clients query these rows by IDs shaped as `block_number padded to 10 digits` + `transaction_hash` suffix + `log_index` padded to 6 digits, for example `0466386813-5bcb0-000014`. New rows were using `chain-block-txhash-log_index`, so legacy `...ById` lookups returned null.

## Tests
- `cargo fmt`
- `cargo test --test schema_compatibility`
- `cargo test --test evm_decoder`
- `cargo test --test tron_decoder`
- `cargo test --test legacy_parity`
- `cargo test`