### PR TITLE
chore(database): collapse initial schema migration

### DIFF
--- a/migrations/0001_schema_compat.sql
+++ b/migrations/0001_schema_compat.sql
@@ -1,7 +1,8 @@
--- ORMP legacy schema compatibility contract.
+-- ORMP indexer initial schema.
 --
--- This initializes the tables exposed by the previous Subsquid GraphQL schema.
--- It does not migrate old rows or define the future event ingestion runner.
+-- This initializes the tables exposed by the previous Subsquid GraphQL schema
+-- and the runtime checkpoint table. Schema changes are expected to reset the
+-- database rather than migrate existing indexed data.
 
 CREATE TABLE IF NOT EXISTS ormp_hash_imported (
   id VARCHAR NOT NULL PRIMARY KEY,
@@ -120,3 +121,11 @@ CREATE INDEX IF NOT EXISTS msgport_message_sent_msg_id_idx
   ON msgport_message_sent (msg_id);
 CREATE INDEX IF NOT EXISTS msgport_message_recv_msg_id_idx
   ON msgport_message_recv (msg_id);
+
+CREATE TABLE IF NOT EXISTS ormp_indexer_checkpoint (
+  chain_id NUMERIC NOT NULL,
+  dataset TEXT NOT NULL,
+  next_block NUMERIC NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (chain_id, dataset)
+);

--- a/migrations/0002_runtime_checkpoint.sql
+++ b/migrations/0002_runtime_checkpoint.sql
@@ -1,7 +1,0 @@
-CREATE TABLE IF NOT EXISTS ormp_indexer_checkpoint (
-  chain_id NUMERIC NOT NULL,
-  dataset TEXT NOT NULL,
-  next_block NUMERIC NOT NULL,
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  PRIMARY KEY (chain_id, dataset)
-);


### PR DESCRIPTION
## Summary
- fold the runtime checkpoint table into the initial schema migration
- remove the second incremental migration file
- clarify that schema changes should reset indexed databases instead of migrating them

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --all-features
- cargo test --no-default-features --test graphql_server test_graphql_schema_exposes_pages_without_connections -- --nocapture
- cargo build --release
- git diff --check