### PR TITLE
ci: add rust check and release workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/target
+/.git
+/.github
+*.local.*
+.env

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,41 @@
+name: Check Code
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-code:
+    name: Check Code
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy,rustfmt
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all-features
+
+      - name: Check no-default-features GraphQL test
+        run: cargo test --no-default-features --test graphql_server test_graphql_schema_exposes_pages_without_connections -- --nocapture
+
+      - name: Build release
+        run: cargo build --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+env:
+  DOCKER_REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-docker-image:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare image metadata
+        run: |
+          SHA="${GITHUB_SHA::7}"
+          IMAGE="${DOCKER_REGISTRY}/${GITHUB_REPOSITORY}"
+          TAGS="${IMAGE}:sha-${SHA},${IMAGE}:staging"
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == v* ]]; then
+            TAGS="${TAGS},${IMAGE}:${GITHUB_REF_NAME},${IMAGE}:latest"
+            echo "GIT_TAG_NAME=${GITHUB_REF_NAME}" >> "${GITHUB_ENV}"
+          fi
+
+          echo "SHA=${SHA}" >> "${GITHUB_ENV}"
+          echo "IMAGE=${IMAGE}" >> "${GITHUB_ENV}"
+          echo "TAGS=${TAGS}" >> "${GITHUB_ENV}"
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.TAGS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7
+
+FROM rust:1-slim-bookworm AS builder
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock ./
+COPY migrations ./migrations
+COPY src ./src
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --locked \
+    && cp /app/target/release/ormpindexer /tmp/ormpindexer
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system ormpindexer \
+    && useradd --system --gid ormpindexer --home-dir /nonexistent --shell /usr/sbin/nologin ormpindexer
+
+COPY --from=builder /tmp/ormpindexer /usr/local/bin/ormpindexer
+COPY migrations /app/migrations
+
+USER ormpindexer
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/ormpindexer"]

--- a/src/datalens.rs
+++ b/src/datalens.rs
@@ -452,35 +452,35 @@ fn body_has_retryable_graphql_errors(body: &str) -> bool {
 }
 
 fn graphql_error_is_retryable(error: &serde_json::Value) -> bool {
-    if let Some(message) = error.get("message").and_then(serde_json::Value::as_str) {
-        if matches!(
+    if let Some(message) = error.get("message").and_then(serde_json::Value::as_str)
+        && matches!(
             classify_datalens_failure_message(message),
             DatalensFailureKind::Transient
-        ) {
-            return true;
-        }
+        )
+    {
+        return true;
     }
 
     let Some(extensions) = error.get("extensions") else {
         return false;
     };
 
-    if let Some(code) = extensions.get("code").and_then(serde_json::Value::as_str) {
-        if matches!(
+    if let Some(code) = extensions.get("code").and_then(serde_json::Value::as_str)
+        && matches!(
             classify_datalens_failure_message(code),
             DatalensFailureKind::Transient
-        ) {
-            return true;
-        }
+        )
+    {
+        return true;
     }
 
-    if let Some(kind) = extensions.get("kind").and_then(serde_json::Value::as_str) {
-        if matches!(
+    if let Some(kind) = extensions.get("kind").and_then(serde_json::Value::as_str)
+        && matches!(
             classify_datalens_failure_message(kind),
             DatalensFailureKind::Transient
-        ) {
-            return true;
-        }
+        )
+    {
+        return true;
     }
 
     ["status", "statusCode", "httpStatus"]

--- a/tests/legacy_parity.rs
+++ b/tests/legacy_parity.rs
@@ -621,6 +621,7 @@ fn tron_log(
     .expect("decode Tron Datalens log")
 }
 
+#[allow(clippy::too_many_arguments)]
 fn evm_log(
     id: &str,
     block_number: u64,


### PR DESCRIPTION
## Summary
- add Rust check workflow for fmt, clippy, tests, no-default feature guard, and release build
- add GHCR release workflow matching the old sha/staging/tag/latest image tags
- add multi-stage Rust Dockerfile and dockerignore
- fix clippy warnings so the new check workflow can pass

## Tests
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo test --no-default-features --test graphql_server test_graphql_schema_exposes_pages_without_connections -- --nocapture
- cargo build --release
- docker build -t ormpindexer-ci-test .
- docker run --rm ormpindexer-ci-test --help