### PR TITLE
feat(graphql): add legacy query compatibility feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 license = "MIT"
 publish = false
 
+[features]
+default = ["legacy-query-compat"]
+legacy-query-compat = []
+
 [dependencies]
 anyhow = "1.0.100"
 async-graphql = "7.0.17"

--- a/src/graphql/query.rs
+++ b/src/graphql/query.rs
@@ -276,6 +276,15 @@ fn push_where_group<'a>(
             }
         };
     }
+    #[cfg(feature = "legacy-query-compat")]
+    macro_rules! bool_cmp {
+        ($field:expr, $column:literal, $op:literal) => {
+            if let Some(value) = $field {
+                push_and(query, has_condition);
+                query.push($column).push($op).push_bind(value);
+            }
+        };
+    }
 
     text_cmp!(where_.id_eq, "id", " = ");
     text_cmp!(where_.id_not_eq, "id", " <> ");
@@ -311,6 +320,8 @@ fn push_where_group<'a>(
     text_cmp!(where_.oracle_eq, "oracle", " = ");
     text_cmp!(where_.relayer_eq, "relayer", " = ");
     text_cmp!(where_.signer_eq, "signer", " = ");
+    #[cfg(feature = "legacy-query-compat")]
+    text_in!(where_.signer_in, "signer", false);
     text_cmp!(where_.port_address_eq, "port_address", " = ");
     text_cmp!(where_.from_eq, r#""from""#, " = ");
     text_cmp!(where_.to_eq, r#""to""#, " = ");
@@ -321,6 +332,20 @@ fn push_where_group<'a>(
     bigint_cmp!(where_.src_chain_id_eq, "src_chain_id", " = ");
     bigint_cmp!(where_.target_chain_id_eq, "target_chain_id", " = ");
     bigint_cmp!(where_.msg_index_eq, "msg_index", " = ");
+    #[cfg(feature = "legacy-query-compat")]
+    {
+        bigint_cmp!(where_.msg_index_gt, "msg_index", " > ");
+        bigint_cmp!(where_.msg_index_gte, "msg_index", " >= ");
+        bigint_cmp!(where_.msg_index_lt, "msg_index", " < ");
+        bigint_cmp!(where_.msg_index_lte, "msg_index", " <= ");
+        bigint_cmp!(where_.index_eq, r#""index""#, " = ");
+        bigint_cmp!(where_.index_gt, r#""index""#, " > ");
+        bigint_cmp!(where_.index_gte, r#""index""#, " >= ");
+        bigint_cmp!(where_.index_lt, r#""index""#, " < ");
+        bigint_cmp!(where_.index_lte, r#""index""#, " <= ");
+        bool_cmp!(where_.oracle_assigned_eq, "oracle_assigned", " = ");
+        bool_cmp!(where_.relayer_assigned_eq, "relayer_assigned", " = ");
+    }
 
     if let Some(groups) = where_.and.as_ref() {
         push_logical_groups(query, has_condition, groups, " AND ");
@@ -392,6 +417,14 @@ fn push_order_by(query: &mut QueryBuilder<'_, Postgres>, order_by: Option<&[Lega
             LegacyOrderByInput::MsgHashDesc => ("msg_hash", "DESC"),
             LegacyOrderByInput::MsgIdAsc => ("msg_id", "ASC"),
             LegacyOrderByInput::MsgIdDesc => ("msg_id", "DESC"),
+            #[cfg(feature = "legacy-query-compat")]
+            LegacyOrderByInput::IndexAsc => (r#""index""#, "ASC"),
+            #[cfg(feature = "legacy-query-compat")]
+            LegacyOrderByInput::IndexDesc => (r#""index""#, "DESC"),
+            #[cfg(feature = "legacy-query-compat")]
+            LegacyOrderByInput::MsgIndexAsc => ("msg_index", "ASC"),
+            #[cfg(feature = "legacy-query-compat")]
+            LegacyOrderByInput::MsgIndexDesc => ("msg_index", "DESC"),
         };
         separated.push(format!("{column} {direction}"));
     }

--- a/src/graphql/types.rs
+++ b/src/graphql/types.rs
@@ -149,6 +149,9 @@ pub struct LegacyWhereInput {
     pub relayer_eq: Option<String>,
     #[graphql(name = "signer_eq")]
     pub signer_eq: Option<String>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "signer_in")]
+    pub signer_in: Option<Vec<String>>,
     #[graphql(name = "portAddress_eq")]
     pub port_address_eq: Option<String>,
     #[graphql(name = "from_eq")]
@@ -169,6 +172,39 @@ pub struct LegacyWhereInput {
     pub target_chain_id_eq: Option<BigInt>,
     #[graphql(name = "msgIndex_eq")]
     pub msg_index_eq: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "msgIndex_gt")]
+    pub msg_index_gt: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "msgIndex_gte")]
+    pub msg_index_gte: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "msgIndex_lt")]
+    pub msg_index_lt: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "msgIndex_lte")]
+    pub msg_index_lte: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "index_eq")]
+    pub index_eq: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "index_gt")]
+    pub index_gt: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "index_gte")]
+    pub index_gte: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "index_lt")]
+    pub index_lt: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "index_lte")]
+    pub index_lte: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "oracleAssigned_eq")]
+    pub oracle_assigned_eq: Option<bool>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "relayerAssigned_eq")]
+    pub relayer_assigned_eq: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Enum, PartialEq)]
@@ -205,6 +241,18 @@ pub enum LegacyOrderByInput {
     MsgIdAsc,
     #[graphql(name = "msgId_DESC")]
     MsgIdDesc,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "index_ASC")]
+    IndexAsc,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "index_DESC")]
+    IndexDesc,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "msgIndex_ASC")]
+    MsgIndexAsc,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "msgIndex_DESC")]
+    MsgIndexDesc,
 }
 
 #[derive(Clone, Debug, FromRow, SimpleObject)]

--- a/tests/graphql_server.rs
+++ b/tests/graphql_server.rs
@@ -44,6 +44,22 @@ async fn test_graphql_schema_exposes_pages_without_connections() {
         sdl.contains("orderBy: [LegacyOrderByInput!]"),
         "list fields must accept OpenReader-style orderBy"
     );
+    #[cfg(feature = "legacy-query-compat")]
+    {
+        for legacy_query_compat_name in [
+            "index_ASC",
+            "msgIndex_DESC",
+            "index_gt",
+            "oracleAssigned_eq",
+            "relayerAssigned_eq",
+            "signer_in",
+        ] {
+            assert!(
+                sdl.contains(legacy_query_compat_name),
+                "schema is missing legacy query compatibility name {legacy_query_compat_name}"
+            );
+        }
+    }
 }
 
 #[tokio::test]
@@ -133,6 +149,116 @@ async fn test_graphql_queries_by_id_and_page_against_postgres() {
     );
 }
 
+#[cfg(feature = "legacy-query-compat")]
+#[tokio::test]
+async fn test_graphql_accepts_ormpipe_legacy_query_compatibility_filters() {
+    let Some(database_url) = test_database_url() else {
+        eprintln!("skipping GraphQL Postgres test; ORMPINDEXER_TEST_DATABASE_URL is not set");
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("connect test postgres");
+    apply_migrations(&pool).await.expect("apply migrations");
+    truncate_legacy_tables(&pool).await;
+    seed_ormpipe_compatibility_rows(&pool).await;
+
+    let schema = build_schema(pool);
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query {
+              nextOracle: ormpMessageAccepteds(
+                limit: 1
+                orderBy: [index_ASC]
+                where: {
+                  oracleAssigned_eq: true
+                  index_gt: "8"
+                  fromChainId_eq: "1"
+                  toChainId_eq: "46"
+                }
+              ) {
+                msgHash
+                index
+              }
+              relayerHashes: ormpMessageAccepteds(
+                limit: 10
+                orderBy: [index_ASC]
+                where: {
+                  relayerAssigned_eq: true
+                  index_lte: "10"
+                  fromChainId_eq: "1"
+                  toChainId_eq: "46"
+                }
+              ) {
+                msgHash
+                index
+              }
+              lastImported: ormpHashImporteds(
+                limit: 1
+                orderBy: [msgIndex_DESC]
+                where: {
+                  srcChainId_eq: "1"
+                  targetChainId_eq: "46"
+                }
+              ) {
+                msgIndex
+                hash
+              }
+              topSignatures: signaturePubSignatureSubmittions(
+                limit: 100
+                orderBy: [blockNumber_DESC]
+                where: {
+                  chainId_eq: "1"
+                  msgIndex_eq: "9"
+                  signer_in: ["0xsigner-a", "0xsigner-c"]
+                }
+              ) {
+                signer
+                msgIndex
+                blockNumber
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+    assert_eq!(
+        response.data.into_json().expect("GraphQL response JSON"),
+        json!({
+            "nextOracle": [{
+                "msgHash": "0xaccepted-9",
+                "index": "9",
+            }],
+            "relayerHashes": [{
+                "msgHash": "0xaccepted-8",
+                "index": "8",
+            }, {
+                "msgHash": "0xaccepted-9",
+                "index": "9",
+            }],
+            "lastImported": [{
+                "msgIndex": "9",
+                "hash": "0xaccepted-9",
+            }],
+            "topSignatures": [{
+                "signer": "0xsigner-c",
+                "msgIndex": "9",
+                "blockNumber": "125",
+            }, {
+                "signer": "0xsigner-a",
+                "msgIndex": "9",
+                "blockNumber": "124",
+            }],
+        })
+    );
+}
+
 fn legacy_events() -> Vec<LegacyOrmPEvent> {
     vec![
         LegacyOrmPEvent::MessageAccepted {
@@ -189,6 +315,49 @@ async fn truncate_legacy_tables(pool: &PgPool) {
     .execute(pool)
     .await
     .expect("truncate legacy tables");
+}
+
+#[cfg(feature = "legacy-query-compat")]
+async fn seed_ormpipe_compatibility_rows(pool: &PgPool) {
+    sqlx::query(
+        r#"INSERT INTO ormp_message_accepted (
+            id, block_number, transaction_hash, block_timestamp, chain_id, log_index,
+            msg_hash, channel, "index", from_chain_id, "from", to_chain_id, "to",
+            gas_limit, encoded, oracle, oracle_assigned, oracle_assigned_fee,
+            relayer, relayer_assigned, relayer_assigned_fee
+        ) VALUES
+            ('accepted-8', 123, '0xtx8', 456, 1, 3, '0xaccepted-8', '0xchannel', 8, 1, '0xfrom', 46, '0xto', 500000, '0xencoded', '0xoracle', true, 11, '0xrelayer', true, 22),
+            ('accepted-9', 124, '0xtx9', 457, 1, 4, '0xaccepted-9', '0xchannel', 9, 1, '0xfrom', 46, '0xto', 500000, '0xencoded', '0xoracle', true, 11, '0xrelayer', true, 22),
+            ('accepted-10', 125, '0xtx10', 458, 1, 5, '0xaccepted-10', '0xchannel', 10, 1, '0xfrom', 46, '0xto', 500000, '0xencoded', NULL, false, NULL, NULL, false, NULL)"#,
+    )
+    .execute(pool)
+    .await
+    .expect("insert ormpipe accepted rows");
+
+    sqlx::query(
+        r#"INSERT INTO ormp_hash_imported (
+            id, block_number, transaction_hash, block_timestamp, chain_id,
+            src_chain_id, target_chain_id, oracle, channel, msg_index, hash
+        ) VALUES
+            ('imported-8', 123, '0xtx8', 456, 46, 1, 46, '0xoracle', '0xchannel', 8, '0xaccepted-8'),
+            ('imported-9', 124, '0xtx9', 457, 46, 1, 46, '0xoracle', '0xchannel', 9, '0xaccepted-9')"#,
+    )
+    .execute(pool)
+    .await
+    .expect("insert ormpipe imported rows");
+
+    sqlx::query(
+        r#"INSERT INTO signature_pub_signature_submittion (
+            id, block_number, transaction_hash, block_timestamp, chain_id,
+            channel, signer, msg_index, signature, data
+        ) VALUES
+            ('signature-a', 124, '0xtx-sign-a', 459, 1, '0xchannel', '0xsigner-a', 9, '0xsiga', '0xdata'),
+            ('signature-b', 126, '0xtx-sign-b', 460, 1, '0xchannel', '0xsigner-b', 9, '0xsigb', '0xdata'),
+            ('signature-c', 125, '0xtx-sign-c', 461, 1, '0xchannel', '0xsigner-c', 9, '0xsigc', '0xdata')"#,
+    )
+    .execute(pool)
+    .await
+    .expect("insert ormpipe signature rows");
 }
 
 fn test_database_url() -> Option<String> {


### PR DESCRIPTION
## Summary
- add default-enabled legacy-query-compat feature
- support ORMPipe legacy filters and orderBy values for ORMP/Subsquid-style queries
- cover ORMPipe query compatibility in GraphQL integration tests

## Tests
- cargo fmt --check
- ORMPINDEXER_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5434/ormpindexer_test cargo test --test graphql_server -- --test-threads=1 --nocapture
- cargo test --no-default-features --test graphql_server test_graphql_schema_exposes_pages_without_connections -- --nocapture
- cargo test
- local http://127.0.0.1:8006/graphql ORMPipe query smoke test