### PR TITLE
fix(indexer): align legacy data compatibility

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -5,8 +5,8 @@ use crate::{
     checkpoint::CheckpointStore,
     config::SecretString,
     schema::{
-        AssignmentConfig, LegacyOrmPEvent, MsgportMessageRecvRow, MsgportMessageSentRow,
-        OrmpHashImportedRow, OrmpMessageAcceptedRow, OrmpMessageAssignedRow,
+        AssignmentConfig, EventSource, LegacyOrmPEvent, MsgportMessageRecvRow,
+        MsgportMessageSentRow, OrmpHashImportedRow, OrmpMessageAcceptedRow, OrmpMessageAssignedRow,
         OrmpMessageDispatchedRow, SignaturePubSignatureSubmittionRow,
     },
 };
@@ -173,15 +173,29 @@ async fn write_legacy_event(
             insert_message_dispatched(tx, OrmpMessageDispatchedRow::from_event(event)).await
         }
         LegacyOrmPEvent::MsgportMessageRecv { .. } => {
+            if event_source(&event) == Some(EventSource::Tron) {
+                return Ok(());
+            }
             insert_msgport_message_recv(tx, MsgportMessageRecvRow::from_event(event)).await
         }
         LegacyOrmPEvent::MsgportMessageSent { .. } => {
+            if event_source(&event) == Some(EventSource::Tron) {
+                return Ok(());
+            }
             insert_msgport_message_sent(tx, MsgportMessageSentRow::from_event(event)).await
         }
         LegacyOrmPEvent::SignatureSubmittion { .. } => {
             insert_signature_submittion(tx, SignaturePubSignatureSubmittionRow::from_event(event))
                 .await
         }
+    }
+}
+
+fn event_source(event: &LegacyOrmPEvent) -> Option<EventSource> {
+    match event {
+        LegacyOrmPEvent::MsgportMessageRecv { metadata, .. }
+        | LegacyOrmPEvent::MsgportMessageSent { metadata, .. } => Some(metadata.source),
+        _ => None,
     }
 }
 

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -67,12 +67,44 @@ pub struct DatalensLogQueryResult {
     pub logs: Vec<DatalensLog>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensTransactionQuery {
+    pub chain_id: u64,
+    pub from_block: u64,
+    pub to_block: u64,
+    pub finality_mode: FinalityMode,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+pub struct DatalensTransaction {
+    #[serde(alias = "transaction_hash")]
+    pub hash: String,
+    #[serde(alias = "blockNumber")]
+    pub block_number: u64,
+    #[serde(alias = "transaction_from")]
+    pub from: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensTransactionQueryResult {
+    pub transactions: Vec<DatalensTransaction>,
+}
+
 #[allow(async_fn_in_trait)]
 pub trait DatalensLogReader {
     async fn latest_block(&self, chain_id: u64, finality_mode: FinalityMode)
     -> anyhow::Result<u64>;
 
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult>;
+
+    async fn query_transactions(
+        &self,
+        _query: DatalensTransactionQuery,
+    ) -> anyhow::Result<DatalensTransactionQueryResult> {
+        Ok(DatalensTransactionQueryResult {
+            transactions: Vec::new(),
+        })
+    }
 }
 
 #[derive(Clone)]
@@ -335,6 +367,38 @@ impl DatalensLogReader for DatalensHttpClient {
         let logs = logs_from_native_query_payload(&payload, query.chain_id)?;
         Ok(DatalensLogQueryResult { logs })
     }
+
+    async fn query_transactions(
+        &self,
+        query: DatalensTransactionQuery,
+    ) -> anyhow::Result<DatalensTransactionQueryResult> {
+        let request = native_graphql_transaction_request(&query)?;
+        let endpoint = self.native_graphql_endpoint();
+        let body = self
+            .request_text_with_retries(
+                "Datalens transaction query",
+                || {
+                    let mut builder = self
+                        .http
+                        .post(&endpoint)
+                        .header("x-datalens-application", &self.config.application)
+                        .json(&request);
+                    if let Some(token) = &self.config.token {
+                        builder = builder.bearer_auth(token.expose_secret());
+                    }
+                    builder
+                },
+                body_has_retryable_graphql_errors,
+            )
+            .await?;
+        let payload: serde_json::Value = serde_json::from_str(&body)?;
+        if let Some(errors) = payload.get("errors") {
+            anyhow::bail!("Datalens transaction query returned errors: {errors}");
+        }
+
+        let transactions = transactions_from_native_query_payload(&payload, query.chain_id)?;
+        Ok(DatalensTransactionQueryResult { transactions })
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -511,6 +575,25 @@ pub fn native_graphql_request(query: &DatalensLogQuery) -> anyhow::Result<serde_
     }))
 }
 
+pub fn native_graphql_transaction_request(
+    query: &DatalensTransactionQuery,
+) -> anyhow::Result<serde_json::Value> {
+    let input = evm_transaction_query_input(query)?;
+
+    Ok(json!({
+        "query": r#"
+            query OrmpIndexerTransactions($input: QueryInput!) {
+              query(input: $input) {
+                rows
+              }
+            }
+        "#,
+        "variables": {
+            "input": input
+        }
+    }))
+}
+
 pub fn logs_from_native_query_payload(
     payload: &serde_json::Value,
     chain_id: u64,
@@ -533,8 +616,29 @@ pub fn logs_from_native_query_payload(
         .collect()
 }
 
+pub fn transactions_from_native_query_payload(
+    payload: &serde_json::Value,
+    chain_id: u64,
+) -> anyhow::Result<Vec<DatalensTransaction>> {
+    if chain_id == TRON_CHAIN_ID {
+        anyhow::bail!("Datalens EVM transaction query does not support Tron chain {chain_id}");
+    }
+
+    let rows = payload
+        .pointer("/data/query/rows")
+        .cloned()
+        .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+    native_transaction_rows(&rows)
+}
+
 fn native_log_rows(rows: &serde_json::Value) -> anyhow::Result<Vec<NativeLogRow>> {
     let rows = native_rows(rows).context("Datalens native query response missing evm log rows")?;
+    Ok(serde_json::from_value(rows.clone())?)
+}
+
+fn native_transaction_rows(rows: &serde_json::Value) -> anyhow::Result<Vec<DatalensTransaction>> {
+    let rows =
+        native_rows(rows).context("Datalens native query response missing evm transaction rows")?;
     Ok(serde_json::from_value(rows.clone())?)
 }
 
@@ -686,6 +790,33 @@ fn evm_query_input(query: &DatalensLogQuery) -> anyhow::Result<serde_json::Value
                 "addresses": query.contracts,
                 "topics": topic_filters(&query.topics),
             },
+        },
+        "range": {
+            "kind": "block",
+            "start": query.from_block,
+            "end": query.to_block,
+        },
+        "finality": native_finality(query.finality_mode),
+        "fields": {},
+    }))
+}
+
+fn evm_transaction_query_input(
+    query: &DatalensTransactionQuery,
+) -> anyhow::Result<serde_json::Value> {
+    let chain_name = evm_chain_name(query.chain_id)?;
+    Ok(json!({
+        "chain": {
+            "family": { "kind": "evm" },
+            "configuredName": chain_name,
+            "networkId": { "numeric": query.chain_id },
+        },
+        "datasetKey": {
+            "family": "evm",
+            "name": "transactions",
+        },
+        "selector": {
+            "kind": "all",
         },
         "range": {
             "kind": "block",

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -34,6 +34,12 @@ pub struct EvmEventDecoder;
 impl EventDecoder for EvmEventDecoder {
     async fn decode(&self, log: &DatalensLog) -> anyhow::Result<Vec<LegacyOrmPEvent>> {
         if log.chain_id == TRON_CHAIN_ID {
+            if matches!(
+                log.event_name.as_deref(),
+                Some(TRON_MESSAGE_RECV_EVENT | TRON_MESSAGE_SENT_EVENT)
+            ) {
+                return Ok(Vec::new());
+            }
             return decode_tron_event(log).map(|event| vec![event]);
         }
 
@@ -66,6 +72,12 @@ pub fn decode_evm_log(log: &DatalensLog) -> anyhow::Result<LegacyOrmPEvent> {
 }
 
 fn evm_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
+    let block_timestamp = normalize_block_timestamp(
+        log.block_timestamp
+            .context("EVM log is missing block timestamp")?,
+    )
+    .context("EVM block timestamp overflows u64")?;
+
     Ok(ChainLogMetadata {
         id: log
             .id
@@ -75,10 +87,7 @@ fn evm_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
         chain_id: log.chain_id.into(),
         block_number: log.block_number.into(),
         block_hash: log.block_hash.clone(),
-        block_timestamp: log
-            .block_timestamp
-            .context("EVM log is missing block timestamp")?
-            .into(),
+        block_timestamp: block_timestamp.into(),
         transaction_hash: normalize_hex(&log.transaction_hash)?,
         transaction_index: log
             .transaction_index
@@ -168,6 +177,12 @@ fn tron_raw_topics(log: &DatalensLog) -> anyhow::Result<Vec<String>> {
 }
 
 fn tron_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
+    let block_timestamp = normalize_block_timestamp(
+        log.block_timestamp
+            .context("Tron event is missing block timestamp")?,
+    )
+    .context("Tron block timestamp overflows u64")?;
+
     Ok(ChainLogMetadata {
         id: log
             .id
@@ -177,11 +192,8 @@ fn tron_metadata(log: &DatalensLog) -> anyhow::Result<ChainLogMetadata> {
         chain_id: log.chain_id.into(),
         block_number: log.block_number.into(),
         block_hash: log.block_hash.clone(),
-        block_timestamp: log
-            .block_timestamp
-            .context("Tron event is missing block timestamp")?
-            .into(),
-        transaction_hash: log.transaction_hash.clone(),
+        block_timestamp: block_timestamp.into(),
+        transaction_hash: normalize_tron_transaction_hash(&log.transaction_hash),
         transaction_index: log
             .transaction_index
             .context("Tron event is missing transaction index")?,
@@ -718,6 +730,27 @@ fn normalize_hex(value: &str) -> anyhow::Result<String> {
         "invalid hex value"
     );
     Ok(format!("0x{}", value.to_ascii_lowercase()))
+}
+
+fn normalize_block_timestamp(value: u64) -> Option<u64> {
+    if (1_000_000_000..10_000_000_000).contains(&value) {
+        value.checked_mul(1_000)
+    } else {
+        Some(value)
+    }
+}
+
+fn normalize_tron_transaction_hash(value: &str) -> String {
+    let trimmed = value.trim();
+    let hex = trimmed
+        .strip_prefix("0x")
+        .or_else(|| trimmed.strip_prefix("0X"))
+        .unwrap_or(trimmed);
+    if hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        format!("0x{}", hex.to_ascii_lowercase())
+    } else {
+        trimmed.to_owned()
+    }
 }
 
 fn optional_field<'a>(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    collections::{BTreeSet, HashMap},
+    time::{Duration, Instant},
+};
 
 use tokio::time::sleep;
 
@@ -11,10 +14,10 @@ use crate::{
     database::EventWriter,
     datalens::{
         DatalensFailureKind, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader,
-        classify_datalens_failure_message,
+        DatalensTransactionQuery, classify_datalens_failure_message,
     },
     decoder::EventDecoder,
-    planner::chain_dataset,
+    planner::{MSGPORT_MESSAGE_SENT_TOPIC, TRON_CHAIN_ID, chain_dataset},
 };
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -325,8 +328,12 @@ where
         batch_started: Instant,
         result: DatalensLogQueryResult,
     ) -> anyhow::Result<ProcessedRangeReport> {
+        let records_read = result.logs.len();
+        let logs = self
+            .enrich_logs_with_transaction_senders(chain, result.logs)
+            .await?;
         let mut events = Vec::new();
-        for log in &result.logs {
+        for log in &logs {
             let topic0 = log
                 .topics
                 .first()
@@ -374,7 +381,7 @@ where
             range.from_block,
             range.to_block,
             target_block,
-            result.logs.len(),
+            records_read,
             events.len(),
             written,
             next_block,
@@ -388,12 +395,81 @@ where
         Ok(ProcessedRangeReport {
             next_block,
             ranges_queried: 1,
-            records_read: result.logs.len() as u64,
+            records_read: records_read as u64,
             records_decoded: events.len() as u64,
             records_written: written as u64,
             checkpoints_advanced: 1,
         })
     }
+
+    async fn enrich_logs_with_transaction_senders(
+        &self,
+        chain: &ChainConfig,
+        mut logs: Vec<crate::datalens::DatalensLog>,
+    ) -> anyhow::Result<Vec<crate::datalens::DatalensLog>> {
+        if chain.chain_id == TRON_CHAIN_ID || logs.iter().all(|log| log.transaction_from.is_some())
+        {
+            return Ok(logs);
+        }
+
+        let sender_blocks =
+            logs.iter()
+                .filter(|log| {
+                    log.transaction_from.is_none()
+                        && log.topics.first().is_some_and(|topic| {
+                            topic.eq_ignore_ascii_case(MSGPORT_MESSAGE_SENT_TOPIC)
+                        })
+                })
+                .map(|log| log.block_number)
+                .collect::<BTreeSet<_>>();
+        if sender_blocks.is_empty() {
+            return Ok(logs);
+        }
+
+        let mut transactions = Vec::new();
+        for block_number in sender_blocks {
+            transactions.extend(
+                self.reader
+                    .query_transactions(DatalensTransactionQuery {
+                        chain_id: chain.chain_id,
+                        from_block: block_number,
+                        to_block: block_number,
+                        finality_mode: self.config.finality_mode,
+                    })
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "query ORMP Datalens transactions chain_id={} block_number={}",
+                            chain.chain_id, block_number
+                        )
+                    })?
+                    .transactions,
+            );
+        }
+        let senders = transactions
+            .into_iter()
+            .map(|transaction| (sender_hash_key(&transaction.hash), transaction.from))
+            .collect::<HashMap<_, _>>();
+
+        for log in &mut logs {
+            if log.transaction_from.is_none() {
+                log.transaction_from = senders
+                    .get(&sender_hash_key(&log.transaction_hash))
+                    .cloned();
+            }
+        }
+
+        Ok(logs)
+    }
+}
+
+fn sender_hash_key(hash: &str) -> String {
+    let hash = hash.trim();
+    let hash = hash
+        .strip_prefix("0x")
+        .or_else(|| hash.strip_prefix("0X"))
+        .unwrap_or(hash);
+    format!("0x{}", hash.to_ascii_lowercase())
 }
 
 fn can_split_datalens_query_failure(error: &anyhow::Error, range: BlockRange) -> bool {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -156,6 +156,8 @@ pub const ADDRESS_RELAYER: &[&str] = &[
 pub const ADDRESS_ORACLE: &[&str] = &[
     "0x8d8a2bd991c1d900c59a82a2eeb0df44e0671aab",
     "0x2cdc7178013de451ed99607ac15def6bab8c37e6",
+    "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e",
+    "0xbe01b76ab454ae2497ae43168b1f70c92ac1c726",
 ];
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -1,7 +1,8 @@
 use ormpindexer::{
     datalens::{
         DatalensFailureKind, DatalensLog, classify_datalens_failure_message, evm_chain_name,
-        logs_from_native_query_payload, native_graphql_request, tron_chain_name,
+        logs_from_native_query_payload, native_graphql_request, native_graphql_transaction_request,
+        transactions_from_native_query_payload, tron_chain_name,
     },
     planner::TRON_CHAIN_ID,
 };
@@ -111,6 +112,49 @@ fn test_native_query_rows_decode_with_context_metadata() {
     assert_eq!(logs[0].transaction_from, None);
     assert_eq!(logs[0].topics, vec!["0xtopic"]);
     assert_eq!(logs[0].data, "0xdata");
+}
+
+#[test]
+fn test_evm_transaction_query_uses_transactions_dataset_and_decodes_senders() {
+    let request =
+        native_graphql_transaction_request(&ormpindexer::datalens::DatalensTransactionQuery {
+            chain_id: 46,
+            from_block: 100,
+            to_block: 110,
+            finality_mode: ormpindexer::config::FinalityMode::Durable,
+        })
+        .expect("build transaction request");
+    let input = &request["variables"]["input"];
+
+    assert_eq!(
+        input["datasetKey"],
+        serde_json::json!({"family": "evm", "name": "transactions"})
+    );
+    assert_eq!(input["selector"], serde_json::json!({"kind": "all"}));
+
+    let transactions = transactions_from_native_query_payload(
+        &serde_json::json!({
+            "data": {
+                "query": {
+                    "rows": {
+                        "dataset": "transactions",
+                        "rows": [{
+                            "hash": "0xtx",
+                            "block_number": 123,
+                            "from": "0xsender"
+                        }]
+                    }
+                }
+            }
+        }),
+        46,
+    )
+    .expect("decode transaction rows");
+
+    assert_eq!(transactions.len(), 1);
+    assert_eq!(transactions[0].hash, "0xtx");
+    assert_eq!(transactions[0].block_number, 123);
+    assert_eq!(transactions[0].from, "0xsender");
 }
 
 #[test]

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -243,6 +243,74 @@ fn test_decode_native_graphql_log_preserves_metadata_in_legacy_row() {
 }
 
 #[test]
+fn test_decode_evm_log_normalizes_second_timestamps_to_milliseconds() {
+    let seconds_log = DatalensLog {
+        block_timestamp: Some(1_700_000_000),
+        ..log(
+            MSGPORT_MESSAGE_RECV_TOPIC,
+            MSGPORT_ADDRESS,
+            encode(&[
+                Token::FixedBytes(bytes32(0x33)),
+                Token::Bool(false),
+                Token::Bytes(vec![0xff]),
+            ]),
+        )
+    };
+    let millis_log = DatalensLog {
+        block_timestamp: Some(1_700_000_000_000),
+        ..log(
+            MSGPORT_MESSAGE_RECV_TOPIC,
+            MSGPORT_ADDRESS,
+            encode(&[
+                Token::FixedBytes(bytes32(0x33)),
+                Token::Bool(false),
+                Token::Bytes(vec![0xff]),
+            ]),
+        )
+    };
+
+    let seconds_row = MsgportMessageSentRow::from_event(
+        decode_evm_log(&DatalensLog {
+            topics: vec![MSGPORT_MESSAGE_SENT_TOPIC.to_owned()],
+            data: format!(
+                "0x{}",
+                hex::encode(encode(&[
+                    Token::FixedBytes(bytes32(0x33)),
+                    Token::Address(address(0x30)),
+                    Token::Uint(U256::from(42161)),
+                    Token::Address(address(0x31)),
+                    Token::Bytes(vec![0xaa]),
+                    Token::Bytes(vec![0xbb, 0xcc]),
+                ]))
+            ),
+            ..seconds_log
+        })
+        .expect("decode seconds timestamp"),
+    );
+    let millis_row = MsgportMessageSentRow::from_event(
+        decode_evm_log(&DatalensLog {
+            topics: vec![MSGPORT_MESSAGE_SENT_TOPIC.to_owned()],
+            data: format!(
+                "0x{}",
+                hex::encode(encode(&[
+                    Token::FixedBytes(bytes32(0x33)),
+                    Token::Address(address(0x30)),
+                    Token::Uint(U256::from(42161)),
+                    Token::Address(address(0x31)),
+                    Token::Bytes(vec![0xaa]),
+                    Token::Bytes(vec![0xbb, 0xcc]),
+                ]))
+            ),
+            ..millis_log
+        })
+        .expect("decode millis timestamp"),
+    );
+
+    assert_eq!(seconds_row.block_timestamp, 1_700_000_000_000);
+    assert_eq!(millis_row.block_timestamp, 1_700_000_000_000);
+}
+
+#[test]
 fn test_decode_evm_indexed_topics_preserves_legacy_fields() {
     let msg_hash = bytes32(0x44);
     let hash_imported = DatalensLog {

--- a/tests/legacy_parity.rs
+++ b/tests/legacy_parity.rs
@@ -7,7 +7,7 @@ use sqlx::{PgPool, Row};
 use ormpindexer::{
     database::{EventWriter, PostgresEventWriter, apply_migrations},
     datalens::DatalensLog,
-    decoder::{decode_evm_log, decode_tron_event},
+    decoder::{EventDecoder, EvmEventDecoder, decode_evm_log},
     planner::{
         MSGPORT_ADDRESS, MSGPORT_MESSAGE_RECV_TOPIC, MSGPORT_MESSAGE_SENT_TOPIC, ORMP_ADDRESS,
         ORMP_HASH_IMPORTED_TOPIC, ORMP_MESSAGE_ACCEPTED_TOPIC, ORMP_MESSAGE_ASSIGNED_TOPIC,
@@ -31,12 +31,18 @@ fn test_evm_legacy_rows_match_subsquid_compatibility_expectations() {
     assert_eq!(compatibility_rows(&decoded), evm_expected_rows());
 }
 
-#[test]
-fn test_tron_structured_json_rows_match_subsquid_compatibility_expectations() {
-    let decoded = tron_fixture_logs()
-        .iter()
-        .map(|log| decode_tron_event(log).expect("decode Tron parity fixture"))
-        .collect::<Vec<_>>();
+#[tokio::test]
+async fn test_tron_structured_json_rows_match_subsquid_compatibility_expectations() {
+    let decoder = EvmEventDecoder;
+    let mut decoded = Vec::new();
+    for log in tron_fixture_logs() {
+        decoded.extend(
+            decoder
+                .decode(&log)
+                .await
+                .expect("decode Tron parity fixture"),
+        );
+    }
 
     assert_eq!(compatibility_rows(&decoded), tron_expected_rows());
 }
@@ -54,15 +60,19 @@ async fn test_postgres_writer_rows_match_subsquid_compatibility_expectations() {
     apply_migrations(&pool).await.expect("apply migrations");
     truncate_legacy_tables(&pool).await;
 
-    let events = evm_fixture_logs()
+    let mut events = evm_fixture_logs()
         .iter()
         .map(|log| decode_evm_log(log).expect("decode EVM parity fixture"))
-        .chain(
-            tron_fixture_logs()
-                .iter()
-                .map(|log| decode_tron_event(log).expect("decode Tron parity fixture")),
-        )
         .collect::<Vec<_>>();
+    let decoder = EvmEventDecoder;
+    for log in tron_fixture_logs() {
+        events.extend(
+            decoder
+                .decode(&log)
+                .await
+                .expect("decode Tron parity fixture"),
+        );
+    }
     let expected = legacy_expected_rows();
 
     let writer = PostgresEventWriter::new(pool.clone());
@@ -242,7 +252,6 @@ fn evm_expected_rows() -> Vec<CompatibilityRow> {
 fn tron_expected_rows() -> Vec<CompatibilityRow> {
     let msg_hash = bytes_hex(0x55);
     let hash = bytes_hex(0x66);
-    let msg_id = bytes_hex(0x33);
     let dispatch_hash = bytes_hex(0x77);
 
     let mut rows = vec![
@@ -304,37 +313,6 @@ fn tron_expected_rows() -> Vec<CompatibilityRow> {
             target_chain_id: TRON_CHAIN_ID.into(),
             msg_hash: dispatch_hash,
             dispatch_result: true,
-        }),
-        CompatibilityRow::MsgportMessageRecv(MsgportMessageRecvRow {
-            id: "0000000124-tron--000007".to_owned(),
-            block_number: 124,
-            transaction_hash: "tron-message-recv".to_owned(),
-            block_timestamp: 456_004,
-            transaction_index: 6,
-            log_index: 7,
-            chain_id: TRON_CHAIN_ID.into(),
-            port_address: "41abcdefabcdefabcdefabcdefabcdefabcdefabcd".to_owned(),
-            msg_id: msg_id.clone(),
-            result: false,
-            return_data: "0xff".to_owned(),
-        }),
-        CompatibilityRow::MsgportMessageSent(MsgportMessageSentRow {
-            id: "0000000123-tront-000003".to_owned(),
-            block_number: 123,
-            transaction_hash: "trontx".to_owned(),
-            block_timestamp: 456,
-            transaction_index: 2,
-            log_index: 3,
-            chain_id: TRON_CHAIN_ID.into(),
-            port_address: "41abcdefabcdefabcdefabcdefabcdefabcdefabcd".to_owned(),
-            transaction_from: None,
-            from_chain_id: TRON_CHAIN_ID.into(),
-            msg_id: bytes_hex(0x33),
-            from_dapp: "0x0000000000000000000000000000000000000030".to_owned(),
-            to_chain_id: 42161,
-            to_dapp: "0x0000000000000000000000000000000000000031".to_owned(),
-            message: "0xaa".to_owned(),
-            params: "0xbbcc".to_owned(),
         }),
         CompatibilityRow::SignatureSubmittion(SignaturePubSignatureSubmittionRow {
             id: "0000000126-tron--000009".to_owned(),

--- a/tests/runtime_skeleton.rs
+++ b/tests/runtime_skeleton.rs
@@ -8,10 +8,14 @@ use ormpindexer::{
     checkpoint::{Checkpoint, CheckpointStore, InMemoryCheckpointStore, plan_next_range},
     config::{FinalityMode, RuntimeConfig},
     database::{DryRunEventWriter, EventWriter},
-    datalens::{DatalensLog, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader},
-    decoder::NoopDecoder,
+    datalens::{
+        DatalensLog, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader,
+        DatalensTransaction, DatalensTransactionQuery, DatalensTransactionQueryResult,
+    },
+    decoder::{EventDecoder, NoopDecoder},
+    planner::MSGPORT_MESSAGE_SENT_TOPIC,
     runner::{IndexerRunner, RunnerReport},
-    schema::LegacyOrmPEvent,
+    schema::{ChainLogMetadata, EventSource, LegacyOrmPEvent},
 };
 
 #[test]
@@ -379,6 +383,81 @@ async fn test_runner_successful_batch_advances_checkpoint_to_next_range() {
         }
     );
     assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 15);
+}
+
+#[tokio::test]
+async fn test_runner_enriches_evm_logs_with_transaction_senders() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "10".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let tx_hash = format!("0x{}", "aa".repeat(32));
+    let reader = RecordingDatalensReader::new(vec![DatalensLog {
+        id: Some("46-12-0".to_owned()),
+        chain_id: 46,
+        block_number: 12,
+        block_hash: None,
+        block_timestamp: Some(1_700_000_000_000),
+        transaction_hash: tx_hash.trim_start_matches("0x").to_ascii_uppercase(),
+        transaction_index: Some(0),
+        log_index: 1,
+        address: "0x333".to_owned(),
+        transaction_from: None,
+        topics: vec![MSGPORT_MESSAGE_SENT_TOPIC.to_owned()],
+        data: "0x".to_owned(),
+        event_name: None,
+        event_signature: None,
+        indexed_fields: Vec::new(),
+        non_indexed_fields: None,
+    }])
+    .with_head(46, 15)
+    .with_transactions(vec![DatalensTransaction {
+        hash: tx_hash,
+        block_number: 12,
+        from: "0xsender".to_owned(),
+    }]);
+    let tx_queries = reader.transaction_queries();
+    let writer = RecordingEventWriter::default();
+    let runner = IndexerRunner::new(
+        config,
+        reader,
+        InMemoryCheckpointStore::default(),
+        EchoTransactionFromDecoder,
+        writer.clone(),
+    );
+
+    runner.run_once().await.expect("batch pass succeeds");
+
+    let events = writer.events();
+    assert_eq!(events.len(), 1);
+    match &events[0] {
+        LegacyOrmPEvent::MsgportMessageSent { metadata, .. } => {
+            assert_eq!(metadata.transaction_from.as_deref(), Some("0xsender"));
+        }
+        _ => panic!("expected MsgportMessageSent event"),
+    }
+    assert_eq!(
+        tx_queries
+            .lock()
+            .expect("transaction queries lock")
+            .as_slice(),
+        &[DatalensTransactionQuery {
+            chain_id: 46,
+            from_block: 12,
+            to_block: 12,
+            finality_mode: FinalityMode::Finalized,
+        }]
+    );
 }
 
 #[tokio::test]
@@ -991,28 +1070,41 @@ async fn test_runner_loop_recovers_chain_errors_without_blocking_other_chains() 
 #[derive(Clone)]
 struct RecordingDatalensReader {
     logs: Vec<DatalensLog>,
+    transactions: Vec<DatalensTransaction>,
     heads: BTreeMap<u64, u64>,
     query_delays: BTreeMap<u64, Duration>,
     query_failures: BTreeMap<u64, String>,
     range_query_failures: BTreeMap<(u64, u64, u64), String>,
     queries: Arc<Mutex<Vec<DatalensLogQuery>>>,
+    transaction_queries: Arc<Mutex<Vec<DatalensTransactionQuery>>>,
 }
 
 impl RecordingDatalensReader {
     fn new(logs: Vec<DatalensLog>) -> Self {
         Self {
             logs,
+            transactions: Vec::new(),
             heads: BTreeMap::new(),
             query_delays: BTreeMap::new(),
             query_failures: BTreeMap::new(),
             range_query_failures: BTreeMap::new(),
             queries: Arc::new(Mutex::new(Vec::new())),
+            transaction_queries: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
     fn with_head(mut self, chain_id: u64, head: u64) -> Self {
         self.heads.insert(chain_id, head);
         self
+    }
+
+    fn with_transactions(mut self, transactions: Vec<DatalensTransaction>) -> Self {
+        self.transactions = transactions;
+        self
+    }
+
+    fn transaction_queries(&self) -> Arc<Mutex<Vec<DatalensTransactionQuery>>> {
+        self.transaction_queries.clone()
     }
 
     fn with_query_delay(mut self, chain_id: u64, delay: Duration) -> Self {
@@ -1067,6 +1159,76 @@ impl DatalensLogReader for RecordingDatalensReader {
         Ok(DatalensLogQueryResult {
             logs: self.logs.clone(),
         })
+    }
+
+    async fn query_transactions(
+        &self,
+        query: DatalensTransactionQuery,
+    ) -> anyhow::Result<DatalensTransactionQueryResult> {
+        self.transaction_queries
+            .lock()
+            .expect("transaction queries lock")
+            .push(query.clone());
+        Ok(DatalensTransactionQueryResult {
+            transactions: self
+                .transactions
+                .iter()
+                .filter(|transaction| {
+                    transaction.block_number >= query.from_block
+                        && transaction.block_number <= query.to_block
+                })
+                .cloned()
+                .collect(),
+        })
+    }
+}
+
+struct EchoTransactionFromDecoder;
+
+impl EventDecoder for EchoTransactionFromDecoder {
+    async fn decode(&self, log: &DatalensLog) -> anyhow::Result<Vec<LegacyOrmPEvent>> {
+        Ok(vec![LegacyOrmPEvent::MsgportMessageSent {
+            metadata: ChainLogMetadata {
+                id: log.id.clone().expect("test log id"),
+                source: EventSource::Evm,
+                chain_id: log.chain_id.into(),
+                block_number: log.block_number.into(),
+                block_hash: log.block_hash.clone(),
+                block_timestamp: log.block_timestamp.expect("test timestamp").into(),
+                transaction_hash: log.transaction_hash.clone(),
+                transaction_index: log.transaction_index.expect("test transaction index"),
+                log_index: i32::try_from(log.log_index).expect("test log index"),
+                contract_address: log.address.clone(),
+                transaction_from: log.transaction_from.clone(),
+            },
+            msg_id: "0xmsgid".to_owned(),
+            from_dapp: "0xfromdapp".to_owned(),
+            to_chain_id: 1,
+            to_dapp: "0xtodapp".to_owned(),
+            message: "0xmessage".to_owned(),
+            params: "0xparams".to_owned(),
+        }])
+    }
+}
+
+#[derive(Clone, Default)]
+struct RecordingEventWriter {
+    events: Arc<Mutex<Vec<LegacyOrmPEvent>>>,
+}
+
+impl RecordingEventWriter {
+    fn events(&self) -> Vec<LegacyOrmPEvent> {
+        self.events.lock().expect("events lock").clone()
+    }
+}
+
+impl EventWriter for RecordingEventWriter {
+    async fn write_events(&self, events: &[LegacyOrmPEvent]) -> anyhow::Result<usize> {
+        self.events
+            .lock()
+            .expect("events lock")
+            .extend_from_slice(events);
+        Ok(events.len())
     }
 }
 

--- a/tests/schema_compatibility.rs
+++ b/tests/schema_compatibility.rs
@@ -76,6 +76,122 @@ fn test_assigned_backfills_accepted_when_configured_addresses_match() {
 }
 
 #[test]
+fn test_legacy_oracle_allowlist_matches_verified_endpoint_behavior() {
+    let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
+        metadata: evm_metadata("accepted-log"),
+        msg_hash: "0x01e4449fa917170d8f95cbefd3c854a04e503b5ba13485c3e2278087f88e3373".to_owned(),
+        channel: "0xchannel".to_owned(),
+        index: 8,
+        from_chain_id: 1,
+        from: "0xfrom".to_owned(),
+        to_chain_id: 46,
+        to: "0xto".to_owned(),
+        gas_limit: 500_000,
+        encoded: "0xencoded".to_owned(),
+    });
+    let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+        metadata: evm_metadata("assigned-log"),
+        msg_hash: accepted.id.clone(),
+        oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
+        relayer: "0x0000000000000000000000000000000000000001".to_owned(),
+        oracle_fee: 11,
+        relayer_fee: 22,
+        params: "0xparams".to_owned(),
+    });
+
+    let updated = apply_assignment_to_accepted(
+        &mut accepted,
+        &assigned,
+        &AssignmentConfig::legacy_defaults(),
+    );
+
+    assert!(updated.oracle);
+    assert!(!updated.relayer);
+    assert_eq!(
+        accepted.oracle.as_deref(),
+        Some("0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e")
+    );
+    assert_eq!(accepted.oracle_assigned, Some(true));
+    assert_eq!(accepted.oracle_assigned_fee, Some(11));
+
+    let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
+        metadata: evm_metadata("accepted-log-2"),
+        msg_hash: "0xother".to_owned(),
+        channel: "0xchannel".to_owned(),
+        index: 9,
+        from_chain_id: 1,
+        from: "0xfrom".to_owned(),
+        to_chain_id: 46,
+        to: "0xto".to_owned(),
+        gas_limit: 500_000,
+        encoded: "0xencoded".to_owned(),
+    });
+    let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+        metadata: evm_metadata("assigned-log-2"),
+        msg_hash: accepted.id.clone(),
+        oracle: "0xbe01b76ab454ae2497ae43168b1f70c92ac1c726".to_owned(),
+        relayer: "0x0000000000000000000000000000000000000001".to_owned(),
+        oracle_fee: 33,
+        relayer_fee: 44,
+        params: "0xparams".to_owned(),
+    });
+
+    let updated = apply_assignment_to_accepted(
+        &mut accepted,
+        &assigned,
+        &AssignmentConfig::legacy_defaults(),
+    );
+
+    assert!(updated.oracle);
+    assert_eq!(
+        accepted.oracle.as_deref(),
+        Some("0xbe01b76ab454ae2497ae43168b1f70c92ac1c726")
+    );
+    assert_eq!(accepted.oracle_assigned_fee, Some(33));
+}
+
+#[test]
+fn test_unverified_oracles_do_not_backfill_unconditionally() {
+    for oracle in [
+        "0xd250c974cbe8eea25ab75c0fc9a18d612ae4b043",
+        "0x985bddbc7e66964f131e3161ba8864f481cbcb2d",
+    ] {
+        let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata("accepted-log"),
+            msg_hash: "0xmsg".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 8,
+            from_chain_id: 1,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 46,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        });
+        let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("assigned-log"),
+            msg_hash: "0xmsg".to_owned(),
+            oracle: oracle.to_owned(),
+            relayer: "0x0000000000000000000000000000000000000001".to_owned(),
+            oracle_fee: 11,
+            relayer_fee: 22,
+            params: "0xparams".to_owned(),
+        });
+
+        let updated = apply_assignment_to_accepted(
+            &mut accepted,
+            &assigned,
+            &AssignmentConfig::legacy_defaults(),
+        );
+
+        assert!(!updated.oracle, "unexpected oracle backfill for {oracle}");
+        assert_eq!(accepted.oracle, None);
+        assert_eq!(accepted.oracle_assigned, None);
+        assert_eq!(accepted.oracle_assigned_fee, None);
+    }
+}
+
+#[test]
 fn test_msgport_sent_and_recv_preserve_event_metadata() {
     let sent_metadata = ChainLogMetadata {
         id: "42161-466386813-0x0f1e4961852aada25e6fda15c4883c7512e2f14c584e0d0917b03d9758682a57-14"

--- a/tests/tron_decoder.rs
+++ b/tests/tron_decoder.rs
@@ -4,7 +4,7 @@ use ethabi::{
 };
 use ormpindexer::{
     datalens::DatalensLog,
-    decoder::decode_tron_event,
+    decoder::{EventDecoder, EvmEventDecoder, decode_tron_event},
     planner::{ORMP_MESSAGE_ACCEPTED_TOPIC, TRON_CHAIN_ID},
     schema::{EventSource, LegacyOrmPEvent, MsgportMessageSentRow},
 };
@@ -149,6 +149,56 @@ fn test_decode_tron_raw_message_accepted_from_block_scan_fields() {
             encoded: "0xabcd".to_owned(),
         }
     );
+}
+
+#[test]
+fn test_decode_tron_event_normalizes_timestamp_and_transaction_hash() {
+    let log = DatalensLog {
+        block_timestamp: Some(1_800_000_000),
+        transaction_hash: "ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD"
+            .to_owned(),
+        ..tron_log()
+    };
+
+    let event = decode_tron_event(&DatalensLog {
+        event_name: Some("MessageAccepted".to_owned()),
+        non_indexed_fields: Some(serde_json::json!({
+            "msgHash": bytes_hex(0x11),
+            "message": {
+                "channel": "41CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+                "index": "8",
+                "fromChainId": "46",
+                "from": "41DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+                "toChainId": "137",
+                "to": "41EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE",
+                "gasLimit": "500000",
+                "encoded": "0xabcd"
+            }
+        })),
+        ..log
+    })
+    .expect("decode Tron event");
+
+    match event {
+        LegacyOrmPEvent::MessageAccepted { metadata, .. } => {
+            assert_eq!(metadata.block_timestamp, 1_800_000_000_000);
+            assert_eq!(
+                metadata.transaction_hash,
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            );
+        }
+        _ => panic!("expected MessageAccepted event"),
+    }
+}
+
+#[tokio::test]
+async fn test_evm_event_decoder_suppresses_tron_msgport_events() {
+    let events = EvmEventDecoder
+        .decode(&tron_log())
+        .await
+        .expect("decode Tron MessageSent through production decoder");
+
+    assert!(events.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- normalize legacy timestamps and Tron transaction hashes
- enrich EVM msgport senders from Datalens transactions
- align assignment oracle allowlist and suppress Tron msgport rows for legacy parity

## Tests
- cargo fmt && cargo test && git diff origin/main --check