### PR TITLE
fix(tron): version Datalens selector fingerprint

### DIFF
--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -756,7 +756,7 @@ fn tron_event_selector(
 
     Ok(json!({
         "kind": "tron_events",
-        "fingerprint": format!("tron-events/{}", digest_prefix(&canonical_key, 12)),
+        "fingerprint": format!("tron-events/ormp-v2/{}", digest_prefix(&canonical_key, 12)),
         "canonicalKey": canonical_key,
     }))
 }

--- a/src/warmup.rs
+++ b/src/warmup.rs
@@ -337,7 +337,7 @@ fn tron_event_selector(
 
     Ok(json!({
         "kind": "tron_events",
-        "fingerprint": format!("tron-events/{}", digest_prefix(&canonical_key, 12)),
+        "fingerprint": format!("tron-events/ormp-v2/{}", digest_prefix(&canonical_key, 12)),
         "canonical_key": canonical_key,
     }))
 }

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -238,11 +238,9 @@ fn test_tron_native_graphql_request_uses_other_selector_shape() {
         input["selector"]["other"]["canonicalKey"],
         "contracts/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t/events/MessageAccepted+MessageDispatched"
     );
-    assert!(
-        input["selector"]["other"]["fingerprint"]
-            .as_str()
-            .expect("fingerprint")
-            .starts_with("tron-events/")
+    assert_eq!(
+        input["selector"]["other"]["fingerprint"],
+        "tron-events/ormp-v2/2edc7c1723a90acd0d3d37c0"
     );
     assert_eq!(
         input["range"],

--- a/tests/datalens_warmup.rs
+++ b/tests/datalens_warmup.rs
@@ -102,7 +102,7 @@ fn test_tron_warmup_request_uses_ormp_selector_and_checkpoint_start() {
                 "kind": "other",
                 "value": {
                     "kind": "tron_events",
-                    "fingerprint": "tron-events/7b3dbd4a0128ad9c818ddb13",
+                    "fingerprint": "tron-events/ormp-v2/7b3dbd4a0128ad9c818ddb13",
                     "canonical_key": "contracts/413bc5362ec3a3dbc07292aed4ef18be18de02da3a+4157aa601a0377f5ab313c5a955ee874f5d495fc92+415c5c383febe62f377f8c0ea1de97f2a2ba102e98/events/HashImported+MessageAccepted+MessageAssigned+MessageDispatched+MessageRecv+MessageSent+SignatureSubmittion"
                 }
             },


### PR DESCRIPTION
## Summary
- version the Tron Datalens selector fingerprint namespace to `tron-events/ormp-v2/...`
- keep Tron selector canonical keys unchanged so the Datalens adapter can continue parsing contracts/events
- assert both live query and warmup selector payloads use the new fingerprint while preserving canonicalKey semantics

## Verification
- `cargo fmt --check`
- `cargo test --test datalens_client`
- `cargo test --test datalens_warmup`
- `cargo test`
