### PR TITLE
fix(indexer): add Darwinia b49e oracle cutover

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -5,10 +5,10 @@ use crate::{
     checkpoint::CheckpointStore,
     config::SecretString,
     schema::{
-        AssignmentConfig, EventSource, LEGACY_B49E_ORACLE, LEGACY_B49E_ORACLE_FROM_BLOCK,
-        LegacyOrmPEvent, MsgportMessageRecvRow, MsgportMessageSentRow, OrmpHashImportedRow,
-        OrmpMessageAcceptedRow, OrmpMessageAssignedRow, OrmpMessageDispatchedRow,
-        SignaturePubSignatureSubmittionRow,
+        AssignmentConfig, EventSource, LEGACY_B49E_DARWINIA_FROM_BLOCK, LEGACY_B49E_ORACLE,
+        LEGACY_B49E_ORACLE_FROM_BLOCK, LegacyOrmPEvent, MsgportMessageRecvRow,
+        MsgportMessageSentRow, OrmpHashImportedRow, OrmpMessageAcceptedRow, OrmpMessageAssignedRow,
+        OrmpMessageDispatchedRow, SignaturePubSignatureSubmittionRow,
     },
 };
 
@@ -356,9 +356,9 @@ async fn backfill_message_assignment(
     sqlx::query(
         "UPDATE ormp_message_accepted
          SET
-            oracle = CASE WHEN $2 OR ($8 AND chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) THEN $3 ELSE oracle END,
-            oracle_assigned = CASE WHEN $2 OR ($8 AND chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) THEN TRUE ELSE oracle_assigned END,
-            oracle_assigned_fee = CASE WHEN $2 OR ($8 AND chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) THEN $4::NUMERIC ELSE oracle_assigned_fee END,
+            oracle = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC))) THEN $3 ELSE oracle END,
+            oracle_assigned = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC))) THEN TRUE ELSE oracle_assigned END,
+            oracle_assigned_fee = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC))) THEN $4::NUMERIC ELSE oracle_assigned_fee END,
             relayer = CASE WHEN $5 THEN $6 ELSE relayer END,
             relayer_assigned = CASE WHEN $5 THEN TRUE ELSE relayer_assigned END,
             relayer_assigned_fee = CASE WHEN $5 THEN $7::NUMERIC ELSE relayer_assigned_fee END
@@ -373,6 +373,7 @@ async fn backfill_message_assignment(
     .bind(row.relayer_fee.to_string())
     .bind(legacy_b49e_oracle_match)
     .bind(LEGACY_B49E_ORACLE_FROM_BLOCK.to_string())
+    .bind(LEGACY_B49E_DARWINIA_FROM_BLOCK.to_string())
     .execute(&mut **tx)
     .await
     .context("backfill ormp_message_accepted assignment fields")?;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -160,6 +160,7 @@ pub const ADDRESS_ORACLE: &[&str] = &[
 
 pub const LEGACY_B49E_ORACLE: &str = "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e";
 pub const LEGACY_B49E_ORACLE_FROM_BLOCK: u128 = 22_474_070;
+pub const LEGACY_B49E_DARWINIA_FROM_BLOCK: u128 = 6_634_860;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssignmentConfig {
@@ -224,10 +225,13 @@ pub fn is_oracle_assignment_for_accepted(
     (contains_address(&config.oracle_addresses, &assigned.oracle)
         && !assigned.oracle.eq_ignore_ascii_case(LEGACY_B49E_ORACLE))
         || (assigned.oracle.eq_ignore_ascii_case(LEGACY_B49E_ORACLE)
-            && accepted.chain_id == 1
-            && accepted.from_chain_id == 1
-            && accepted.to_chain_id == 46
-            && accepted.block_number >= LEGACY_B49E_ORACLE_FROM_BLOCK)
+            && ((accepted.chain_id == 1
+                && accepted.from_chain_id == 1
+                && accepted.to_chain_id == 46
+                && accepted.block_number >= LEGACY_B49E_ORACLE_FROM_BLOCK)
+                || (accepted.chain_id == 46
+                    && accepted.from_chain_id == 46
+                    && accepted.block_number >= LEGACY_B49E_DARWINIA_FROM_BLOCK)))
 }
 
 fn contains_address(addresses: &[String], candidate: &str) -> bool {

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -32,8 +32,8 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(written, events.len());
     assert_eq!(repeated, events.len());
     assert_table_count(&pool, "ormp_hash_imported", 1).await;
-    assert_table_count(&pool, "ormp_message_accepted", 3).await;
-    assert_table_count(&pool, "ormp_message_assigned", 5).await;
+    assert_table_count(&pool, "ormp_message_accepted", 5).await;
+    assert_table_count(&pool, "ormp_message_assigned", 7).await;
     assert_table_count(&pool, "ormp_message_dispatched", 1).await;
     assert_table_count(&pool, "msgport_message_recv", 1).await;
     assert_table_count(&pool, "msgport_message_sent", 1).await;
@@ -79,6 +79,22 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(b49e_negative.0, None);
     assert_eq!(b49e_negative.1, None);
     assert_eq!(b49e_negative.2, None);
+
+    let b49e_darwinia_positive = assignment_fields(&pool, "0xb49e-darwinia-positive").await;
+    assert_eq!(
+        b49e_darwinia_positive.0.as_deref(),
+        Some("0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e")
+    );
+    assert_eq!(b49e_darwinia_positive.1, Some(true));
+    assert_eq!(
+        b49e_darwinia_positive.2.as_deref(),
+        Some("1000000000000000000")
+    );
+
+    let b49e_darwinia_negative = assignment_fields(&pool, "0xb49e-darwinia-negative").await;
+    assert_eq!(b49e_darwinia_negative.0, None);
+    assert_eq!(b49e_darwinia_negative.1, None);
+    assert_eq!(b49e_darwinia_negative.2, None);
 
     let writer = PostgresEventWriter::new(pool.clone());
     writer
@@ -171,6 +187,30 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
             gas_limit: 500_000,
             encoded: "0xencoded".to_owned(),
         },
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata_at("b49e-darwinia-positive-log", 46, 6_634_860),
+            msg_hash: "0xb49e-darwinia-positive".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 11,
+            from_chain_id: 46,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 44,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata_at("b49e-darwinia-negative-log", 46, 6_614_836),
+            msg_hash: "0xb49e-darwinia-negative".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 12,
+            from_chain_id: 46,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 1,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
         LegacyOrmPEvent::MessageAssigned {
             metadata: evm_metadata("assigned-log"),
             msg_hash: "0xaccepted".to_owned(),
@@ -213,6 +253,24 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
             oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
             relayer: "0x0000000000000000000000000000000000000002".to_owned(),
             oracle_fee: 40_000_000_000_000,
+            relayer_fee: 44,
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("b49e-darwinia-positive-assigned-log"),
+            msg_hash: "0xb49e-darwinia-positive".to_owned(),
+            oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
+            relayer: "0x0000000000000000000000000000000000000002".to_owned(),
+            oracle_fee: 1_000_000_000_000_000_000,
+            relayer_fee: 44,
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("b49e-darwinia-negative-assigned-log"),
+            msg_hash: "0xb49e-darwinia-negative".to_owned(),
+            oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
+            relayer: "0x0000000000000000000000000000000000000002".to_owned(),
+            oracle_fee: 1_000_000_000_000_000_000,
             relayer_fee: 44,
             params: "0xparams".to_owned(),
         },

--- a/tests/schema_compatibility.rs
+++ b/tests/schema_compatibility.rs
@@ -117,11 +117,53 @@ fn test_legacy_b49e_oracle_backfills_ethereum_to_darwinia_after_cutover() {
 }
 
 #[test]
+fn test_legacy_b49e_oracle_backfills_darwinia_after_cutover() {
+    let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
+        metadata: evm_metadata("accepted-log"),
+        msg_hash: "0xf532dbdee1bab1840e28660d212310e161116d2123a7451f40f40b7ca999f21b".to_owned(),
+        channel: "0xchannel".to_owned(),
+        index: 8,
+        from_chain_id: 46,
+        from: "0xfrom".to_owned(),
+        to_chain_id: 44,
+        to: "0xto".to_owned(),
+        gas_limit: 500_000,
+        encoded: "0xencoded".to_owned(),
+    });
+    accepted.chain_id = 46;
+    accepted.block_number = 6_634_860;
+    let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+        metadata: evm_metadata("assigned-log"),
+        msg_hash: accepted.id.clone(),
+        oracle: LEGACY_B49E_ORACLE.to_owned(),
+        relayer: "0x0000000000000000000000000000000000000001".to_owned(),
+        oracle_fee: 1_000_000_000_000_000_000,
+        relayer_fee: 22,
+        params: "0xparams".to_owned(),
+    });
+
+    let updated = apply_assignment_to_accepted(
+        &mut accepted,
+        &assigned,
+        &AssignmentConfig::legacy_defaults(),
+    );
+
+    assert!(updated.oracle);
+    assert!(!updated.relayer);
+    assert_eq!(accepted.oracle.as_deref(), Some(LEGACY_B49E_ORACLE));
+    assert_eq!(accepted.oracle_assigned, Some(true));
+    assert_eq!(
+        accepted.oracle_assigned_fee,
+        Some(1_000_000_000_000_000_000)
+    );
+}
+
+#[test]
 fn test_legacy_b49e_oracle_does_not_backfill_outside_ethereum_to_darwinia_cutover() {
     for (chain_id, from_chain_id, to_chain_id, block_number) in [
         (1, 1, 42_161, 22_336_887),
         (1, 1, 46, 22_363_073),
-        (46, 46, 1, 23_738_310),
+        (46, 46, 1, 6_614_836),
     ] {
         let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
             metadata: evm_metadata("accepted-log"),


### PR DESCRIPTION
## Summary
- add the legacy Darwinia-source b49e oracle cutover rule at block 6634860
- keep the existing Ethereum -> Darwinia b49e rule unchanged
- align the SQL backfill path with the in-memory assignment predicate
- add schema and Postgres writer coverage for positive and negative Darwinia b49e cases

## Tests
- cargo test
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5434/ormpindexer_test cargo test --test postgres_writer test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_assignments -- --nocapture