### PR TITLE
fix(graphql): sort legacy numeric fields numerically

### DIFF
--- a/src/graphql/query.rs
+++ b/src/graphql/query.rs
@@ -72,7 +72,7 @@ macro_rules! query_fns {
             if limit == 0 {
                 return Ok(Vec::new());
             }
-            fetch_page(pool, $select, where_, order_by, offset, limit).await
+            fetch_page(pool, $select, $table, where_, order_by, offset, limit).await
         }
 
         pub(super) async fn $page(
@@ -87,7 +87,7 @@ macro_rules! query_fns {
             let items = if limit == 0 {
                 Vec::new()
             } else {
-                fetch_page(pool, $select, where_, order_by, offset, limit).await?
+                fetch_page(pool, $select, $table, where_, order_by, offset, limit).await?
             };
             Ok(<$page_ty>::new(total_count, offset, limit, items))
         }
@@ -171,6 +171,7 @@ where
 async fn fetch_page<T>(
     pool: &PgPool,
     select: &'static str,
+    table: &'static str,
     where_: Option<&LegacyWhereInput>,
     order_by: Option<&[LegacyOrderByInput]>,
     offset: i32,
@@ -181,7 +182,7 @@ where
 {
     let mut query = QueryBuilder::<Postgres>::new(select);
     push_where(&mut query, where_);
-    push_order_by(&mut query, order_by);
+    push_order_by(&mut query, table, order_by);
     push_page(&mut query, offset, limit);
 
     Ok(query.build_query_as().fetch_all(pool).await?)
@@ -391,41 +392,78 @@ fn push_and(query: &mut QueryBuilder<'_, Postgres>, has_condition: &mut bool) {
     *has_condition = true;
 }
 
-fn push_order_by(query: &mut QueryBuilder<'_, Postgres>, order_by: Option<&[LegacyOrderByInput]>) {
+fn push_order_by(
+    query: &mut QueryBuilder<'_, Postgres>,
+    table: &'static str,
+    order_by: Option<&[LegacyOrderByInput]>,
+) {
     let orders = order_by.unwrap_or(&[]);
     query.push(" ORDER BY ");
     if orders.is_empty() {
-        query.push("block_number ASC, id ASC");
+        query.push(format!("{table}.block_number ASC, id ASC"));
         return;
     }
     let mut separated = query.separated(", ");
     for order in orders {
-        let (column, direction) = match order {
-            LegacyOrderByInput::IdAsc => ("id", "ASC"),
-            LegacyOrderByInput::IdDesc => ("id", "DESC"),
-            LegacyOrderByInput::BlockNumberAsc => ("block_number", "ASC"),
-            LegacyOrderByInput::BlockNumberDesc => ("block_number", "DESC"),
-            LegacyOrderByInput::BlockTimestampAsc => ("block_timestamp", "ASC"),
-            LegacyOrderByInput::BlockTimestampDesc => ("block_timestamp", "DESC"),
-            LegacyOrderByInput::ChainIdAsc => ("chain_id", "ASC"),
-            LegacyOrderByInput::ChainIdDesc => ("chain_id", "DESC"),
-            LegacyOrderByInput::LogIndexAsc => ("log_index", "ASC"),
-            LegacyOrderByInput::LogIndexDesc => ("log_index", "DESC"),
-            LegacyOrderByInput::TransactionIndexAsc => ("transaction_index", "ASC"),
-            LegacyOrderByInput::TransactionIndexDesc => ("transaction_index", "DESC"),
-            LegacyOrderByInput::MsgHashAsc => ("msg_hash", "ASC"),
-            LegacyOrderByInput::MsgHashDesc => ("msg_hash", "DESC"),
-            LegacyOrderByInput::MsgIdAsc => ("msg_id", "ASC"),
-            LegacyOrderByInput::MsgIdDesc => ("msg_id", "DESC"),
+        let (column, direction, qualify) = match order {
+            LegacyOrderByInput::IdAsc => ("id", "ASC", false),
+            LegacyOrderByInput::IdDesc => ("id", "DESC", false),
+            LegacyOrderByInput::BlockNumberAsc => ("block_number", "ASC", true),
+            LegacyOrderByInput::BlockNumberDesc => ("block_number", "DESC", true),
+            LegacyOrderByInput::BlockTimestampAsc => ("block_timestamp", "ASC", true),
+            LegacyOrderByInput::BlockTimestampDesc => ("block_timestamp", "DESC", true),
+            LegacyOrderByInput::ChainIdAsc => ("chain_id", "ASC", true),
+            LegacyOrderByInput::ChainIdDesc => ("chain_id", "DESC", true),
+            LegacyOrderByInput::LogIndexAsc => ("log_index", "ASC", true),
+            LegacyOrderByInput::LogIndexDesc => ("log_index", "DESC", true),
+            LegacyOrderByInput::TransactionIndexAsc => ("transaction_index", "ASC", true),
+            LegacyOrderByInput::TransactionIndexDesc => ("transaction_index", "DESC", true),
+            LegacyOrderByInput::MsgHashAsc => ("msg_hash", "ASC", false),
+            LegacyOrderByInput::MsgHashDesc => ("msg_hash", "DESC", false),
+            LegacyOrderByInput::MsgIdAsc => ("msg_id", "ASC", false),
+            LegacyOrderByInput::MsgIdDesc => ("msg_id", "DESC", false),
             #[cfg(feature = "legacy-query-compat")]
-            LegacyOrderByInput::IndexAsc => (r#""index""#, "ASC"),
+            LegacyOrderByInput::IndexAsc => (r#""index""#, "ASC", true),
             #[cfg(feature = "legacy-query-compat")]
-            LegacyOrderByInput::IndexDesc => (r#""index""#, "DESC"),
+            LegacyOrderByInput::IndexDesc => (r#""index""#, "DESC", true),
             #[cfg(feature = "legacy-query-compat")]
-            LegacyOrderByInput::MsgIndexAsc => ("msg_index", "ASC"),
+            LegacyOrderByInput::MsgIndexAsc => ("msg_index", "ASC", true),
             #[cfg(feature = "legacy-query-compat")]
-            LegacyOrderByInput::MsgIndexDesc => ("msg_index", "DESC"),
+            LegacyOrderByInput::MsgIndexDesc => ("msg_index", "DESC", true),
         };
-        separated.push(format!("{column} {direction}"));
+        if qualify {
+            separated.push(format!("{table}.{column} {direction}"));
+        } else {
+            separated.push(format!("{column} {direction}"));
+        }
+    }
+}
+
+#[cfg(all(test, feature = "legacy-query-compat"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_order_by_qualifies_numeric_columns_to_avoid_text_alias_sorting() {
+        let mut query =
+            QueryBuilder::<Postgres>::new("SELECT block_number::TEXT AS block_number FROM events");
+        push_order_by(
+            &mut query,
+            "events",
+            Some(&[
+                LegacyOrderByInput::BlockNumberDesc,
+                LegacyOrderByInput::BlockTimestampDesc,
+                LegacyOrderByInput::ChainIdDesc,
+                LegacyOrderByInput::LogIndexDesc,
+                LegacyOrderByInput::TransactionIndexDesc,
+                LegacyOrderByInput::MsgIndexDesc,
+                LegacyOrderByInput::IndexDesc,
+            ]),
+        );
+
+        assert_eq!(
+            query.sql(),
+            r#"SELECT block_number::TEXT AS block_number FROM events ORDER BY events.block_number DESC, events.block_timestamp DESC, events.chain_id DESC, events.log_index DESC, events.transaction_index DESC, events.msg_index DESC, events."index" DESC"#
+        );
     }
 }

--- a/tests/graphql_server.rs
+++ b/tests/graphql_server.rs
@@ -314,6 +314,86 @@ async fn test_graphql_legacy_list_default_limit_covers_ormpipe_hash_chunks() {
     assert_eq!(rows.len(), 58);
 }
 
+#[cfg(feature = "legacy-query-compat")]
+#[tokio::test]
+async fn test_graphql_legacy_order_by_sorts_numeric_fields_numerically() {
+    let Some(database_url) = test_database_url() else {
+        eprintln!("skipping GraphQL Postgres test; ORMPINDEXER_TEST_DATABASE_URL is not set");
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("connect test postgres");
+    apply_migrations(&pool).await.expect("apply migrations");
+    truncate_legacy_tables(&pool).await;
+    seed_numeric_order_rows(&pool).await;
+
+    let schema = build_schema(pool);
+    let response = schema
+        .execute(Request::new(
+            r#"
+            query {
+              imported: ormpHashImporteds(
+                limit: 2
+                orderBy: [msgIndex_DESC]
+                where: {
+                  srcChainId_eq: "46"
+                  targetChainId_eq: "1"
+                }
+              ) {
+                msgIndex
+              }
+              accepted: ormpMessageAccepteds(
+                limit: 2
+                orderBy: [index_DESC]
+                where: {
+                  chainId_eq: "46"
+                  toChainId_eq: "1"
+                }
+              ) {
+                index
+              }
+              blocks: ormpMessageDispatcheds(
+                limit: 2
+                orderBy: [blockNumber_DESC]
+                where: {
+                  targetChainId_eq: "1"
+                }
+              ) {
+                blockNumber
+              }
+            }
+            "#,
+        ))
+        .await;
+
+    assert!(
+        response.errors.is_empty(),
+        "unexpected GraphQL errors: {:?}",
+        response.errors
+    );
+    assert_eq!(
+        response.data.into_json().expect("GraphQL response JSON"),
+        json!({
+            "imported": [{
+                "msgIndex": "9687",
+            }, {
+                "msgIndex": "97",
+            }],
+            "accepted": [{
+                "index": "9691",
+            }, {
+                "index": "97",
+            }],
+            "blocks": [{
+                "blockNumber": "12089177",
+            }, {
+                "blockNumber": "9989983",
+            }],
+        })
+    );
+}
+
 fn legacy_events() -> Vec<LegacyOrmPEvent> {
     vec![
         LegacyOrmPEvent::MessageAccepted {
@@ -370,6 +450,47 @@ async fn truncate_legacy_tables(pool: &PgPool) {
     .execute(pool)
     .await
     .expect("truncate legacy tables");
+}
+
+#[cfg(feature = "legacy-query-compat")]
+async fn seed_numeric_order_rows(pool: &PgPool) {
+    sqlx::query(
+        r#"INSERT INTO ormp_hash_imported (
+            id, block_number, transaction_hash, block_timestamp, chain_id,
+            src_chain_id, target_chain_id, oracle, channel, msg_index, hash
+        ) VALUES
+            ('imported-97', 100, '0xtx-imported-97', 456, 46, 46, 1, '0xoracle', '0xchannel', 97, '0ximported-97'),
+            ('imported-9687', 101, '0xtx-imported-9687', 457, 46, 46, 1, '0xoracle', '0xchannel', 9687, '0ximported-9687')"#,
+    )
+    .execute(pool)
+    .await
+    .expect("insert numeric order imported rows");
+
+    sqlx::query(
+        r#"INSERT INTO ormp_message_accepted (
+            id, block_number, transaction_hash, block_timestamp, chain_id, log_index,
+            msg_hash, channel, "index", from_chain_id, "from", to_chain_id, "to",
+            gas_limit, encoded, oracle, oracle_assigned, oracle_assigned_fee,
+            relayer, relayer_assigned, relayer_assigned_fee
+        ) VALUES
+            ('accepted-97', 100, '0xtx-accepted-97', 456, 46, 3, '0xaccepted-97', '0xchannel', 97, 46, '0xfrom', 1, '0xto', 500000, '0xencoded', '0xoracle', true, 11, '0xrelayer', true, 22),
+            ('accepted-9691', 101, '0xtx-accepted-9691', 457, 46, 4, '0xaccepted-9691', '0xchannel', 9691, 46, '0xfrom', 1, '0xto', 500000, '0xencoded', '0xoracle', true, 11, '0xrelayer', true, 22)"#,
+    )
+    .execute(pool)
+    .await
+    .expect("insert numeric order accepted rows");
+
+    sqlx::query(
+        r#"INSERT INTO ormp_message_dispatched (
+            id, block_number, transaction_hash, block_timestamp, chain_id,
+            target_chain_id, msg_hash, dispatch_result
+        ) VALUES
+            ('dispatched-9989983', 9989983, '0xtx-dispatched-9989983', 456, 46, 1, '0xdispatched-9989983', true),
+            ('dispatched-12089177', 12089177, '0xtx-dispatched-12089177', 457, 46, 1, '0xdispatched-12089177', true)"#,
+    )
+    .execute(pool)
+    .await
+    .expect("insert numeric order dispatched rows");
 }
 
 #[cfg(feature = "legacy-query-compat")]


### PR DESCRIPTION
## Summary
- qualify numeric legacy GraphQL orderBy columns with their source table to avoid sorting by TEXT SELECT aliases
- add a no-DB SQL regression guard covering numeric orderBy variants
- add DB-backed GraphQL regression coverage for msgIndex_DESC, index_DESC, and blockNumber_DESC lexical edge cases

## Tests
- cargo fmt --check
- cargo test test_push_order_by_qualifies_numeric_columns_to_avoid_text_alias_sorting -- --nocapture
- cargo test --test graphql_server -- --nocapture (DB-backed bodies skipped locally because ORMPINDEXER_TEST_DATABASE_URL is unset)
- cargo test --no-default-features --test graphql_server test_graphql_schema_exposes_pages_without_connections -- --nocapture
