### PR TITLE
fix(warmup): serialize Tron chain family for Datalens

### DIFF
--- a/src/warmup.rs
+++ b/src/warmup.rs
@@ -51,7 +51,7 @@ pub struct DatalensWarmupSubmitRequest {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct WarmupChainIdentity {
-    pub family: String,
+    pub family: serde_json::Value,
     pub configured_name: String,
     pub network_id: WarmupNetworkId,
 }
@@ -239,7 +239,7 @@ pub fn evm_warmup_request(
 
     Ok(DatalensWarmupSubmitRequest {
         chain: WarmupChainIdentity {
-            family: "Evm".to_owned(),
+            family: json!("Evm"),
             configured_name: evm_chain_name(chain.chain_id)?.to_owned(),
             network_id: WarmupNetworkId {
                 kind: "numeric".to_owned(),
@@ -283,7 +283,7 @@ pub fn tron_warmup_request(
     let selector = tron_event_selector(&chain.contracts, &chain.topics)?;
     Ok(DatalensWarmupSubmitRequest {
         chain: WarmupChainIdentity {
-            family: "Other".to_owned(),
+            family: json!({ "Other": "tron" }),
             configured_name: tron_chain_name(chain.chain_id)?.to_owned(),
             network_id: WarmupNetworkId {
                 kind: "numeric".to_owned(),

--- a/tests/datalens_warmup.rs
+++ b/tests/datalens_warmup.rs
@@ -93,7 +93,7 @@ fn test_tron_warmup_request_uses_ormp_selector_and_checkpoint_start() {
         value,
         serde_json::json!({
             "chain": {
-                "family": "Other",
+                "family": {"Other": "tron"},
                 "configured_name": "tron-mainnet",
                 "network_id": {"kind": "numeric", "value": 728126428}
             },


### PR DESCRIPTION
## Summary
- serialize Datalens warmup chain family with the native enum JSON shape
- send Tron as `{ "Other": "tron" }` so Datalens can deserialize startup warmup requests
- update the Tron warmup request test fixture

## Tests
- cargo fmt --check
- cargo test --test datalens_warmup -- --nocapture
- cargo test