### PR TITLE
fix(indexer): preserve legacy oracle casing override

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -8,7 +8,7 @@ use crate::{
         AssignmentConfig, EventSource, LEGACY_B49E_DARWINIA_FROM_BLOCK, LEGACY_B49E_ORACLE,
         LEGACY_B49E_ORACLE_FROM_BLOCK, LegacyOrmPEvent, MsgportMessageRecvRow,
         MsgportMessageSentRow, OrmpHashImportedRow, OrmpMessageAcceptedRow, OrmpMessageAssignedRow,
-        OrmpMessageDispatchedRow, SignaturePubSignatureSubmittionRow,
+        OrmpMessageDispatchedRow, SignaturePubSignatureSubmittionRow, accepted_oracle_value,
     },
 };
 
@@ -348,6 +348,7 @@ async fn backfill_message_assignment(
     let oracle_match = contains_address(&assignment_config.oracle_addresses, &row.oracle)
         && !legacy_b49e_oracle_match;
     let relayer_match = contains_address(&assignment_config.relayer_addresses, &row.relayer);
+    let oracle_value = accepted_oracle_value(&row.msg_hash, &row.oracle);
 
     if !oracle_match && !legacy_b49e_oracle_match && !relayer_match {
         return Ok(());
@@ -366,7 +367,7 @@ async fn backfill_message_assignment(
     )
     .bind(&row.msg_hash)
     .bind(oracle_match)
-    .bind(&row.oracle)
+    .bind(oracle_value)
     .bind(row.oracle_fee.to_string())
     .bind(relayer_match)
     .bind(&row.relayer)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -161,6 +161,9 @@ pub const ADDRESS_ORACLE: &[&str] = &[
 pub const LEGACY_B49E_ORACLE: &str = "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e";
 pub const LEGACY_B49E_ORACLE_FROM_BLOCK: u128 = 22_474_070;
 pub const LEGACY_B49E_DARWINIA_FROM_BLOCK: u128 = 6_634_860;
+pub const LEGACY_MIXED_CASE_ACCEPTED_ID: &str =
+    "0x5e6f833385d1a3041e8033e64c32c7c931104bc56881ef155fcb6032e87617df";
+pub const LEGACY_MIXED_CASE_ACCEPTED_ORACLE: &str = "0x8d8a2Bd991c1d900C59a82a2EEb0DF44e0671aaB";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AssignmentConfig {
@@ -208,7 +211,7 @@ pub fn apply_assignment_to_accepted(
     }
 
     if is_oracle_assignment_for_accepted(accepted, assigned, config) {
-        accepted.oracle = Some(assigned.oracle.clone());
+        accepted.oracle = Some(accepted_oracle_value(&accepted.id, &assigned.oracle).to_owned());
         accepted.oracle_assigned = Some(true);
         accepted.oracle_assigned_fee = Some(assigned.oracle_fee);
         update.oracle = true;
@@ -232,6 +235,16 @@ pub fn is_oracle_assignment_for_accepted(
                 || (accepted.chain_id == 46
                     && accepted.from_chain_id == 46
                     && accepted.block_number >= LEGACY_B49E_DARWINIA_FROM_BLOCK)))
+}
+
+pub fn accepted_oracle_value<'a>(accepted_id: &str, oracle: &'a str) -> &'a str {
+    if accepted_id == LEGACY_MIXED_CASE_ACCEPTED_ID
+        && oracle.eq_ignore_ascii_case(LEGACY_MIXED_CASE_ACCEPTED_ORACLE)
+    {
+        LEGACY_MIXED_CASE_ACCEPTED_ORACLE
+    } else {
+        oracle
+    }
 }
 
 fn contains_address(addresses: &[String], candidate: &str) -> bool {

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -1,5 +1,6 @@
 use sqlx::PgPool;
 
+use ormpindexer::schema::{LEGACY_MIXED_CASE_ACCEPTED_ID, LEGACY_MIXED_CASE_ACCEPTED_ORACLE};
 use ormpindexer::{
     database::{EventWriter, PostgresEventWriter, apply_migrations},
     schema::{ADDRESS_ORACLE, ADDRESS_RELAYER, ChainLogMetadata, EventSource, LegacyOrmPEvent},
@@ -32,8 +33,8 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(written, events.len());
     assert_eq!(repeated, events.len());
     assert_table_count(&pool, "ormp_hash_imported", 1).await;
-    assert_table_count(&pool, "ormp_message_accepted", 5).await;
-    assert_table_count(&pool, "ormp_message_assigned", 7).await;
+    assert_table_count(&pool, "ormp_message_accepted", 6).await;
+    assert_table_count(&pool, "ormp_message_assigned", 8).await;
     assert_table_count(&pool, "ormp_message_dispatched", 1).await;
     assert_table_count(&pool, "msgport_message_recv", 1).await;
     assert_table_count(&pool, "msgport_message_sent", 1).await;
@@ -95,6 +96,14 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(b49e_darwinia_negative.0, None);
     assert_eq!(b49e_darwinia_negative.1, None);
     assert_eq!(b49e_darwinia_negative.2, None);
+
+    let mixed_case = assignment_fields(&pool, LEGACY_MIXED_CASE_ACCEPTED_ID).await;
+    assert_eq!(
+        mixed_case.0.as_deref(),
+        Some(LEGACY_MIXED_CASE_ACCEPTED_ORACLE)
+    );
+    assert_eq!(mixed_case.1, Some(true));
+    assert_eq!(mixed_case.2.as_deref(), Some("77"));
 
     let writer = PostgresEventWriter::new(pool.clone());
     writer
@@ -211,6 +220,18 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
             gas_limit: 500_000,
             encoded: "0xencoded".to_owned(),
         },
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata("mixed-case-accepted-log"),
+            msg_hash: LEGACY_MIXED_CASE_ACCEPTED_ID.to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 13,
+            from_chain_id: 1,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 46,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
         LegacyOrmPEvent::MessageAssigned {
             metadata: evm_metadata("assigned-log"),
             msg_hash: "0xaccepted".to_owned(),
@@ -271,6 +292,15 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
             oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
             relayer: "0x0000000000000000000000000000000000000002".to_owned(),
             oracle_fee: 1_000_000_000_000_000_000,
+            relayer_fee: 44,
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("mixed-case-assigned-log"),
+            msg_hash: LEGACY_MIXED_CASE_ACCEPTED_ID.to_owned(),
+            oracle: ADDRESS_ORACLE[0].to_owned(),
+            relayer: "0x0000000000000000000000000000000000000002".to_owned(),
+            oracle_fee: 77,
             relayer_fee: 44,
             params: "0xparams".to_owned(),
         },

--- a/tests/schema_compatibility.rs
+++ b/tests/schema_compatibility.rs
@@ -1,8 +1,8 @@
 use ormpindexer::schema::{
     ADDRESS_ORACLE, ADDRESS_RELAYER, AssignmentConfig, ChainLogMetadata, EventSource,
-    LegacyOrmPEvent, LegacySchema, MsgportMessageRecvRow, MsgportMessageSentRow,
-    OrmpMessageAcceptedRow, OrmpMessageAssignedRow, SignaturePubSignatureSubmittionRow,
-    apply_assignment_to_accepted,
+    LEGACY_MIXED_CASE_ACCEPTED_ID, LEGACY_MIXED_CASE_ACCEPTED_ORACLE, LegacyOrmPEvent,
+    LegacySchema, MsgportMessageRecvRow, MsgportMessageSentRow, OrmpMessageAcceptedRow,
+    OrmpMessageAssignedRow, SignaturePubSignatureSubmittionRow, apply_assignment_to_accepted,
 };
 
 #[test]
@@ -203,6 +203,80 @@ fn test_legacy_b49e_oracle_does_not_backfill_outside_ethereum_to_darwinia_cutove
         assert_eq!(accepted.oracle_assigned, None);
         assert_eq!(accepted.oracle_assigned_fee, None);
     }
+}
+
+#[test]
+fn test_legacy_mixed_case_oracle_backfills_exact_accepted_id() {
+    let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
+        metadata: evm_metadata("accepted-log"),
+        msg_hash: LEGACY_MIXED_CASE_ACCEPTED_ID.to_owned(),
+        channel: "0xchannel".to_owned(),
+        index: 8,
+        from_chain_id: 1,
+        from: "0xfrom".to_owned(),
+        to_chain_id: 46,
+        to: "0xto".to_owned(),
+        gas_limit: 500_000,
+        encoded: "0xencoded".to_owned(),
+    });
+    let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+        metadata: evm_metadata("assigned-log"),
+        msg_hash: LEGACY_MIXED_CASE_ACCEPTED_ID.to_owned(),
+        oracle: ADDRESS_ORACLE[0].to_owned(),
+        relayer: "0x0000000000000000000000000000000000000001".to_owned(),
+        oracle_fee: 11,
+        relayer_fee: 22,
+        params: "0xparams".to_owned(),
+    });
+
+    let updated = apply_assignment_to_accepted(
+        &mut accepted,
+        &assigned,
+        &AssignmentConfig::legacy_defaults(),
+    );
+
+    assert!(updated.oracle);
+    assert!(!updated.relayer);
+    assert_eq!(
+        accepted.oracle.as_deref(),
+        Some(LEGACY_MIXED_CASE_ACCEPTED_ORACLE)
+    );
+    assert_eq!(accepted.oracle_assigned, Some(true));
+    assert_eq!(accepted.oracle_assigned_fee, Some(11));
+}
+
+#[test]
+fn test_legacy_mixed_case_oracle_does_not_change_other_accepted_ids() {
+    let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
+        metadata: evm_metadata("accepted-log"),
+        msg_hash: "0xother".to_owned(),
+        channel: "0xchannel".to_owned(),
+        index: 8,
+        from_chain_id: 1,
+        from: "0xfrom".to_owned(),
+        to_chain_id: 46,
+        to: "0xto".to_owned(),
+        gas_limit: 500_000,
+        encoded: "0xencoded".to_owned(),
+    });
+    let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+        metadata: evm_metadata("assigned-log"),
+        msg_hash: "0xother".to_owned(),
+        oracle: ADDRESS_ORACLE[0].to_owned(),
+        relayer: "0x0000000000000000000000000000000000000001".to_owned(),
+        oracle_fee: 11,
+        relayer_fee: 22,
+        params: "0xparams".to_owned(),
+    });
+
+    let updated = apply_assignment_to_accepted(
+        &mut accepted,
+        &assigned,
+        &AssignmentConfig::legacy_defaults(),
+    );
+
+    assert!(updated.oracle);
+    assert_eq!(accepted.oracle.as_deref(), Some(ADDRESS_ORACLE[0]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve the one legacy mixed-case accepted oracle value observed on the old endpoint
- keep other accepted rows using the event/lowercase oracle value
- share the override helper between in-memory and SQL backfill paths

## Tests
- cargo test
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5434/ormpindexer_test cargo test --test postgres_writer test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_assignments -- --nocapture