### PR TITLE
fix(indexer): constrain legacy b49e oracle parity

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -5,9 +5,10 @@ use crate::{
     checkpoint::CheckpointStore,
     config::SecretString,
     schema::{
-        AssignmentConfig, EventSource, LegacyOrmPEvent, MsgportMessageRecvRow,
-        MsgportMessageSentRow, OrmpHashImportedRow, OrmpMessageAcceptedRow, OrmpMessageAssignedRow,
-        OrmpMessageDispatchedRow, SignaturePubSignatureSubmittionRow,
+        AssignmentConfig, EventSource, LEGACY_B49E_ORACLE, LEGACY_B49E_ORACLE_FROM_BLOCK,
+        LegacyOrmPEvent, MsgportMessageRecvRow, MsgportMessageSentRow, OrmpHashImportedRow,
+        OrmpMessageAcceptedRow, OrmpMessageAssignedRow, OrmpMessageDispatchedRow,
+        SignaturePubSignatureSubmittionRow,
     },
 };
 
@@ -343,19 +344,21 @@ async fn backfill_message_assignment(
     row: &OrmpMessageAssignedRow,
     assignment_config: &AssignmentConfig,
 ) -> anyhow::Result<()> {
-    let oracle_match = contains_address(&assignment_config.oracle_addresses, &row.oracle);
+    let legacy_b49e_oracle_match = row.oracle.eq_ignore_ascii_case(LEGACY_B49E_ORACLE);
+    let oracle_match = contains_address(&assignment_config.oracle_addresses, &row.oracle)
+        && !legacy_b49e_oracle_match;
     let relayer_match = contains_address(&assignment_config.relayer_addresses, &row.relayer);
 
-    if !oracle_match && !relayer_match {
+    if !oracle_match && !legacy_b49e_oracle_match && !relayer_match {
         return Ok(());
     }
 
     sqlx::query(
         "UPDATE ormp_message_accepted
          SET
-            oracle = CASE WHEN $2 THEN $3 ELSE oracle END,
-            oracle_assigned = CASE WHEN $2 THEN TRUE ELSE oracle_assigned END,
-            oracle_assigned_fee = CASE WHEN $2 THEN $4::NUMERIC ELSE oracle_assigned_fee END,
+            oracle = CASE WHEN $2 OR ($8 AND chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) THEN $3 ELSE oracle END,
+            oracle_assigned = CASE WHEN $2 OR ($8 AND chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) THEN TRUE ELSE oracle_assigned END,
+            oracle_assigned_fee = CASE WHEN $2 OR ($8 AND chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) THEN $4::NUMERIC ELSE oracle_assigned_fee END,
             relayer = CASE WHEN $5 THEN $6 ELSE relayer END,
             relayer_assigned = CASE WHEN $5 THEN TRUE ELSE relayer_assigned END,
             relayer_assigned_fee = CASE WHEN $5 THEN $7::NUMERIC ELSE relayer_assigned_fee END
@@ -368,6 +371,8 @@ async fn backfill_message_assignment(
     .bind(relayer_match)
     .bind(&row.relayer)
     .bind(row.relayer_fee.to_string())
+    .bind(legacy_b49e_oracle_match)
+    .bind(LEGACY_B49E_ORACLE_FROM_BLOCK.to_string())
     .execute(&mut **tx)
     .await
     .context("backfill ormp_message_accepted assignment fields")?;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -156,8 +156,10 @@ pub const ADDRESS_RELAYER: &[&str] = &[
 pub const ADDRESS_ORACLE: &[&str] = &[
     "0x8d8a2bd991c1d900c59a82a2eeb0df44e0671aab",
     "0x2cdc7178013de451ed99607ac15def6bab8c37e6",
-    "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e",
 ];
+
+pub const LEGACY_B49E_ORACLE: &str = "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e";
+pub const LEGACY_B49E_ORACLE_FROM_BLOCK: u128 = 22_474_070;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssignmentConfig {
@@ -204,7 +206,7 @@ pub fn apply_assignment_to_accepted(
         update.relayer = true;
     }
 
-    if contains_address(&config.oracle_addresses, &assigned.oracle) {
+    if is_oracle_assignment_for_accepted(accepted, assigned, config) {
         accepted.oracle = Some(assigned.oracle.clone());
         accepted.oracle_assigned = Some(true);
         accepted.oracle_assigned_fee = Some(assigned.oracle_fee);
@@ -212,6 +214,20 @@ pub fn apply_assignment_to_accepted(
     }
 
     update
+}
+
+pub fn is_oracle_assignment_for_accepted(
+    accepted: &OrmpMessageAcceptedRow,
+    assigned: &OrmpMessageAssignedRow,
+    config: &AssignmentConfig,
+) -> bool {
+    (contains_address(&config.oracle_addresses, &assigned.oracle)
+        && !assigned.oracle.eq_ignore_ascii_case(LEGACY_B49E_ORACLE))
+        || (assigned.oracle.eq_ignore_ascii_case(LEGACY_B49E_ORACLE)
+            && accepted.chain_id == 1
+            && accepted.from_chain_id == 1
+            && accepted.to_chain_id == 46
+            && accepted.block_number >= LEGACY_B49E_ORACLE_FROM_BLOCK)
 }
 
 fn contains_address(addresses: &[String], candidate: &str) -> bool {

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -32,8 +32,8 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(written, events.len());
     assert_eq!(repeated, events.len());
     assert_table_count(&pool, "ormp_hash_imported", 1).await;
-    assert_table_count(&pool, "ormp_message_accepted", 1).await;
-    assert_table_count(&pool, "ormp_message_assigned", 3).await;
+    assert_table_count(&pool, "ormp_message_accepted", 3).await;
+    assert_table_count(&pool, "ormp_message_assigned", 5).await;
     assert_table_count(&pool, "ormp_message_dispatched", 1).await;
     assert_table_count(&pool, "msgport_message_recv", 1).await;
     assert_table_count(&pool, "msgport_message_sent", 1).await;
@@ -66,6 +66,19 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(accepted.3.as_deref(), Some(ADDRESS_RELAYER[0]));
     assert_eq!(accepted.4, Some(true));
     assert_eq!(accepted.5.as_deref(), Some("22"));
+
+    let b49e_positive = assignment_fields(&pool, "0xb49e-positive").await;
+    assert_eq!(
+        b49e_positive.0.as_deref(),
+        Some("0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e")
+    );
+    assert_eq!(b49e_positive.1, Some(true));
+    assert_eq!(b49e_positive.2.as_deref(), Some("2000000000000"));
+
+    let b49e_negative = assignment_fields(&pool, "0xb49e-negative").await;
+    assert_eq!(b49e_negative.0, None);
+    assert_eq!(b49e_negative.1, None);
+    assert_eq!(b49e_negative.2, None);
 
     let writer = PostgresEventWriter::new(pool.clone());
     writer
@@ -134,6 +147,30 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
             gas_limit: 500_000,
             encoded: "0xencoded".to_owned(),
         },
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata_at("b49e-positive-log", 1, 22_474_070),
+            msg_hash: "0xb49e-positive".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 9,
+            from_chain_id: 1,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 46,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata_at("b49e-negative-log", 1, 22_336_887),
+            msg_hash: "0xb49e-negative".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 10,
+            from_chain_id: 1,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 42_161,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
         LegacyOrmPEvent::MessageAssigned {
             metadata: evm_metadata("assigned-log"),
             msg_hash: "0xaccepted".to_owned(),
@@ -159,6 +196,24 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
             relayer: ADDRESS_RELAYER[0].to_owned(),
             oracle_fee: 55,
             relayer_fee: 66,
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("b49e-positive-assigned-log"),
+            msg_hash: "0xb49e-positive".to_owned(),
+            oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
+            relayer: "0x0000000000000000000000000000000000000002".to_owned(),
+            oracle_fee: 2_000_000_000_000,
+            relayer_fee: 44,
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("b49e-negative-assigned-log"),
+            msg_hash: "0xb49e-negative".to_owned(),
+            oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
+            relayer: "0x0000000000000000000000000000000000000002".to_owned(),
+            oracle_fee: 40_000_000_000_000,
+            relayer_fee: 44,
             params: "0xparams".to_owned(),
         },
         LegacyOrmPEvent::MessageDispatched {
@@ -195,11 +250,15 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
 }
 
 fn evm_metadata(id: &str) -> ChainLogMetadata {
+    evm_metadata_at(id, 46, 123)
+}
+
+fn evm_metadata_at(id: &str, chain_id: u128, block_number: u128) -> ChainLogMetadata {
     ChainLogMetadata {
         id: id.to_owned(),
         source: EventSource::Evm,
-        chain_id: 46,
-        block_number: 123,
+        chain_id,
+        block_number,
         block_hash: None,
         block_timestamp: 456,
         transaction_hash: "0xtx".to_owned(),
@@ -208,6 +267,21 @@ fn evm_metadata(id: &str) -> ChainLogMetadata {
         contract_address: "0xport".to_owned(),
         transaction_from: Some("0xsender".to_owned()),
     }
+}
+
+async fn assignment_fields(
+    pool: &PgPool,
+    msg_hash: &str,
+) -> (Option<String>, Option<bool>, Option<String>) {
+    sqlx::query_as::<_, (Option<String>, Option<bool>, Option<String>)>(
+        r#"SELECT oracle, oracle_assigned, oracle_assigned_fee::TEXT
+           FROM ormp_message_accepted
+           WHERE id = $1"#,
+    )
+    .bind(msg_hash)
+    .fetch_one(pool)
+    .await
+    .expect("fetch accepted assignment fields")
 }
 
 async fn assert_table_count(pool: &PgPool, table: &str, expected: i64) {

--- a/tests/schema_compatibility.rs
+++ b/tests/schema_compatibility.rs
@@ -75,8 +75,10 @@ fn test_assigned_backfills_accepted_when_configured_addresses_match() {
     assert_eq!(accepted.relayer_assigned_fee, Some(22));
 }
 
+const LEGACY_B49E_ORACLE: &str = "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e";
+
 #[test]
-fn test_legacy_oracle_allowlist_matches_verified_endpoint_behavior() {
+fn test_legacy_b49e_oracle_backfills_ethereum_to_darwinia_after_cutover() {
     let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
         metadata: evm_metadata("accepted-log"),
         msg_hash: "0x01e4449fa917170d8f95cbefd3c854a04e503b5ba13485c3e2278087f88e3373".to_owned(),
@@ -89,12 +91,14 @@ fn test_legacy_oracle_allowlist_matches_verified_endpoint_behavior() {
         gas_limit: 500_000,
         encoded: "0xencoded".to_owned(),
     });
+    accepted.chain_id = 1;
+    accepted.block_number = 23_738_310;
     let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
         metadata: evm_metadata("assigned-log"),
         msg_hash: accepted.id.clone(),
-        oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
+        oracle: LEGACY_B49E_ORACLE.to_owned(),
         relayer: "0x0000000000000000000000000000000000000001".to_owned(),
-        oracle_fee: 11,
+        oracle_fee: 2_000_000_000_000,
         relayer_fee: 22,
         params: "0xparams".to_owned(),
     });
@@ -107,12 +111,56 @@ fn test_legacy_oracle_allowlist_matches_verified_endpoint_behavior() {
 
     assert!(updated.oracle);
     assert!(!updated.relayer);
-    assert_eq!(
-        accepted.oracle.as_deref(),
-        Some("0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e")
-    );
+    assert_eq!(accepted.oracle.as_deref(), Some(LEGACY_B49E_ORACLE));
     assert_eq!(accepted.oracle_assigned, Some(true));
-    assert_eq!(accepted.oracle_assigned_fee, Some(11));
+    assert_eq!(accepted.oracle_assigned_fee, Some(2_000_000_000_000));
+}
+
+#[test]
+fn test_legacy_b49e_oracle_does_not_backfill_outside_ethereum_to_darwinia_cutover() {
+    for (chain_id, from_chain_id, to_chain_id, block_number) in [
+        (1, 1, 42_161, 22_336_887),
+        (1, 1, 46, 22_363_073),
+        (46, 46, 1, 23_738_310),
+    ] {
+        let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata("accepted-log"),
+            msg_hash: "0xmsg".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 8,
+            from_chain_id,
+            from: "0xfrom".to_owned(),
+            to_chain_id,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        });
+        accepted.chain_id = chain_id;
+        accepted.block_number = block_number;
+        let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("assigned-log"),
+            msg_hash: "0xmsg".to_owned(),
+            oracle: LEGACY_B49E_ORACLE.to_owned(),
+            relayer: "0x0000000000000000000000000000000000000001".to_owned(),
+            oracle_fee: 11,
+            relayer_fee: 22,
+            params: "0xparams".to_owned(),
+        });
+
+        let updated = apply_assignment_to_accepted(
+            &mut accepted,
+            &assigned,
+            &AssignmentConfig::legacy_defaults(),
+        );
+
+        assert!(
+            !updated.oracle,
+            "unexpected b49e oracle backfill for chain {chain_id}, from {from_chain_id}, to {to_chain_id}, block {block_number}"
+        );
+        assert_eq!(accepted.oracle, None);
+        assert_eq!(accepted.oracle_assigned, None);
+        assert_eq!(accepted.oracle_assigned_fee, None);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- constrain legacy b49e oracle backfill to the verified Ethereum -> Darwinia cutover window
- keep other legacy oracle allowlist behavior unchanged
- add schema and Postgres writer coverage for positive and negative b49e cases

## Tests
- cargo test
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5434/ormpindexer_test cargo test --test postgres_writer test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_assignments -- --nocapture