### PR TITLE
ci(release): publish amd64 image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.TAGS }}


### PR DESCRIPTION
## Summary
- publish release images for linux/amd64 only

## Why
- helixbox-nue nodes are amd64
- avoids slow multi-arch QEMU builds while deploying the new ORMPIndexer

## Tests
- workflow-only change