### PR TITLE
fix(tron): decode raw ABI block-scan events

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -99,10 +99,16 @@ pub fn decode_tron_event(log: &DatalensLog) -> anyhow::Result<LegacyOrmPEvent> {
         .as_deref()
         .context("Tron event is missing event_name")?;
     let metadata = tron_metadata(log)?;
-    let fields = log
+    let payload = log
         .non_indexed_fields
         .as_ref()
-        .context("Tron event is missing non_indexed_fields")?
+        .context("Tron event is missing non_indexed_fields")?;
+
+    if let Some(data) = payload.as_str() {
+        return decode_tron_raw_event(metadata, event_name, log, data);
+    }
+
+    let fields = payload
         .as_object()
         .context("Tron event payload must be an object")?;
 
@@ -118,6 +124,47 @@ pub fn decode_tron_event(log: &DatalensLog) -> anyhow::Result<LegacyOrmPEvent> {
         }
         _ => bail!("unsupported ORMP Tron event name {event_name}"),
     }
+}
+
+fn decode_tron_raw_event(
+    metadata: ChainLogMetadata,
+    event_name: &str,
+    log: &DatalensLog,
+    data: &str,
+) -> anyhow::Result<LegacyOrmPEvent> {
+    let topics = tron_raw_topics(log)?;
+    let data = decode_hex(data).context("decode Tron raw event data")?;
+
+    match event_name {
+        TRON_HASH_IMPORTED_EVENT => decode_hash_imported(metadata, &topics, &data),
+        TRON_MESSAGE_ACCEPTED_EVENT => decode_message_accepted(metadata, &topics, &data),
+        TRON_MESSAGE_ASSIGNED_EVENT => decode_message_assigned(metadata, &topics, &data),
+        TRON_MESSAGE_DISPATCHED_EVENT => decode_message_dispatched(metadata, &topics, &data),
+        TRON_MESSAGE_RECV_EVENT => decode_msgport_message_recv(metadata, &topics, &data),
+        TRON_MESSAGE_SENT_EVENT => decode_msgport_message_sent(metadata, &topics, &data),
+        TRON_SIGNATURE_SUBMITTION_EVENT | "SignatureSubmission" => {
+            decode_signature_submittion(metadata, &topics, &data)
+        }
+        _ => bail!("unsupported ORMP Tron event name {event_name}"),
+    }
+}
+
+fn tron_raw_topics(log: &DatalensLog) -> anyhow::Result<Vec<String>> {
+    if !log.indexed_fields.is_empty() {
+        return log
+            .indexed_fields
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                value
+                    .as_str()
+                    .map(ToOwned::to_owned)
+                    .with_context(|| format!("Tron indexed field {index} must be a hex string"))
+            })
+            .collect();
+    }
+
+    Ok(log.topics.clone())
 }
 
 fn tron_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {

--- a/tests/tron_decoder.rs
+++ b/tests/tron_decoder.rs
@@ -1,7 +1,11 @@
+use ethabi::{
+    Token, encode,
+    ethereum_types::{H160, U256},
+};
 use ormpindexer::{
     datalens::DatalensLog,
     decoder::decode_tron_event,
-    planner::TRON_CHAIN_ID,
+    planner::{ORMP_MESSAGE_ACCEPTED_TOPIC, TRON_CHAIN_ID},
     schema::{EventSource, LegacyOrmPEvent, MsgportMessageSentRow},
 };
 
@@ -74,6 +78,80 @@ fn test_decode_tron_message_sent_preserves_legacy_fields() {
 }
 
 #[test]
+fn test_decode_tron_raw_message_accepted_from_block_scan_fields() {
+    let log = DatalensLog {
+        id: Some("62254349-0xtrontx-7".to_owned()),
+        chain_id: TRON_CHAIN_ID,
+        block_number: 62_254_349,
+        block_hash: Some(
+            "0x9c64f37100000000000000000000000000000000000000000000000000000000".to_owned(),
+        ),
+        block_timestamp: Some(1_800_000_000_000),
+        transaction_hash: "trontx".to_owned(),
+        transaction_index: Some(4),
+        log_index: 7,
+        address: "415c5c383febe62f377f8c0ea1de97f2a2ba102e98".to_owned(),
+        transaction_from: Some("41ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD".to_owned()),
+        topics: Vec::new(),
+        data: "0x".to_owned(),
+        event_name: Some("MessageAccepted".to_owned()),
+        event_signature: Some(
+            ORMP_MESSAGE_ACCEPTED_TOPIC
+                .trim_start_matches("0x")
+                .to_owned(),
+        ),
+        indexed_fields: vec![
+            serde_json::json!(ORMP_MESSAGE_ACCEPTED_TOPIC.trim_start_matches("0x")),
+            serde_json::json!(bytes_hex(0x11).trim_start_matches("0x")),
+        ],
+        non_indexed_fields: Some(serde_json::json!(hex::encode(encode(&[Token::Tuple(
+            vec![
+                Token::Address(address(0x21)),
+                Token::Uint(U256::from(8)),
+                Token::Uint(U256::from(46)),
+                Token::Address(address(0x22)),
+                Token::Uint(U256::from(137)),
+                Token::Address(address(0x23)),
+                Token::Uint(U256::from(500_000)),
+                Token::Bytes(vec![0xab, 0xcd]),
+            ]
+        )])))),
+    };
+
+    let event = decode_tron_event(&log).expect("decode raw Tron block-scan event");
+
+    assert_eq!(
+        event,
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: ormpindexer::schema::ChainLogMetadata {
+                id: "62254349-0xtrontx-7".to_owned(),
+                source: EventSource::Tron,
+                chain_id: TRON_CHAIN_ID.into(),
+                block_number: 62_254_349,
+                block_hash: Some(
+                    "0x9c64f37100000000000000000000000000000000000000000000000000000000".to_owned(),
+                ),
+                block_timestamp: 1_800_000_000_000,
+                transaction_hash: "trontx".to_owned(),
+                transaction_index: 4,
+                log_index: 7,
+                contract_address: "415c5c383febe62f377f8c0ea1de97f2a2ba102e98".to_owned(),
+                transaction_from: Some("41abcdefabcdefabcdefabcdefabcdefabcdefabcd".to_owned()),
+            },
+            msg_hash: bytes_hex(0x11),
+            channel: address_hex(0x21),
+            index: 8,
+            from_chain_id: 46,
+            from: address_hex(0x22),
+            to_chain_id: 137,
+            to: address_hex(0x23),
+            gas_limit: 500_000,
+            encoded: "0xabcd".to_owned(),
+        }
+    );
+}
+
+#[test]
 fn test_decode_tron_errors_are_explicit() {
     let unsupported = DatalensLog {
         event_name: Some("Transfer".to_owned()),
@@ -87,16 +165,16 @@ fn test_decode_tron_errors_are_explicit() {
             .contains("unsupported ORMP Tron event name Transfer")
     );
 
-    let raw_payload = DatalensLog {
+    let malformed_raw_payload = DatalensLog {
         event_name: Some("MessageSent".to_owned()),
         non_indexed_fields: Some(serde_json::json!("0x1234")),
         ..tron_log()
     };
     assert!(
-        decode_tron_event(&raw_payload)
-            .expect_err("raw payload should fail")
+        decode_tron_event(&malformed_raw_payload)
+            .expect_err("malformed raw payload should fail")
             .to_string()
-            .contains("Tron event payload must be an object")
+            .contains("decode ABI event data")
     );
 
     let missing_field = DatalensLog {
@@ -144,4 +222,12 @@ fn tron_log() -> DatalensLog {
 
 fn bytes_hex(value: u8) -> String {
     format!("0x{}", hex::encode(vec![value; 32]))
+}
+
+fn address(value: u8) -> H160 {
+    H160::from_slice(&[value; 20])
+}
+
+fn address_hex(value: u8) -> String {
+    format!("0x{}", hex::encode([value; 20]))
 }


### PR DESCRIPTION
## Summary
- Add Tron raw ABI string payload decoding for Datalens block-scan rows.
- Reuse existing ABI decoder paths for ORMP events while preserving decoded TronGrid object payload handling.
- Add MessageAccepted block-scan coverage with no-0x topics/data and normalized decoded payload expectations.

## Validation
- cargo fmt --check
- cargo test --test tron_decoder --test legacy_parity

## Self-review
- Object payload dispatch remains unchanged for TronGrid rows.
- Raw topics come from Datalens indexedFields first, with topics fallback for existing log-shaped inputs.
- Hex strings without 0x are accepted through existing normalization/decode helpers.