### PR TITLE
fix(indexer): add arbitrum b49e oracle cutover

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -5,10 +5,11 @@ use crate::{
     checkpoint::CheckpointStore,
     config::SecretString,
     schema::{
-        AssignmentConfig, EventSource, LEGACY_B49E_DARWINIA_FROM_BLOCK, LEGACY_B49E_ORACLE,
-        LEGACY_B49E_ORACLE_FROM_BLOCK, LegacyOrmPEvent, MsgportMessageRecvRow,
-        MsgportMessageSentRow, OrmpHashImportedRow, OrmpMessageAcceptedRow, OrmpMessageAssignedRow,
-        OrmpMessageDispatchedRow, SignaturePubSignatureSubmittionRow, accepted_oracle_value,
+        AssignmentConfig, EventSource, LEGACY_B49E_ARBITRUM_FROM_BLOCK,
+        LEGACY_B49E_DARWINIA_FROM_BLOCK, LEGACY_B49E_ORACLE, LEGACY_B49E_ORACLE_FROM_BLOCK,
+        LegacyOrmPEvent, MsgportMessageRecvRow, MsgportMessageSentRow, OrmpHashImportedRow,
+        OrmpMessageAcceptedRow, OrmpMessageAssignedRow, OrmpMessageDispatchedRow,
+        SignaturePubSignatureSubmittionRow, accepted_oracle_value,
     },
 };
 
@@ -357,9 +358,9 @@ async fn backfill_message_assignment(
     sqlx::query(
         "UPDATE ormp_message_accepted
          SET
-            oracle = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC))) THEN $3 ELSE oracle END,
-            oracle_assigned = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC))) THEN TRUE ELSE oracle_assigned END,
-            oracle_assigned_fee = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC))) THEN $4::NUMERIC ELSE oracle_assigned_fee END,
+            oracle = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC) OR (chain_id = 42161 AND from_chain_id = 42161 AND block_number >= $11::NUMERIC))) THEN $3 ELSE oracle END,
+            oracle_assigned = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC) OR (chain_id = 42161 AND from_chain_id = 42161 AND block_number >= $11::NUMERIC))) THEN TRUE ELSE oracle_assigned END,
+            oracle_assigned_fee = CASE WHEN $2 OR ($8 AND ((chain_id = 1 AND from_chain_id = 1 AND to_chain_id = 46 AND block_number >= $9::NUMERIC) OR (chain_id = 46 AND from_chain_id = 46 AND block_number >= $10::NUMERIC) OR (chain_id = 42161 AND from_chain_id = 42161 AND block_number >= $11::NUMERIC))) THEN $4::NUMERIC ELSE oracle_assigned_fee END,
             relayer = CASE WHEN $5 THEN $6 ELSE relayer END,
             relayer_assigned = CASE WHEN $5 THEN TRUE ELSE relayer_assigned END,
             relayer_assigned_fee = CASE WHEN $5 THEN $7::NUMERIC ELSE relayer_assigned_fee END
@@ -375,6 +376,7 @@ async fn backfill_message_assignment(
     .bind(legacy_b49e_oracle_match)
     .bind(LEGACY_B49E_ORACLE_FROM_BLOCK.to_string())
     .bind(LEGACY_B49E_DARWINIA_FROM_BLOCK.to_string())
+    .bind(LEGACY_B49E_ARBITRUM_FROM_BLOCK.to_string())
     .execute(&mut **tx)
     .await
     .context("backfill ormp_message_accepted assignment fields")?;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -161,6 +161,7 @@ pub const ADDRESS_ORACLE: &[&str] = &[
 pub const LEGACY_B49E_ORACLE: &str = "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e";
 pub const LEGACY_B49E_ORACLE_FROM_BLOCK: u128 = 22_474_070;
 pub const LEGACY_B49E_DARWINIA_FROM_BLOCK: u128 = 6_634_860;
+pub const LEGACY_B49E_ARBITRUM_FROM_BLOCK: u128 = 334_644_126;
 pub const LEGACY_MIXED_CASE_ACCEPTED_ID: &str =
     "0x5e6f833385d1a3041e8033e64c32c7c931104bc56881ef155fcb6032e87617df";
 pub const LEGACY_MIXED_CASE_ACCEPTED_ORACLE: &str = "0x8d8a2Bd991c1d900C59a82a2EEb0DF44e0671aaB";
@@ -234,7 +235,10 @@ pub fn is_oracle_assignment_for_accepted(
                 && accepted.block_number >= LEGACY_B49E_ORACLE_FROM_BLOCK)
                 || (accepted.chain_id == 46
                     && accepted.from_chain_id == 46
-                    && accepted.block_number >= LEGACY_B49E_DARWINIA_FROM_BLOCK)))
+                    && accepted.block_number >= LEGACY_B49E_DARWINIA_FROM_BLOCK)
+                || (accepted.chain_id == 42_161
+                    && accepted.from_chain_id == 42_161
+                    && accepted.block_number >= LEGACY_B49E_ARBITRUM_FROM_BLOCK)))
 }
 
 pub fn accepted_oracle_value<'a>(accepted_id: &str, oracle: &'a str) -> &'a str {

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -33,8 +33,8 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(written, events.len());
     assert_eq!(repeated, events.len());
     assert_table_count(&pool, "ormp_hash_imported", 1).await;
-    assert_table_count(&pool, "ormp_message_accepted", 6).await;
-    assert_table_count(&pool, "ormp_message_assigned", 8).await;
+    assert_table_count(&pool, "ormp_message_accepted", 8).await;
+    assert_table_count(&pool, "ormp_message_assigned", 10).await;
     assert_table_count(&pool, "ormp_message_dispatched", 1).await;
     assert_table_count(&pool, "msgport_message_recv", 1).await;
     assert_table_count(&pool, "msgport_message_sent", 1).await;
@@ -96,6 +96,19 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(b49e_darwinia_negative.0, None);
     assert_eq!(b49e_darwinia_negative.1, None);
     assert_eq!(b49e_darwinia_negative.2, None);
+
+    let b49e_arbitrum_positive = assignment_fields(&pool, "0xb49e-arbitrum-positive").await;
+    assert_eq!(
+        b49e_arbitrum_positive.0.as_deref(),
+        Some("0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e")
+    );
+    assert_eq!(b49e_arbitrum_positive.1, Some(true));
+    assert_eq!(b49e_arbitrum_positive.2.as_deref(), Some("3000000000000"));
+
+    let b49e_arbitrum_negative = assignment_fields(&pool, "0xb49e-arbitrum-negative").await;
+    assert_eq!(b49e_arbitrum_negative.0, None);
+    assert_eq!(b49e_arbitrum_negative.1, None);
+    assert_eq!(b49e_arbitrum_negative.2, None);
 
     let mixed_case = assignment_fields(&pool, LEGACY_MIXED_CASE_ACCEPTED_ID).await;
     assert_eq!(
@@ -221,10 +234,34 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
             encoded: "0xencoded".to_owned(),
         },
         LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata_at("b49e-arbitrum-positive-log", 42_161, 334_644_126),
+            msg_hash: "0xb49e-arbitrum-positive".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 13,
+            from_chain_id: 42_161,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 2_818,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata_at("b49e-arbitrum-negative-log", 42_161, 333_775_437),
+            msg_hash: "0xb49e-arbitrum-negative".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 14,
+            from_chain_id: 42_161,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 46,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAccepted {
             metadata: evm_metadata("mixed-case-accepted-log"),
             msg_hash: LEGACY_MIXED_CASE_ACCEPTED_ID.to_owned(),
             channel: "0xchannel".to_owned(),
-            index: 13,
+            index: 15,
             from_chain_id: 1,
             from: "0xfrom".to_owned(),
             to_chain_id: 46,
@@ -292,6 +329,24 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
             oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
             relayer: "0x0000000000000000000000000000000000000002".to_owned(),
             oracle_fee: 1_000_000_000_000_000_000,
+            relayer_fee: 44,
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("b49e-arbitrum-positive-assigned-log"),
+            msg_hash: "0xb49e-arbitrum-positive".to_owned(),
+            oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
+            relayer: "0x0000000000000000000000000000000000000002".to_owned(),
+            oracle_fee: 3_000_000_000_000,
+            relayer_fee: 44,
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("b49e-arbitrum-negative-assigned-log"),
+            msg_hash: "0xb49e-arbitrum-negative".to_owned(),
+            oracle: "0xb49e82067a54b3e8c5d9db2f378fdb6892c04d2e".to_owned(),
+            relayer: "0x0000000000000000000000000000000000000002".to_owned(),
+            oracle_fee: 3_000_000_000_000,
             relayer_fee: 44,
             params: "0xparams".to_owned(),
         },

--- a/tests/schema_compatibility.rs
+++ b/tests/schema_compatibility.rs
@@ -159,11 +159,56 @@ fn test_legacy_b49e_oracle_backfills_darwinia_after_cutover() {
 }
 
 #[test]
+fn test_legacy_b49e_oracle_backfills_arbitrum_after_cutover_for_any_target_chain() {
+    for (to_chain_id, block_number) in [(46, 334_644_126), (2_818, 368_234_912)] {
+        let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata("accepted-log"),
+            msg_hash: "0xarbitrum-b49e".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 8,
+            from_chain_id: 42_161,
+            from: "0xfrom".to_owned(),
+            to_chain_id,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        });
+        accepted.chain_id = 42_161;
+        accepted.block_number = block_number;
+        let assigned = OrmpMessageAssignedRow::from_event(LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("assigned-log"),
+            msg_hash: accepted.id.clone(),
+            oracle: LEGACY_B49E_ORACLE.to_owned(),
+            relayer: "0x0000000000000000000000000000000000000001".to_owned(),
+            oracle_fee: 3_000_000_000_000,
+            relayer_fee: 22,
+            params: "0xparams".to_owned(),
+        });
+
+        let updated = apply_assignment_to_accepted(
+            &mut accepted,
+            &assigned,
+            &AssignmentConfig::legacy_defaults(),
+        );
+
+        assert!(
+            updated.oracle,
+            "expected b49e oracle backfill for Arbitrum to {to_chain_id} at block {block_number}"
+        );
+        assert!(!updated.relayer);
+        assert_eq!(accepted.oracle.as_deref(), Some(LEGACY_B49E_ORACLE));
+        assert_eq!(accepted.oracle_assigned, Some(true));
+        assert_eq!(accepted.oracle_assigned_fee, Some(3_000_000_000_000));
+    }
+}
+
+#[test]
 fn test_legacy_b49e_oracle_does_not_backfill_outside_ethereum_to_darwinia_cutover() {
     for (chain_id, from_chain_id, to_chain_id, block_number) in [
         (1, 1, 42_161, 22_336_887),
         (1, 1, 46, 22_363_073),
         (46, 46, 1, 6_614_836),
+        (42_161, 42_161, 46, 333_775_437),
     ] {
         let mut accepted = OrmpMessageAcceptedRow::from_event(LegacyOrmPEvent::MessageAccepted {
             metadata: evm_metadata("accepted-log"),


### PR DESCRIPTION
## Summary
- add legacy b49e oracle backfill cutover for Arbitrum source messages from block 334644126
- mirror the rule in Postgres backfill SQL
- cover positive and pre-cutover negative cases in schema and writer tests

## Tests
- cargo test
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5434/ormpindexer_test cargo test --test postgres_writer test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_assignments -- --nocapture