### PR TITLE
fix(tron): use production contract defaults

### DIFF
--- a/src/planner.rs
+++ b/src/planner.rs
@@ -29,8 +29,8 @@ pub const EVM_LOGS_DATASET: &str = "evm.logs";
 pub const TRON_CHAIN_ID: u64 = 728_126_428;
 pub const TRON_EVENTS_DATASET: &str = "tron.events";
 
-pub const TRON_MSGPORT_ADDRESS: &str = "0x2cd1867Fb8016f93710B6386f7f9F1D540A60812";
-pub const TRON_ORMP_ADDRESS: &str = "0x13b2211a7cA45Db2808F6dB05557ce5347e3634e";
+pub const TRON_MSGPORT_ADDRESS: &str = "413bc5362ec3a3dbc07292aed4ef18be18de02da3a";
+pub const TRON_ORMP_ADDRESS: &str = "415c5c383febe62f377f8c0ea1de97f2a2ba102e98";
 pub const TRON_SIGNATURE_PUB_ADDRESS: &str = "0x57Aa601A0377f5AB313C5A955ee874f5D495fC92";
 
 pub const TRON_HASH_IMPORTED_EVENT: &str = "HashImported";

--- a/tests/datalens_planner.rs
+++ b/tests/datalens_planner.rs
@@ -5,8 +5,8 @@ use ormpindexer::{
     planner::{
         PRODUCTION_EVM_CHAIN_IDS, SIGNATURE_PUB_ADDRESS, SIGNATURE_PUB_SIGNATURE_SUBMITTION_TOPIC,
         TRON_CHAIN_ID, TRON_MESSAGE_ACCEPTED_EVENT, TRON_MESSAGE_DISPATCHED_EVENT,
-        default_chain_config, default_evm_chain_config, default_tron_chain_config,
-        plan_evm_log_queries, plan_tron_event_queries,
+        TRON_MSGPORT_ADDRESS, TRON_ORMP_ADDRESS, default_chain_config, default_evm_chain_config,
+        default_tron_chain_config, plan_evm_log_queries, plan_tron_event_queries,
     },
 };
 
@@ -96,7 +96,16 @@ fn test_tron_chain_default_config_and_query_plans_are_available() {
     .expect("tron query plans");
 
     assert_eq!(chain.chain_id, TRON_CHAIN_ID);
-    assert!(!chain.contracts.is_empty());
+    assert_eq!(
+        TRON_ORMP_ADDRESS,
+        "415c5c383febe62f377f8c0ea1de97f2a2ba102e98"
+    );
+    assert_eq!(
+        TRON_MSGPORT_ADDRESS,
+        "413bc5362ec3a3dbc07292aed4ef18be18de02da3a"
+    );
+    assert!(chain.contracts.contains(&TRON_ORMP_ADDRESS.to_owned()));
+    assert!(chain.contracts.contains(&TRON_MSGPORT_ADDRESS.to_owned()));
     assert!(
         chain
             .topics

--- a/tests/datalens_warmup.rs
+++ b/tests/datalens_warmup.rs
@@ -102,8 +102,8 @@ fn test_tron_warmup_request_uses_ormp_selector_and_checkpoint_start() {
                 "kind": "other",
                 "value": {
                     "kind": "tron_events",
-                    "fingerprint": "tron-events/47bf6bd754c8e9955438fdc7",
-                    "canonical_key": "contracts/4113b2211a7ca45db2808f6db05557ce5347e3634e+412cd1867fb8016f93710b6386f7f9f1d540a60812+4157aa601a0377f5ab313c5a955ee874f5d495fc92/events/HashImported+MessageAccepted+MessageAssigned+MessageDispatched+MessageRecv+MessageSent+SignatureSubmittion"
+                    "fingerprint": "tron-events/7b3dbd4a0128ad9c818ddb13",
+                    "canonical_key": "contracts/413bc5362ec3a3dbc07292aed4ef18be18de02da3a+4157aa601a0377f5ab313c5a955ee874f5d495fc92+415c5c383febe62f377f8c0ea1de97f2a2ba102e98/events/HashImported+MessageAccepted+MessageAssigned+MessageDispatched+MessageRecv+MessageSent+SignatureSubmittion"
                 }
             },
             "range_kind": {"kind": "block"},


### PR DESCRIPTION
## Summary
- update Tron ORMP and Msgport default contract addresses to the production Tron contracts
- keep SignaturePub unchanged until separately verified
- update planner and warmup tests for the new Tron selector canonical key

## Tests
- cargo test --test datalens_planner --test datalens_warmup --test datalens_client --test tron_decoder
- cargo fmt --check