### PR TITLE
feat(ormpindexer): support latest finality reorg rollback

### DIFF
--- a/migrations/0001_schema_compat.sql
+++ b/migrations/0001_schema_compat.sql
@@ -129,3 +129,14 @@ CREATE TABLE IF NOT EXISTS ormp_indexer_checkpoint (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (chain_id, dataset)
 );
+
+CREATE TABLE IF NOT EXISTS ormp_indexer_block_anchor (
+  chain_id NUMERIC NOT NULL,
+  dataset TEXT NOT NULL,
+  block_number NUMERIC NOT NULL,
+  block_hash TEXT NOT NULL,
+  parent_hash TEXT,
+  finality TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (chain_id, dataset, block_number)
+);

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -5,6 +5,8 @@ use std::{
 
 use anyhow::{Context, bail};
 
+use crate::config::FinalityMode;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Checkpoint {
     pub chain_id: u64,
@@ -16,6 +18,16 @@ pub struct Checkpoint {
 pub struct BlockRange {
     pub from_block: u64,
     pub to_block: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockAnchor {
+    pub chain_id: u64,
+    pub dataset: String,
+    pub block_number: u64,
+    pub block_hash: String,
+    pub parent_hash: Option<String>,
+    pub finality: FinalityMode,
 }
 
 pub fn plan_next_range(checkpoint: &Checkpoint, batch_size: u64) -> anyhow::Result<BlockRange> {
@@ -42,11 +54,35 @@ pub trait CheckpointStore {
     ) -> anyhow::Result<Checkpoint>;
 
     async fn advance(&self, chain_id: u64, dataset: &str, next_block: u64) -> anyhow::Result<()>;
+
+    async fn upsert_block_anchors(&self, _anchors: &[BlockAnchor]) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn read_block_anchors(
+        &self,
+        _chain_id: u64,
+        _dataset: &str,
+        _from_block: u64,
+        _to_block: u64,
+    ) -> anyhow::Result<Vec<BlockAnchor>> {
+        Ok(Vec::new())
+    }
+
+    async fn rollback_legacy_from(
+        &self,
+        chain_id: u64,
+        dataset: &str,
+        rollback_block: u64,
+    ) -> anyhow::Result<()> {
+        self.advance(chain_id, dataset, rollback_block).await
+    }
 }
 
 #[derive(Clone, Default)]
 pub struct InMemoryCheckpointStore {
     checkpoints: Arc<Mutex<BTreeMap<(u64, String), u64>>>,
+    anchors: Arc<Mutex<BTreeMap<(u64, String, u64), BlockAnchor>>>,
 }
 
 impl InMemoryCheckpointStore {
@@ -85,5 +121,59 @@ impl CheckpointStore for InMemoryCheckpointStore {
             .map_err(|_| anyhow::anyhow!("checkpoint store lock poisoned"))?;
         checkpoints.insert((chain_id, dataset.to_owned()), next_block);
         Ok(())
+    }
+
+    async fn upsert_block_anchors(&self, anchors: &[BlockAnchor]) -> anyhow::Result<()> {
+        let mut stored = self
+            .anchors
+            .lock()
+            .map_err(|_| anyhow::anyhow!("block anchor store lock poisoned"))?;
+        for anchor in anchors {
+            stored.insert(
+                (anchor.chain_id, anchor.dataset.clone(), anchor.block_number),
+                anchor.clone(),
+            );
+        }
+        Ok(())
+    }
+
+    async fn read_block_anchors(
+        &self,
+        chain_id: u64,
+        dataset: &str,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<Vec<BlockAnchor>> {
+        let stored = self
+            .anchors
+            .lock()
+            .map_err(|_| anyhow::anyhow!("block anchor store lock poisoned"))?;
+        Ok(stored
+            .range(
+                (chain_id, dataset.to_owned(), from_block)
+                    ..=(chain_id, dataset.to_owned(), to_block),
+            )
+            .map(|(_, anchor)| anchor.clone())
+            .collect())
+    }
+
+    async fn rollback_legacy_from(
+        &self,
+        chain_id: u64,
+        dataset: &str,
+        rollback_block: u64,
+    ) -> anyhow::Result<()> {
+        {
+            let mut stored = self
+                .anchors
+                .lock()
+                .map_err(|_| anyhow::anyhow!("block anchor store lock poisoned"))?;
+            stored.retain(|(anchor_chain_id, anchor_dataset, block_number), _| {
+                *anchor_chain_id != chain_id
+                    || anchor_dataset != dataset
+                    || *block_number < rollback_block
+            });
+        }
+        self.advance(chain_id, dataset, rollback_block).await
     }
 }

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -81,9 +81,12 @@ pub trait CheckpointStore {
 
 #[derive(Clone, Default)]
 pub struct InMemoryCheckpointStore {
-    checkpoints: Arc<Mutex<BTreeMap<(u64, String), u64>>>,
-    anchors: Arc<Mutex<BTreeMap<(u64, String, u64), BlockAnchor>>>,
+    checkpoints: Arc<Mutex<InMemoryCheckpoints>>,
+    anchors: Arc<Mutex<InMemoryBlockAnchors>>,
 }
+
+type InMemoryCheckpoints = BTreeMap<(u64, String), u64>;
+type InMemoryBlockAnchors = BTreeMap<(u64, String, u64), BlockAnchor>;
 
 impl InMemoryCheckpointStore {
     pub async fn next_block(&self, chain_id: u64, dataset: &str) -> anyhow::Result<u64> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub struct RuntimeConfig {
     pub batch_size: u64,
     pub start_block: u64,
     pub finality_mode: FinalityMode,
+    pub reorg_window_blocks: u64,
     pub poll_interval: Duration,
 }
 
@@ -53,9 +54,17 @@ impl RuntimeConfig {
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
+        let finality_mode = optional_env(env, "ORMPINDEXER_FINALITY_MODE")
+            .as_deref()
+            .map(str::parse)
+            .transpose()?
+            .unwrap_or(FinalityMode::Finalized);
+
         let enabled_chains = chain_ids
             .into_iter()
-            .map(|chain_id| ChainConfig::from_env_map(env, chain_id, start_block, batch_size))
+            .map(|chain_id| {
+                ChainConfig::from_env_map(env, chain_id, start_block, batch_size, finality_mode)
+            })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         let warmup_chunk_size =
@@ -77,6 +86,15 @@ impl RuntimeConfig {
             optional_u64(env, "ORMPINDEXER_DATALENS_HEAD_BUFFER_BLOCKS")?.unwrap_or(1);
         let datalens_min_request_interval_ms =
             optional_u64(env, "ORMPINDEXER_DATALENS_MIN_REQUEST_INTERVAL_MS")?.unwrap_or(100);
+        let reorg_window_blocks =
+            optional_u64(env, "ORMPINDEXER_REORG_WINDOW_BLOCKS")?.unwrap_or(128);
+        if reorg_window_blocks == 0
+            && enabled_chains
+                .iter()
+                .any(|chain| chain.finality_mode.uses_reorg_protection())
+        {
+            bail!("ORMPINDEXER_REORG_WINDOW_BLOCKS must be greater than zero");
+        }
 
         Ok(Self {
             datalens: DatalensConfig {
@@ -106,11 +124,8 @@ impl RuntimeConfig {
             enabled_chains,
             batch_size,
             start_block: start_block.unwrap_or(0),
-            finality_mode: optional_env(env, "ORMPINDEXER_FINALITY_MODE")
-                .as_deref()
-                .map(str::parse)
-                .transpose()?
-                .unwrap_or(FinalityMode::Finalized),
+            finality_mode,
+            reorg_window_blocks,
             poll_interval: Duration::from_secs(
                 optional_u64(env, "ORMPINDEXER_POLL_INTERVAL_SECS")?.unwrap_or(30),
             ),
@@ -142,6 +157,7 @@ pub struct ChainConfig {
     pub batch_size: u64,
     pub contracts: Vec<String>,
     pub topics: Vec<String>,
+    pub finality_mode: FinalityMode,
 }
 
 impl ChainConfig {
@@ -150,6 +166,7 @@ impl ChainConfig {
         chain_id: u64,
         default_start_block: Option<u64>,
         default_batch_size: u64,
+        default_finality_mode: FinalityMode,
     ) -> anyhow::Result<Self> {
         let prefix = format!("ORMPINDEXER_CHAIN_{chain_id}");
         let default = default_chain_config(chain_id)?;
@@ -169,6 +186,11 @@ impl ChainConfig {
         if batch_size == 0 {
             bail!("{prefix}_BATCH_SIZE must be greater than zero");
         }
+        let finality_mode = optional_env(env, &format!("{prefix}_FINALITY_MODE"))
+            .as_deref()
+            .map(str::parse)
+            .transpose()?
+            .unwrap_or(default_finality_mode);
 
         Ok(Self {
             chain_id,
@@ -184,6 +206,7 @@ impl ChainConfig {
             } else {
                 topics
             },
+            finality_mode,
         })
     }
 }
@@ -192,6 +215,8 @@ impl ChainConfig {
 pub enum FinalityMode {
     Finalized,
     Durable,
+    Safe,
+    Latest,
 }
 
 impl FinalityMode {
@@ -199,7 +224,13 @@ impl FinalityMode {
         match self {
             Self::Finalized => "finalized",
             Self::Durable => "durable",
+            Self::Safe => "safe",
+            Self::Latest => "latest",
         }
+    }
+
+    pub fn uses_reorg_protection(self) -> bool {
+        matches!(self, Self::Safe | Self::Latest)
     }
 }
 
@@ -210,7 +241,9 @@ impl std::str::FromStr for FinalityMode {
         match value {
             "finalized" => Ok(Self::Finalized),
             "durable" => Ok(Self::Durable),
-            _ => bail!("ORMPINDEXER_FINALITY_MODE must be finalized or durable"),
+            "safe" => Ok(Self::Safe),
+            "latest" => Ok(Self::Latest),
+            _ => bail!("ORMPINDEXER_FINALITY_MODE must be finalized, durable, safe, or latest"),
         }
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -155,6 +155,17 @@ impl CheckpointStore for PostgresCheckpointStore {
             .await
             .context("begin ORMP rollback transaction")?;
 
+        let assignment_msg_hashes =
+            rolled_back_assignment_msg_hashes_tx(&mut tx, chain_id, rollback_block).await?;
+
+        delete_signature_submittions_by_source_anchors_tx(
+            &mut tx,
+            chain_id,
+            dataset,
+            rollback_block,
+        )
+        .await?;
+
         for table in LEGACY_ROLLBACK_TABLES {
             let sql = format!(
                 "DELETE FROM {table}
@@ -167,6 +178,13 @@ impl CheckpointStore for PostgresCheckpointStore {
                 .await
                 .with_context(|| format!("rollback {table} rows"))?;
         }
+
+        recompute_accepted_assignments_tx(
+            &mut tx,
+            &assignment_msg_hashes,
+            &AssignmentConfig::legacy_defaults(),
+        )
+        .await?;
 
         sqlx::query(
             "DELETE FROM ormp_indexer_block_anchor
@@ -306,6 +324,109 @@ const LEGACY_ROLLBACK_TABLES: &[&str] = &[
     "msgport_message_sent",
     "signature_pub_signature_submittion",
 ];
+
+async fn rolled_back_assignment_msg_hashes_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    chain_id: u64,
+    rollback_block: u64,
+) -> anyhow::Result<Vec<String>> {
+    let rows = sqlx::query_as::<_, (String,)>(
+        "SELECT DISTINCT msg_hash
+         FROM ormp_message_assigned
+         WHERE chain_id = $1::NUMERIC AND block_number >= $2::NUMERIC",
+    )
+    .bind(chain_id.to_string())
+    .bind(rollback_block.to_string())
+    .fetch_all(&mut **tx)
+    .await
+    .context("load rolled back assignment message hashes")?;
+
+    Ok(rows.into_iter().map(|(msg_hash,)| msg_hash).collect())
+}
+
+async fn delete_signature_submittions_by_source_anchors_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    chain_id: u64,
+    dataset: &str,
+    rollback_block: u64,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "DELETE FROM signature_pub_signature_submittion signatures
+         USING ormp_indexer_block_anchor anchors
+         WHERE anchors.chain_id = $1::NUMERIC
+           AND anchors.dataset = $2
+           AND anchors.block_number >= $3::NUMERIC
+           AND signatures.block_number = anchors.block_number
+           AND signatures.id LIKE
+                LPAD(TRUNC(anchors.block_number)::TEXT, 10, '0')
+                || '-'
+                || LOWER(LEFT(REGEXP_REPLACE(anchors.block_hash, '^0[xX]', ''), 5))
+                || '-%'",
+    )
+    .bind(chain_id.to_string())
+    .bind(dataset)
+    .bind(rollback_block.to_string())
+    .execute(&mut **tx)
+    .await
+    .context("rollback signature_pub_signature_submittion rows by source anchors")?;
+
+    Ok(())
+}
+
+async fn recompute_accepted_assignments_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    msg_hashes: &[String],
+    assignment_config: &AssignmentConfig,
+) -> anyhow::Result<()> {
+    if msg_hashes.is_empty() {
+        return Ok(());
+    }
+
+    sqlx::query(
+        "UPDATE ormp_message_accepted
+         SET
+            oracle = NULL,
+            oracle_assigned = NULL,
+            oracle_assigned_fee = NULL,
+            relayer = NULL,
+            relayer_assigned = NULL,
+            relayer_assigned_fee = NULL
+         WHERE msg_hash = ANY($1::TEXT[])",
+    )
+    .bind(msg_hashes)
+    .execute(&mut **tx)
+    .await
+    .context("clear rolled back accepted assignment fields")?;
+
+    let assignments = sqlx::query_as::<_, OrmpMessageAssignedDbRow>(
+        "SELECT
+            id,
+            block_number::TEXT AS block_number,
+            transaction_hash,
+            block_timestamp::TEXT AS block_timestamp,
+            chain_id::TEXT AS chain_id,
+            msg_hash,
+            oracle,
+            relayer,
+            oracle_fee::TEXT AS oracle_fee,
+            relayer_fee::TEXT AS relayer_fee,
+            params
+         FROM ormp_message_assigned
+         WHERE msg_hash = ANY($1::TEXT[])
+         ORDER BY block_number ASC, id ASC",
+    )
+    .bind(msg_hashes)
+    .fetch_all(&mut **tx)
+    .await
+    .context("load remaining assignment rows for rollback backfill")?;
+
+    for assignment in assignments {
+        let assignment = assignment.into_schema_row()?;
+        backfill_message_assignment(tx, &assignment, assignment_config).await?;
+    }
+
+    Ok(())
+}
 
 #[derive(sqlx::FromRow)]
 struct BlockAnchorDbRow {

--- a/src/database.rs
+++ b/src/database.rs
@@ -33,11 +33,22 @@ pub async fn apply_migrations(pool: &PgPool) -> anyhow::Result<()> {
 #[derive(Clone)]
 pub struct PostgresCheckpointStore {
     pool: PgPool,
+    assignment_config: AssignmentConfig,
 }
 
 impl PostgresCheckpointStore {
     pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            assignment_config: AssignmentConfig::legacy_defaults(),
+        }
+    }
+
+    pub fn with_assignment_config(pool: PgPool, assignment_config: AssignmentConfig) -> Self {
+        Self {
+            pool,
+            assignment_config,
+        }
     }
 }
 
@@ -179,12 +190,8 @@ impl CheckpointStore for PostgresCheckpointStore {
                 .with_context(|| format!("rollback {table} rows"))?;
         }
 
-        recompute_accepted_assignments_tx(
-            &mut tx,
-            &assignment_msg_hashes,
-            &AssignmentConfig::legacy_defaults(),
-        )
-        .await?;
+        recompute_accepted_assignments_tx(&mut tx, &assignment_msg_hashes, &self.assignment_config)
+            .await?;
 
         sqlx::query(
             "DELETE FROM ormp_indexer_block_anchor

--- a/src/database.rs
+++ b/src/database.rs
@@ -2,8 +2,8 @@ use anyhow::Context;
 use sqlx::{PgPool, Postgres, Transaction, migrate::Migrator, postgres::PgPoolOptions};
 
 use crate::{
-    checkpoint::CheckpointStore,
-    config::SecretString,
+    checkpoint::{BlockAnchor, CheckpointStore},
+    config::{FinalityMode, SecretString},
     schema::{
         AssignmentConfig, EventSource, LEGACY_B49E_ARBITRUM_FROM_BLOCK,
         LEGACY_B49E_DARWINIA_FROM_BLOCK, LEGACY_B49E_ORACLE, LEGACY_B49E_ORACLE_FROM_BLOCK,
@@ -90,11 +90,125 @@ impl CheckpointStore for PostgresCheckpointStore {
 
         Ok(())
     }
+
+    async fn upsert_block_anchors(&self, anchors: &[BlockAnchor]) -> anyhow::Result<()> {
+        if anchors.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .context("begin ORMP block anchor transaction")?;
+        upsert_block_anchors_tx(&mut tx, anchors).await?;
+        tx.commit()
+            .await
+            .context("commit ORMP block anchor transaction")?;
+        Ok(())
+    }
+
+    async fn read_block_anchors(
+        &self,
+        chain_id: u64,
+        dataset: &str,
+        from_block: u64,
+        to_block: u64,
+    ) -> anyhow::Result<Vec<BlockAnchor>> {
+        let rows = sqlx::query_as::<_, BlockAnchorDbRow>(
+            "SELECT
+                chain_id::TEXT AS chain_id,
+                dataset,
+                block_number::TEXT AS block_number,
+                block_hash,
+                parent_hash,
+                finality
+             FROM ormp_indexer_block_anchor
+             WHERE chain_id = $1::NUMERIC
+               AND dataset = $2
+               AND block_number >= $3::NUMERIC
+               AND block_number <= $4::NUMERIC
+             ORDER BY block_number ASC",
+        )
+        .bind(chain_id.to_string())
+        .bind(dataset)
+        .bind(from_block.to_string())
+        .bind(to_block.to_string())
+        .fetch_all(&self.pool)
+        .await
+        .context("read ORMP block anchors")?;
+
+        rows.into_iter()
+            .map(BlockAnchorDbRow::into_anchor)
+            .collect()
+    }
+
+    async fn rollback_legacy_from(
+        &self,
+        chain_id: u64,
+        dataset: &str,
+        rollback_block: u64,
+    ) -> anyhow::Result<()> {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .context("begin ORMP rollback transaction")?;
+
+        for table in LEGACY_ROLLBACK_TABLES {
+            let sql = format!(
+                "DELETE FROM {table}
+                 WHERE chain_id = $1::NUMERIC AND block_number >= $2::NUMERIC"
+            );
+            sqlx::query(&sql)
+                .bind(chain_id.to_string())
+                .bind(rollback_block.to_string())
+                .execute(&mut *tx)
+                .await
+                .with_context(|| format!("rollback {table} rows"))?;
+        }
+
+        sqlx::query(
+            "DELETE FROM ormp_indexer_block_anchor
+             WHERE chain_id = $1::NUMERIC AND dataset = $2 AND block_number >= $3::NUMERIC",
+        )
+        .bind(chain_id.to_string())
+        .bind(dataset)
+        .bind(rollback_block.to_string())
+        .execute(&mut *tx)
+        .await
+        .context("rollback ORMP block anchors")?;
+
+        upsert_checkpoint_tx(&mut tx, chain_id, dataset, rollback_block).await?;
+
+        tx.commit()
+            .await
+            .context("commit ORMP rollback transaction")?;
+        Ok(())
+    }
 }
 
 #[allow(async_fn_in_trait)]
 pub trait EventWriter {
     async fn write_events(&self, events: &[LegacyOrmPEvent]) -> anyhow::Result<usize>;
+
+    async fn write_events_and_advance_checkpoint<C>(
+        &self,
+        checkpoints: &C,
+        events: &[LegacyOrmPEvent],
+        anchors: &[BlockAnchor],
+        chain_id: u64,
+        dataset: &str,
+        next_block: u64,
+    ) -> anyhow::Result<usize>
+    where
+        C: CheckpointStore + Sync,
+    {
+        let written = self.write_events(events).await?;
+        checkpoints.upsert_block_anchors(anchors).await?;
+        checkpoints.advance(chain_id, dataset, next_block).await?;
+        Ok(written)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -150,6 +264,122 @@ impl EventWriter for PostgresEventWriter {
 
         Ok(events.len())
     }
+
+    async fn write_events_and_advance_checkpoint<C>(
+        &self,
+        _checkpoints: &C,
+        events: &[LegacyOrmPEvent],
+        anchors: &[BlockAnchor],
+        chain_id: u64,
+        dataset: &str,
+        next_block: u64,
+    ) -> anyhow::Result<usize>
+    where
+        C: CheckpointStore + Sync,
+    {
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .context("begin ORMP indexed range transaction")?;
+
+        for event in events {
+            write_legacy_event(&mut tx, event.clone(), &self.assignment_config).await?;
+        }
+        upsert_block_anchors_tx(&mut tx, anchors).await?;
+        upsert_checkpoint_tx(&mut tx, chain_id, dataset, next_block).await?;
+
+        tx.commit()
+            .await
+            .context("commit ORMP indexed range transaction")?;
+
+        Ok(events.len())
+    }
+}
+
+const LEGACY_ROLLBACK_TABLES: &[&str] = &[
+    "ormp_hash_imported",
+    "ormp_message_accepted",
+    "ormp_message_assigned",
+    "ormp_message_dispatched",
+    "msgport_message_recv",
+    "msgport_message_sent",
+    "signature_pub_signature_submittion",
+];
+
+#[derive(sqlx::FromRow)]
+struct BlockAnchorDbRow {
+    chain_id: String,
+    dataset: String,
+    block_number: String,
+    block_hash: String,
+    parent_hash: Option<String>,
+    finality: String,
+}
+
+impl BlockAnchorDbRow {
+    fn into_anchor(self) -> anyhow::Result<BlockAnchor> {
+        Ok(BlockAnchor {
+            chain_id: self.chain_id.parse()?,
+            dataset: self.dataset,
+            block_number: self.block_number.parse()?,
+            block_hash: self.block_hash,
+            parent_hash: self.parent_hash,
+            finality: self.finality.parse::<FinalityMode>()?,
+        })
+    }
+}
+
+async fn upsert_block_anchors_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    anchors: &[BlockAnchor],
+) -> anyhow::Result<()> {
+    for anchor in anchors {
+        sqlx::query(
+            "INSERT INTO ormp_indexer_block_anchor (
+                chain_id, dataset, block_number, block_hash, parent_hash, finality, updated_at
+             )
+             VALUES ($1::NUMERIC, $2, $3::NUMERIC, $4, $5, $6, now())
+             ON CONFLICT (chain_id, dataset, block_number) DO UPDATE SET
+                block_hash = EXCLUDED.block_hash,
+                parent_hash = EXCLUDED.parent_hash,
+                finality = EXCLUDED.finality,
+                updated_at = EXCLUDED.updated_at",
+        )
+        .bind(anchor.chain_id.to_string())
+        .bind(&anchor.dataset)
+        .bind(anchor.block_number.to_string())
+        .bind(&anchor.block_hash)
+        .bind(&anchor.parent_hash)
+        .bind(anchor.finality.as_str())
+        .execute(&mut **tx)
+        .await
+        .context("upsert ORMP block anchor")?;
+    }
+    Ok(())
+}
+
+async fn upsert_checkpoint_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    chain_id: u64,
+    dataset: &str,
+    next_block: u64,
+) -> anyhow::Result<()> {
+    sqlx::query(
+        "INSERT INTO ormp_indexer_checkpoint (chain_id, dataset, next_block, updated_at)
+         VALUES ($1::NUMERIC, $2, $3::NUMERIC, now())
+         ON CONFLICT (chain_id, dataset) DO UPDATE SET
+            next_block = EXCLUDED.next_block,
+            updated_at = EXCLUDED.updated_at",
+    )
+    .bind(chain_id.to_string())
+    .bind(dataset)
+    .bind(next_block.to_string())
+    .execute(&mut **tx)
+    .await
+    .context("upsert ORMP checkpoint")?;
+
+    Ok(())
 }
 
 async fn write_legacy_event(

--- a/src/datalens/client.rs
+++ b/src/datalens/client.rs
@@ -11,17 +11,17 @@ use crate::{
     config::{DatalensConfig, FinalityMode},
     datalens::{
         query::{
-            chain_head_finality, chain_name, logs_from_native_query_payload,
-            native_graphql_request, native_graphql_transaction_request,
-            transactions_from_native_query_payload,
+            blocks_from_native_query_payload, chain_head_finality, chain_name,
+            logs_from_native_query_payload, native_graphql_block_request, native_graphql_request,
+            native_graphql_transaction_request, transactions_from_native_query_payload,
         },
         retry::{
             body_has_retryable_graphql_errors, datalens_retry_delay, graphql_retry_after,
             http_retry_after, is_retryable_http_status,
         },
         types::{
-            DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader, DatalensTransactionQuery,
-            DatalensTransactionQueryResult,
+            DatalensBlockQuery, DatalensBlockQueryResult, DatalensLogQuery, DatalensLogQueryResult,
+            DatalensLogReader, DatalensTransactionQuery, DatalensTransactionQueryResult,
         },
     },
     warmup::{
@@ -289,6 +289,38 @@ impl DatalensLogReader for DatalensHttpClient {
 
         let logs = logs_from_native_query_payload(&payload, query.chain_id)?;
         Ok(DatalensLogQueryResult { logs })
+    }
+
+    async fn query_blocks(
+        &self,
+        query: DatalensBlockQuery,
+    ) -> anyhow::Result<DatalensBlockQueryResult> {
+        let request = native_graphql_block_request(&query)?;
+        let endpoint = self.native_graphql_endpoint();
+        let body = self
+            .request_text_with_retries(
+                "Datalens block query",
+                || {
+                    let mut builder = self
+                        .http
+                        .post(&endpoint)
+                        .header("x-datalens-application", &self.config.application)
+                        .json(&request);
+                    if let Some(token) = &self.config.token {
+                        builder = builder.bearer_auth(token.expose_secret());
+                    }
+                    builder
+                },
+                body_has_retryable_graphql_errors,
+            )
+            .await?;
+        let payload: serde_json::Value = serde_json::from_str(&body)?;
+        if let Some(errors) = payload.get("errors") {
+            anyhow::bail!("Datalens block query returned errors: {errors}");
+        }
+
+        let blocks = blocks_from_native_query_payload(&payload, query.chain_id)?;
+        Ok(DatalensBlockQueryResult { blocks })
     }
 
     async fn query_transactions(

--- a/src/datalens/mod.rs
+++ b/src/datalens/mod.rs
@@ -5,7 +5,7 @@ mod types;
 
 pub use client::DatalensHttpClient;
 pub use query::{
-    evm_chain_name, logs_from_native_query_payload, native_graphql_request,
+    chain_head_finality, evm_chain_name, logs_from_native_query_payload, native_graphql_request,
     native_graphql_transaction_request, transactions_from_native_query_payload, tron_chain_name,
 };
 pub use retry::{DatalensFailureKind, classify_datalens_failure_message};

--- a/src/datalens/mod.rs
+++ b/src/datalens/mod.rs
@@ -5,11 +5,13 @@ mod types;
 
 pub use client::DatalensHttpClient;
 pub use query::{
-    chain_head_finality, evm_chain_name, logs_from_native_query_payload, native_graphql_request,
+    blocks_from_native_query_payload, chain_head_finality, evm_chain_name,
+    logs_from_native_query_payload, native_graphql_block_request, native_graphql_request,
     native_graphql_transaction_request, transactions_from_native_query_payload, tron_chain_name,
 };
 pub use retry::{DatalensFailureKind, classify_datalens_failure_message};
 pub use types::{
-    DatalensLog, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader, DatalensTransaction,
-    DatalensTransactionQuery, DatalensTransactionQueryResult,
+    DatalensBlock, DatalensBlockQuery, DatalensBlockQueryResult, DatalensLog, DatalensLogQuery,
+    DatalensLogQueryResult, DatalensLogReader, DatalensTransaction, DatalensTransactionQuery,
+    DatalensTransactionQueryResult,
 };

--- a/src/datalens/query.rs
+++ b/src/datalens/query.rs
@@ -107,6 +107,8 @@ struct NativeLogRow {
     #[serde(default)]
     block_hash: Option<String>,
     #[serde(default)]
+    parent_hash: Option<String>,
+    #[serde(default)]
     block_timestamp: Option<u64>,
     transaction_hash: String,
     transaction_index: i32,
@@ -132,6 +134,7 @@ impl NativeLogRow {
             chain_id,
             block_number: self.block_number,
             block_hash: self.block_hash,
+            parent_hash: self.parent_hash,
             block_timestamp: self.block_timestamp,
             transaction_hash: self.transaction_hash,
             transaction_index: Some(self.transaction_index),
@@ -165,6 +168,8 @@ struct NativeTronEventRow {
     block_number: u64,
     #[serde(default)]
     block_hash: Option<String>,
+    #[serde(default)]
+    parent_hash: Option<String>,
     block_timestamp: u64,
     transaction_index: i32,
     event_index: u64,
@@ -199,6 +204,7 @@ impl NativeTronEventRow {
             chain_id,
             block_number: self.block_number,
             block_hash: self.block_hash,
+            parent_hash: self.parent_hash,
             block_timestamp: Some(self.block_timestamp),
             transaction_hash: self.transaction_id,
             transaction_index: Some(self.transaction_index),
@@ -400,13 +406,17 @@ fn native_finality(finality_mode: FinalityMode) -> &'static str {
     match finality_mode {
         FinalityMode::Finalized => "durable_only",
         FinalityMode::Durable => "durable_only",
+        FinalityMode::Safe => "safe_to_latest",
+        FinalityMode::Latest => "latest_only",
     }
 }
 
-pub(super) fn chain_head_finality(finality_mode: FinalityMode) -> &'static str {
+pub fn chain_head_finality(finality_mode: FinalityMode) -> &'static str {
     match finality_mode {
         FinalityMode::Finalized => "finalized",
         FinalityMode::Durable => "finalized",
+        FinalityMode::Safe => "safe",
+        FinalityMode::Latest => "latest",
     }
 }
 

--- a/src/datalens/query.rs
+++ b/src/datalens/query.rs
@@ -6,7 +6,8 @@ use sha2::{Digest, Sha256};
 use crate::{
     config::FinalityMode,
     datalens::types::{
-        DatalensLog, DatalensLogQuery, DatalensTransaction, DatalensTransactionQuery,
+        DatalensBlock, DatalensBlockQuery, DatalensLog, DatalensLogQuery, DatalensTransaction,
+        DatalensTransactionQuery,
     },
     planner::TRON_CHAIN_ID,
 };
@@ -21,6 +22,25 @@ pub fn native_graphql_request(query: &DatalensLogQuery) -> anyhow::Result<serde_
     Ok(json!({
         "query": r#"
             query OrmpIndexerLogs($input: QueryInput!) {
+              query(input: $input) {
+                rows
+              }
+            }
+        "#,
+        "variables": {
+            "input": input
+        }
+    }))
+}
+
+pub fn native_graphql_block_request(
+    query: &DatalensBlockQuery,
+) -> anyhow::Result<serde_json::Value> {
+    let input = block_query_input(query)?;
+
+    Ok(json!({
+        "query": r#"
+            query OrmpIndexerBlocks($input: QueryInput!) {
               query(input: $input) {
                 rows
               }
@@ -49,6 +69,21 @@ pub fn native_graphql_transaction_request(
             "input": input
         }
     }))
+}
+
+pub fn blocks_from_native_query_payload(
+    payload: &serde_json::Value,
+    chain_id: u64,
+) -> anyhow::Result<Vec<DatalensBlock>> {
+    let rows = payload
+        .pointer("/data/query/rows")
+        .cloned()
+        .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
+    let blocks = native_block_rows(&rows)?;
+    blocks
+        .into_iter()
+        .map(|row| row.into_datalens_block(chain_id))
+        .collect()
 }
 
 pub fn logs_from_native_query_payload(
@@ -97,6 +132,32 @@ fn native_transaction_rows(rows: &serde_json::Value) -> anyhow::Result<Vec<Datal
     let rows =
         native_rows(rows).context("Datalens native query response missing evm transaction rows")?;
     Ok(serde_json::from_value(rows.clone())?)
+}
+
+fn native_block_rows(rows: &serde_json::Value) -> anyhow::Result<Vec<NativeBlockRow>> {
+    let rows = native_rows(rows).context("Datalens native query response missing block rows")?;
+    Ok(serde_json::from_value(rows.clone())?)
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
+struct NativeBlockRow {
+    #[serde(alias = "blockNumber", alias = "number")]
+    block_number: u64,
+    #[serde(alias = "blockHash", alias = "hash")]
+    block_hash: String,
+    #[serde(default, alias = "parentHash")]
+    parent_hash: Option<String>,
+}
+
+impl NativeBlockRow {
+    fn into_datalens_block(self, chain_id: u64) -> anyhow::Result<DatalensBlock> {
+        Ok(DatalensBlock {
+            chain_id,
+            block_number: self.block_number,
+            block_hash: self.block_hash,
+            parent_hash: self.parent_hash,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize)]
@@ -277,6 +338,46 @@ fn evm_transaction_query_input(
         "datasetKey": {
             "family": "evm",
             "name": "transactions",
+        },
+        "selector": {
+            "kind": "all",
+        },
+        "range": {
+            "kind": "block",
+            "start": query.from_block,
+            "end": query.to_block,
+        },
+        "finality": native_finality(query.finality_mode),
+        "fields": {},
+    }))
+}
+
+fn block_query_input(query: &DatalensBlockQuery) -> anyhow::Result<serde_json::Value> {
+    let (family, chain) = if query.chain_id == TRON_CHAIN_ID {
+        (
+            "tron",
+            json!({
+                "family": { "kind": "other", "other": "tron" },
+                "configuredName": tron_chain_name(query.chain_id)?,
+                "networkId": { "numeric": query.chain_id },
+            }),
+        )
+    } else {
+        (
+            "evm",
+            json!({
+                "family": { "kind": "evm" },
+                "configuredName": evm_chain_name(query.chain_id)?,
+                "networkId": { "numeric": query.chain_id },
+            }),
+        )
+    };
+
+    Ok(json!({
+        "chain": chain,
+        "datasetKey": {
+            "family": family,
+            "name": "blocks",
         },
         "selector": {
             "kind": "all",

--- a/src/datalens/types.rs
+++ b/src/datalens/types.rs
@@ -3,6 +3,32 @@ use serde::{Deserialize, Serialize};
 use crate::config::FinalityMode;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensBlockQuery {
+    pub chain_id: u64,
+    pub from_block: u64,
+    pub to_block: u64,
+    pub finality_mode: FinalityMode,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DatalensBlock {
+    #[serde(alias = "chain_id")]
+    pub chain_id: u64,
+    #[serde(alias = "block_number", alias = "number")]
+    pub block_number: u64,
+    #[serde(alias = "block_hash", alias = "hash")]
+    pub block_hash: String,
+    #[serde(default, alias = "parent_hash")]
+    pub parent_hash: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatalensBlockQueryResult {
+    pub blocks: Vec<DatalensBlock>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DatalensLogQuery {
     pub chain_id: u64,
     pub from_block: u64,
@@ -81,6 +107,13 @@ pub struct DatalensTransactionQueryResult {
 pub trait DatalensLogReader {
     async fn latest_block(&self, chain_id: u64, finality_mode: FinalityMode)
     -> anyhow::Result<u64>;
+
+    async fn query_blocks(
+        &self,
+        _query: DatalensBlockQuery,
+    ) -> anyhow::Result<DatalensBlockQueryResult> {
+        anyhow::bail!("Datalens block query is not implemented")
+    }
 
     async fn query_logs(&self, query: DatalensLogQuery) -> anyhow::Result<DatalensLogQueryResult>;
 

--- a/src/datalens/types.rs
+++ b/src/datalens/types.rs
@@ -23,6 +23,8 @@ pub struct DatalensLog {
     pub block_number: u64,
     #[serde(default, alias = "block_hash")]
     pub block_hash: Option<String>,
+    #[serde(default, alias = "parent_hash")]
+    pub parent_hash: Option<String>,
     #[serde(default, alias = "block_timestamp")]
     pub block_timestamp: Option<u64>,
     #[serde(alias = "transaction_hash")]

--- a/src/planner.rs
+++ b/src/planner.rs
@@ -116,6 +116,7 @@ pub fn default_evm_chain_config(chain_id: u64) -> anyhow::Result<ChainConfig> {
         batch_size: 1_000,
         contracts: default_contracts(default.include_signature_pub),
         topics: default_topics(default.include_signature_pub),
+        finality_mode: FinalityMode::Finalized,
     })
 }
 
@@ -147,6 +148,7 @@ pub fn default_tron_chain_config() -> anyhow::Result<ChainConfig> {
             TRON_MESSAGE_DISPATCHED_EVENT.to_owned(),
             TRON_SIGNATURE_SUBMITTION_EVENT.to_owned(),
         ],
+        finality_mode: FinalityMode::Finalized,
     })
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -185,13 +185,12 @@ where
                     chain.chain_id, dataset, chain.start_block
                 )
             })?;
-        if chain.finality_mode.uses_reorg_protection() {
-            if let Some(rollback_block) = self
+        if chain.finality_mode.uses_reorg_protection()
+            && let Some(rollback_block) = self
                 .rollback_reorged_anchors(&chain, dataset, checkpoint.next_block)
                 .await?
-            {
-                checkpoint.next_block = rollback_block;
-            }
+        {
+            checkpoint.next_block = rollback_block;
         }
         let latest_block = self
             .reader

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -13,8 +13,8 @@ use crate::{
     config::{ChainConfig, RuntimeConfig},
     database::EventWriter,
     datalens::{
-        DatalensFailureKind, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader,
-        DatalensTransactionQuery, classify_datalens_failure_message,
+        DatalensBlockQuery, DatalensFailureKind, DatalensLogQuery, DatalensLogQueryResult,
+        DatalensLogReader, DatalensTransactionQuery, classify_datalens_failure_message,
     },
     decoder::EventDecoder,
     planner::{MSGPORT_MESSAGE_SENT_TOPIC, TRON_CHAIN_ID, chain_dataset},
@@ -365,7 +365,9 @@ where
                 chain.chain_id, dataset, range.to_block
             )
         })?;
-        let anchors = block_anchors_from_logs(chain.chain_id, dataset, chain.finality_mode, &logs);
+        let anchors = self
+            .block_anchors_for_range(chain, dataset, range, &logs)
+            .await?;
         let written = self
             .writer
             .write_events_and_advance_checkpoint(
@@ -482,7 +484,12 @@ where
         let Some(to_block) = checkpoint_next_block.checked_sub(1) else {
             return Ok(None);
         };
-        let from_block = checkpoint_next_block.saturating_sub(self.config.reorg_window_blocks);
+        let from_block = chain
+            .start_block
+            .max(checkpoint_next_block.saturating_sub(self.config.reorg_window_blocks));
+        if from_block > to_block {
+            return Ok(None);
+        }
         let anchors = self
             .checkpoints
             .read_block_anchors(chain.chain_id, dataset, from_block, to_block)
@@ -493,47 +500,39 @@ where
                     chain.chain_id, dataset, from_block, to_block
                 )
             })?;
-        if anchors.is_empty() {
-            return Ok(None);
-        }
-
-        let current_from = anchors.first().expect("anchors not empty").block_number;
-        let current_to = anchors.last().expect("anchors not empty").block_number;
-        let current_logs = self
+        let stored_anchors = anchors
+            .into_iter()
+            .map(|anchor| (anchor.block_number, anchor))
+            .collect::<BTreeMap<_, _>>();
+        let current_blocks = self
             .reader
-            .query_logs(DatalensLogQuery {
+            .query_blocks(DatalensBlockQuery {
                 chain_id: chain.chain_id,
-                from_block: current_from,
-                to_block: current_to,
-                contracts: chain.contracts.clone(),
-                topics: chain.topics.clone(),
+                from_block,
+                to_block,
                 finality_mode: chain.finality_mode,
             })
             .await
             .with_context(|| {
                 format!(
-                    "query ORMP Datalens reorg anchors chain_id={} dataset={} from_block={} to_block={}",
-                    chain.chain_id, dataset, current_from, current_to
+                    "query ORMP Datalens reorg block anchors chain_id={} dataset={} from_block={} to_block={}",
+                    chain.chain_id, dataset, from_block, to_block
                 )
             })?;
-        let current_hashes = current_logs
-            .logs
-            .iter()
-            .filter_map(|log| {
-                log.block_hash
-                    .as_ref()
-                    .map(|block_hash| (log.block_number, block_hash))
-            })
+        let current_blocks = current_blocks
+            .blocks
+            .into_iter()
+            .map(|block| (block.block_number, block))
             .collect::<HashMap<_, _>>();
 
-        let rollback_block = anchors
-            .iter()
-            .find(|anchor| {
-                current_hashes
-                    .get(&anchor.block_number)
-                    .is_none_or(|block_hash| *block_hash != &anchor.block_hash)
-            })
-            .map(|anchor| anchor.block_number);
+        let rollback_block = (from_block..=to_block).find(|block_number| {
+            let Some(anchor) = stored_anchors.get(block_number) else {
+                return true;
+            };
+            current_blocks
+                .get(block_number)
+                .is_none_or(|block| block.block_hash != anchor.block_hash)
+        });
         let Some(rollback_block) = rollback_block else {
             return Ok(None);
         };
@@ -556,6 +555,47 @@ where
                 )
             })?;
         Ok(Some(rollback_block))
+    }
+
+    async fn block_anchors_for_range(
+        &self,
+        chain: &ChainConfig,
+        dataset: &str,
+        range: BlockRange,
+        logs: &[crate::datalens::DatalensLog],
+    ) -> anyhow::Result<Vec<BlockAnchor>> {
+        if !chain.finality_mode.uses_reorg_protection() {
+            return Ok(block_anchors_from_logs(
+                chain.chain_id,
+                dataset,
+                chain.finality_mode,
+                logs,
+            ));
+        }
+
+        let blocks = self
+            .reader
+            .query_blocks(DatalensBlockQuery {
+                chain_id: chain.chain_id,
+                from_block: range.from_block,
+                to_block: range.to_block,
+                finality_mode: chain.finality_mode,
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "query ORMP Datalens block anchors chain_id={} dataset={} from_block={} to_block={}",
+                    chain.chain_id, dataset, range.from_block, range.to_block
+                )
+            })?;
+
+        block_anchors_from_blocks(
+            chain.chain_id,
+            dataset,
+            chain.finality_mode,
+            range,
+            blocks.blocks,
+        )
     }
 }
 
@@ -591,6 +631,39 @@ fn block_anchors_from_logs(
             });
     }
     anchors.into_values().collect()
+}
+
+fn block_anchors_from_blocks(
+    chain_id: u64,
+    dataset: &str,
+    finality: crate::config::FinalityMode,
+    range: BlockRange,
+    blocks: Vec<crate::datalens::DatalensBlock>,
+) -> anyhow::Result<Vec<BlockAnchor>> {
+    let blocks = blocks
+        .into_iter()
+        .map(|block| (block.block_number, block))
+        .collect::<BTreeMap<_, _>>();
+    let mut anchors = Vec::new();
+    for block_number in range.from_block..=range.to_block {
+        let Some(block) = blocks.get(&block_number) else {
+            anyhow::bail!(
+                "Datalens block query missing block header chain_id={} dataset={} block_number={}",
+                chain_id,
+                dataset,
+                block_number
+            );
+        };
+        anchors.push(BlockAnchor {
+            chain_id,
+            dataset: dataset.to_owned(),
+            block_number,
+            block_hash: block.block_hash.clone(),
+            parent_hash: block.parent_hash.clone(),
+            finality,
+        });
+    }
+    Ok(anchors)
 }
 
 fn can_split_datalens_query_failure(error: &anyhow::Error, range: BlockRange) -> bool {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     time::{Duration, Instant},
 };
 
@@ -9,7 +9,7 @@ use anyhow::Context;
 use futures_util::{StreamExt, stream::FuturesUnordered};
 
 use crate::{
-    checkpoint::{BlockRange, CheckpointStore, plan_next_range},
+    checkpoint::{BlockAnchor, BlockRange, CheckpointStore, plan_next_range},
     config::{ChainConfig, RuntimeConfig},
     database::EventWriter,
     datalens::{
@@ -109,7 +109,7 @@ impl<R, C, D, W> IndexerRunner<R, C, D, W> {
 impl<R, C, D, W> IndexerRunner<R, C, D, W>
 where
     R: DatalensLogReader,
-    C: CheckpointStore,
+    C: CheckpointStore + Sync,
     D: EventDecoder,
     W: EventWriter,
 {
@@ -185,9 +185,17 @@ where
                     chain.chain_id, dataset, chain.start_block
                 )
             })?;
+        if chain.finality_mode.uses_reorg_protection() {
+            if let Some(rollback_block) = self
+                .rollback_reorged_anchors(&chain, dataset, checkpoint.next_block)
+                .await?
+            {
+                checkpoint.next_block = rollback_block;
+            }
+        }
         let latest_block = self
             .reader
-            .latest_block(chain.chain_id, self.config.finality_mode)
+            .latest_block(chain.chain_id, chain.finality_mode)
             .await
             .with_context(|| format!("query Datalens chain head for chain {}", chain.chain_id))?;
         let target_block = latest_block.saturating_sub(self.config.datalens.head_buffer_blocks);
@@ -246,7 +254,7 @@ where
         let mut report = ProcessedRangeReport::default();
 
         while let Some(range) = pending.pop() {
-            log_query_start(chain, dataset, range, target_block, &self.config);
+            log_query_start(chain, dataset, range, target_block);
             let batch_started = Instant::now();
             let result = match self.query_range_once(chain, dataset, range).await {
                 Ok(result) => result,
@@ -308,7 +316,7 @@ where
                 to_block: range.to_block,
                 contracts: chain.contracts.clone(),
                 topics: chain.topics.clone(),
-                finality_mode: self.config.finality_mode,
+                finality_mode: chain.finality_mode,
             })
             .await
             .with_context(|| {
@@ -351,25 +359,28 @@ where
                 )
             })?);
         }
-        let written = self.writer.write_events(&events).await.with_context(|| {
-            format!(
-                "write ORMP events chain_id={} dataset={} from_block={} to_block={}",
-                chain.chain_id, dataset, range.from_block, range.to_block
-            )
-        })?;
         let next_block = range.to_block.checked_add(1).with_context(|| {
             format!(
                 "ORMP checkpoint next block overflow chain_id={} dataset={} to_block={}",
                 chain.chain_id, dataset, range.to_block
             )
         })?;
-        self.checkpoints
-            .advance(chain.chain_id, dataset, next_block)
+        let anchors = block_anchors_from_logs(chain.chain_id, dataset, chain.finality_mode, &logs);
+        let written = self
+            .writer
+            .write_events_and_advance_checkpoint(
+                &self.checkpoints,
+                &events,
+                &anchors,
+                chain.chain_id,
+                dataset,
+                next_block,
+            )
             .await
             .with_context(|| {
                 format!(
-                    "advance ORMP checkpoint chain_id={} dataset={} next_block={}",
-                    chain.chain_id, dataset, next_block
+                    "write ORMP events chain_id={} dataset={} from_block={} to_block={} next_block={}",
+                    chain.chain_id, dataset, range.from_block, range.to_block, next_block
                 )
             })?;
 
@@ -434,7 +445,7 @@ where
                         chain_id: chain.chain_id,
                         from_block: block_number,
                         to_block: block_number,
-                        finality_mode: self.config.finality_mode,
+                        finality_mode: chain.finality_mode,
                     })
                     .await
                     .with_context(|| {
@@ -461,6 +472,91 @@ where
 
         Ok(logs)
     }
+
+    async fn rollback_reorged_anchors(
+        &self,
+        chain: &ChainConfig,
+        dataset: &str,
+        checkpoint_next_block: u64,
+    ) -> anyhow::Result<Option<u64>> {
+        let Some(to_block) = checkpoint_next_block.checked_sub(1) else {
+            return Ok(None);
+        };
+        let from_block = checkpoint_next_block.saturating_sub(self.config.reorg_window_blocks);
+        let anchors = self
+            .checkpoints
+            .read_block_anchors(chain.chain_id, dataset, from_block, to_block)
+            .await
+            .with_context(|| {
+                format!(
+                    "read ORMP block anchors chain_id={} dataset={} from_block={} to_block={}",
+                    chain.chain_id, dataset, from_block, to_block
+                )
+            })?;
+        if anchors.is_empty() {
+            return Ok(None);
+        }
+
+        let current_from = anchors.first().expect("anchors not empty").block_number;
+        let current_to = anchors.last().expect("anchors not empty").block_number;
+        let current_logs = self
+            .reader
+            .query_logs(DatalensLogQuery {
+                chain_id: chain.chain_id,
+                from_block: current_from,
+                to_block: current_to,
+                contracts: chain.contracts.clone(),
+                topics: chain.topics.clone(),
+                finality_mode: chain.finality_mode,
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "query ORMP Datalens reorg anchors chain_id={} dataset={} from_block={} to_block={}",
+                    chain.chain_id, dataset, current_from, current_to
+                )
+            })?;
+        let current_hashes = current_logs
+            .logs
+            .iter()
+            .filter_map(|log| {
+                log.block_hash
+                    .as_ref()
+                    .map(|block_hash| (log.block_number, block_hash))
+            })
+            .collect::<HashMap<_, _>>();
+
+        let rollback_block = anchors
+            .iter()
+            .find(|anchor| {
+                current_hashes
+                    .get(&anchor.block_number)
+                    .is_none_or(|block_hash| *block_hash != &anchor.block_hash)
+            })
+            .map(|anchor| anchor.block_number);
+        let Some(rollback_block) = rollback_block else {
+            return Ok(None);
+        };
+
+        log::warn!(
+            "rolling back ORMP reorged range chain_id={} dataset={} rollback_block={} checkpoint_next_block={} finality={}",
+            chain.chain_id,
+            dataset,
+            rollback_block,
+            checkpoint_next_block,
+            chain.finality_mode.as_str(),
+        );
+        self.checkpoints
+            .rollback_legacy_from(chain.chain_id, dataset, rollback_block)
+            .await
+            .with_context(|| {
+                format!(
+                    "rollback ORMP legacy rows chain_id={} dataset={} rollback_block={}",
+                    chain.chain_id, dataset, rollback_block
+                )
+            })?;
+        Ok(Some(rollback_block))
+    }
 }
 
 fn sender_hash_key(hash: &str) -> String {
@@ -470,6 +566,31 @@ fn sender_hash_key(hash: &str) -> String {
         .or_else(|| hash.strip_prefix("0X"))
         .unwrap_or(hash);
     format!("0x{}", hash.to_ascii_lowercase())
+}
+
+fn block_anchors_from_logs(
+    chain_id: u64,
+    dataset: &str,
+    finality: crate::config::FinalityMode,
+    logs: &[crate::datalens::DatalensLog],
+) -> Vec<BlockAnchor> {
+    let mut anchors = BTreeMap::new();
+    for log in logs {
+        let Some(block_hash) = log.block_hash.as_ref() else {
+            continue;
+        };
+        anchors
+            .entry(log.block_number)
+            .or_insert_with(|| BlockAnchor {
+                chain_id,
+                dataset: dataset.to_owned(),
+                block_number: log.block_number,
+                block_hash: block_hash.clone(),
+                parent_hash: log.parent_hash.clone(),
+                finality,
+            });
+    }
+    anchors.into_values().collect()
 }
 
 fn can_split_datalens_query_failure(error: &anyhow::Error, range: BlockRange) -> bool {
@@ -501,13 +622,7 @@ fn split_range(range: BlockRange) -> (BlockRange, BlockRange) {
     )
 }
 
-fn log_query_start(
-    chain: &ChainConfig,
-    dataset: &str,
-    range: BlockRange,
-    target_block: u64,
-    config: &RuntimeConfig,
-) {
+fn log_query_start(chain: &ChainConfig, dataset: &str, range: BlockRange, target_block: u64) {
     log::info!(
         "querying ORMP Datalens logs chain_id={} dataset={} from_block={} to_block={} target_block={} batch_size={} contracts={} topics={} finality={}",
         chain.chain_id,
@@ -518,7 +633,7 @@ fn log_query_start(
         chain.batch_size,
         chain.contracts.len(),
         chain.topics.len(),
-        config.finality_mode.as_str(),
+        chain.finality_mode.as_str(),
     );
 }
 

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -1,8 +1,10 @@
 use ormpindexer::{
+    config::FinalityMode,
     datalens::{
-        DatalensFailureKind, DatalensLog, classify_datalens_failure_message, evm_chain_name,
-        logs_from_native_query_payload, native_graphql_request, native_graphql_transaction_request,
-        transactions_from_native_query_payload, tron_chain_name,
+        DatalensFailureKind, DatalensLog, chain_head_finality, classify_datalens_failure_message,
+        evm_chain_name, logs_from_native_query_payload, native_graphql_request,
+        native_graphql_transaction_request, transactions_from_native_query_payload,
+        tron_chain_name,
     },
     planner::TRON_CHAIN_ID,
 };
@@ -104,6 +106,7 @@ fn test_native_query_rows_decode_with_context_metadata() {
     assert_eq!(logs[0].chain_id, 46);
     assert_eq!(logs[0].block_number, 123);
     assert_eq!(logs[0].block_hash.as_deref(), Some("0xblock"));
+    assert_eq!(logs[0].parent_hash.as_deref(), Some("0xparent"));
     assert_eq!(logs[0].block_timestamp, Some(456));
     assert_eq!(logs[0].transaction_hash, "0xtx");
     assert_eq!(logs[0].transaction_index, Some(2));
@@ -204,6 +207,7 @@ fn test_tron_native_query_rows_decode_with_context_metadata() {
     assert_eq!(logs[0].chain_id, TRON_CHAIN_ID);
     assert_eq!(logs[0].block_number, 123);
     assert_eq!(logs[0].block_hash.as_deref(), Some("0xblock"));
+    assert_eq!(logs[0].parent_hash.as_deref(), Some("0xparent"));
     assert_eq!(logs[0].block_timestamp, Some(456));
     assert_eq!(logs[0].transaction_hash, "trontx");
     assert_eq!(logs[0].transaction_index, Some(2));
@@ -295,17 +299,32 @@ fn test_tron_native_graphql_request_uses_other_selector_shape() {
 
 #[test]
 fn test_evm_native_graphql_request_uses_datalens_finality_enum() {
-    let request = native_graphql_request(&ormpindexer::datalens::DatalensLogQuery {
-        chain_id: 42161,
-        from_block: 466_386_813,
-        to_block: 466_386_813,
-        contracts: vec!["0x2cd1867fb8016f93710b6386f7f9f1d540a60812".to_owned()],
-        topics: Vec::new(),
-        finality_mode: ormpindexer::config::FinalityMode::Finalized,
-    })
-    .expect("build EVM request");
+    for (finality_mode, expected) in [
+        (FinalityMode::Finalized, "durable_only"),
+        (FinalityMode::Durable, "durable_only"),
+        (FinalityMode::Safe, "safe_to_latest"),
+        (FinalityMode::Latest, "latest_only"),
+    ] {
+        let request = native_graphql_request(&ormpindexer::datalens::DatalensLogQuery {
+            chain_id: 42161,
+            from_block: 466_386_813,
+            to_block: 466_386_813,
+            contracts: vec!["0x2cd1867fb8016f93710b6386f7f9f1d540a60812".to_owned()],
+            topics: Vec::new(),
+            finality_mode,
+        })
+        .expect("build EVM request");
 
-    assert_eq!(request["variables"]["input"]["finality"], "durable_only");
+        assert_eq!(request["variables"]["input"]["finality"], expected);
+    }
+}
+
+#[test]
+fn test_chain_head_finality_maps_runtime_modes_to_datalens_head_finality() {
+    assert_eq!(chain_head_finality(FinalityMode::Finalized), "finalized");
+    assert_eq!(chain_head_finality(FinalityMode::Durable), "finalized");
+    assert_eq!(chain_head_finality(FinalityMode::Safe), "safe");
+    assert_eq!(chain_head_finality(FinalityMode::Latest), "latest");
 }
 
 #[test]

--- a/tests/datalens_client.rs
+++ b/tests/datalens_client.rs
@@ -1,10 +1,10 @@
 use ormpindexer::{
     config::FinalityMode,
     datalens::{
-        DatalensFailureKind, DatalensLog, chain_head_finality, classify_datalens_failure_message,
-        evm_chain_name, logs_from_native_query_payload, native_graphql_request,
-        native_graphql_transaction_request, transactions_from_native_query_payload,
-        tron_chain_name,
+        DatalensFailureKind, DatalensLog, blocks_from_native_query_payload, chain_head_finality,
+        classify_datalens_failure_message, evm_chain_name, logs_from_native_query_payload,
+        native_graphql_block_request, native_graphql_request, native_graphql_transaction_request,
+        transactions_from_native_query_payload, tron_chain_name,
     },
     planner::TRON_CHAIN_ID,
 };
@@ -158,6 +158,50 @@ fn test_evm_transaction_query_uses_transactions_dataset_and_decodes_senders() {
     assert_eq!(transactions[0].hash, "0xtx");
     assert_eq!(transactions[0].block_number, 123);
     assert_eq!(transactions[0].from, "0xsender");
+}
+
+#[test]
+fn test_block_query_uses_blocks_dataset_and_decodes_headers() {
+    let request = native_graphql_block_request(&ormpindexer::datalens::DatalensBlockQuery {
+        chain_id: 46,
+        from_block: 100,
+        to_block: 110,
+        finality_mode: ormpindexer::config::FinalityMode::Safe,
+    })
+    .expect("build block request");
+    let input = &request["variables"]["input"];
+
+    assert_eq!(
+        input["datasetKey"],
+        serde_json::json!({"family": "evm", "name": "blocks"})
+    );
+    assert_eq!(input["selector"], serde_json::json!({"kind": "all"}));
+    assert_eq!(input["finality"], "safe_to_latest");
+
+    let blocks = blocks_from_native_query_payload(
+        &serde_json::json!({
+            "data": {
+                "query": {
+                    "rows": {
+                        "dataset": "blocks",
+                        "rows": [{
+                            "number": 123,
+                            "hash": "0xblock",
+                            "parent_hash": "0xparent"
+                        }]
+                    }
+                }
+            }
+        }),
+        46,
+    )
+    .expect("decode block rows");
+
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks[0].chain_id, 46);
+    assert_eq!(blocks[0].block_number, 123);
+    assert_eq!(blocks[0].block_hash, "0xblock");
+    assert_eq!(blocks[0].parent_hash.as_deref(), Some("0xparent"));
 }
 
 #[test]

--- a/tests/datalens_planner.rs
+++ b/tests/datalens_planner.rs
@@ -149,7 +149,7 @@ fn test_runtime_config_accepts_tron_chain_defaults() {
 }
 
 #[test]
-fn test_runtime_config_rejects_safe_finality_for_persistent_indexing() {
+fn test_runtime_config_accepts_safe_finality_with_reorg_window() {
     let env = BTreeMap::from([
         (
             "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
@@ -163,13 +163,14 @@ fn test_runtime_config_rejects_safe_finality_for_persistent_indexing() {
         ("ORMPINDEXER_FINALITY_MODE".to_owned(), "safe".to_owned()),
     ]);
 
-    let error = RuntimeConfig::from_env_map(&env).expect_err("safe mode is rejected");
+    let config = RuntimeConfig::from_env_map(&env).expect("safe mode is accepted");
 
-    assert!(
-        error
-            .to_string()
-            .contains("ORMPINDEXER_FINALITY_MODE must be finalized or durable")
+    assert_eq!(config.finality_mode, FinalityMode::Safe);
+    assert_eq!(
+        config.chain(46).expect("chain 46").finality_mode,
+        FinalityMode::Safe
     );
+    assert_eq!(config.reorg_window_blocks, 128);
 }
 
 #[test]

--- a/tests/evm_decoder.rs
+++ b/tests/evm_decoder.rs
@@ -518,6 +518,7 @@ fn log(topic: &str, address: &str, data: Vec<u8>) -> DatalensLog {
         chain_id: 1,
         block_number: 100,
         block_hash: None,
+        parent_hash: None,
         block_timestamp: Some(1_700_000_000_000),
         transaction_hash: bytes_hex(0xaa),
         transaction_index: Some(2),

--- a/tests/legacy_parity_support/fixtures.rs
+++ b/tests/legacy_parity_support/fixtures.rs
@@ -311,6 +311,7 @@ fn evm_log(
         chain_id: 1,
         block_number,
         block_hash: Some(transaction_hash.clone()),
+        parent_hash: None,
         block_timestamp: Some(1_700_000_000_000 + block_number - 100),
         transaction_hash,
         transaction_index: Some(transaction_index),

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -237,6 +237,160 @@ async fn test_postgres_rollback_deletes_legacy_rows_anchors_and_resets_checkpoin
     );
 }
 
+#[tokio::test]
+async fn test_postgres_rollback_recomputes_assignment_backfills_for_remaining_accepteds() {
+    let Some(database_url) = test_database_url() else {
+        eprintln!(
+            "skipping Postgres assignment rollback test; ORMPINDEXER_TEST_DATABASE_URL is not set"
+        );
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("connect test postgres");
+    apply_migrations(&pool).await.expect("apply migrations");
+    truncate_legacy_tables(&pool).await;
+
+    let writer = PostgresEventWriter::new(pool.clone());
+    writer
+        .write_events(&[
+            LegacyOrmPEvent::MessageAccepted {
+                metadata: evm_metadata_at("rollback-clear-accepted-log", 46, 122),
+                msg_hash: "0xrollback-clear".to_owned(),
+                channel: "0xchannel".to_owned(),
+                index: 1,
+                from_chain_id: 1,
+                from: "0xfrom".to_owned(),
+                to_chain_id: 46,
+                to: "0xto".to_owned(),
+                gas_limit: 500_000,
+                encoded: "0xencoded".to_owned(),
+            },
+            LegacyOrmPEvent::MessageAssigned {
+                metadata: evm_metadata_at("rollback-clear-assigned-log", 46, 123),
+                msg_hash: "0xrollback-clear".to_owned(),
+                oracle: ADDRESS_ORACLE[0].to_owned(),
+                relayer: ADDRESS_RELAYER[0].to_owned(),
+                oracle_fee: 11,
+                relayer_fee: 22,
+                params: "0xparams".to_owned(),
+            },
+            LegacyOrmPEvent::MessageAccepted {
+                metadata: evm_metadata_at("rollback-restore-accepted-log", 46, 121),
+                msg_hash: "0xrollback-restore".to_owned(),
+                channel: "0xchannel".to_owned(),
+                index: 2,
+                from_chain_id: 1,
+                from: "0xfrom".to_owned(),
+                to_chain_id: 46,
+                to: "0xto".to_owned(),
+                gas_limit: 500_000,
+                encoded: "0xencoded".to_owned(),
+            },
+            LegacyOrmPEvent::MessageAssigned {
+                metadata: evm_metadata_at("rollback-restore-old-assigned-log", 46, 122),
+                msg_hash: "0xrollback-restore".to_owned(),
+                oracle: ADDRESS_ORACLE[0].to_owned(),
+                relayer: ADDRESS_RELAYER[0].to_owned(),
+                oracle_fee: 33,
+                relayer_fee: 44,
+                params: "0xparams".to_owned(),
+            },
+            LegacyOrmPEvent::MessageAssigned {
+                metadata: evm_metadata_at("rollback-restore-new-assigned-log", 46, 123),
+                msg_hash: "0xrollback-restore".to_owned(),
+                oracle: ADDRESS_ORACLE[1].to_owned(),
+                relayer: ADDRESS_RELAYER[1].to_owned(),
+                oracle_fee: 55,
+                relayer_fee: 66,
+                params: "0xparams".to_owned(),
+            },
+        ])
+        .await
+        .expect("write rollback assignment events");
+
+    let before_restore = all_assignment_fields(&pool, "0xrollback-restore").await;
+    assert_eq!(before_restore.0.as_deref(), Some(ADDRESS_ORACLE[1]));
+    assert_eq!(before_restore.2.as_deref(), Some("55"));
+    assert_eq!(before_restore.3.as_deref(), Some(ADDRESS_RELAYER[1]));
+    assert_eq!(before_restore.5.as_deref(), Some("66"));
+
+    let checkpoints = PostgresCheckpointStore::new(pool.clone());
+    checkpoints
+        .rollback_legacy_from(46, "evm.logs", 123)
+        .await
+        .expect("rollback legacy rows");
+
+    let remaining_assignments = sqlx::query_as::<_, (i64,)>(
+        "SELECT COUNT(*) FROM ormp_message_assigned WHERE block_number >= 123",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count rolled back assignments");
+    assert_eq!(remaining_assignments.0, 0);
+
+    let clear = all_assignment_fields(&pool, "0xrollback-clear").await;
+    assert_eq!(clear, (None, None, None, None, None, None));
+
+    let restored = all_assignment_fields(&pool, "0xrollback-restore").await;
+    assert_eq!(restored.0.as_deref(), Some(ADDRESS_ORACLE[0]));
+    assert_eq!(restored.1, Some(true));
+    assert_eq!(restored.2.as_deref(), Some("33"));
+    assert_eq!(restored.3.as_deref(), Some(ADDRESS_RELAYER[0]));
+    assert_eq!(restored.4, Some(true));
+    assert_eq!(restored.5.as_deref(), Some("44"));
+}
+
+#[tokio::test]
+async fn test_postgres_rollback_deletes_signature_rows_by_indexed_source_chain() {
+    let Some(database_url) = test_database_url() else {
+        eprintln!(
+            "skipping Postgres signature rollback test; ORMPINDEXER_TEST_DATABASE_URL is not set"
+        );
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("connect test postgres");
+    apply_migrations(&pool).await.expect("apply migrations");
+    truncate_legacy_tables(&pool).await;
+
+    let checkpoints = PostgresCheckpointStore::new(pool.clone());
+    checkpoints
+        .upsert_block_anchors(&[BlockAnchor {
+            chain_id: 46,
+            dataset: "evm.logs".to_owned(),
+            block_number: 123,
+            block_hash: "0xblock".to_owned(),
+            parent_hash: Some("0xparent".to_owned()),
+            finality: FinalityMode::Latest,
+        }])
+        .await
+        .expect("seed source anchor");
+
+    let writer = PostgresEventWriter::new(pool.clone());
+    writer
+        .write_events(&[LegacyOrmPEvent::SignatureSubmittion {
+            metadata: evm_metadata_at("rollback-signature-payload-chain-log", 46, 123),
+            chain_id: 1,
+            channel: "0xchannel".to_owned(),
+            signer: "0xsigner".to_owned(),
+            msg_index: 9,
+            signature: "0xsig".to_owned(),
+            data: "0xdata".to_owned(),
+        }])
+        .await
+        .expect("write signature submittion");
+    assert_table_count(&pool, "signature_pub_signature_submittion", 1).await;
+
+    checkpoints
+        .rollback_legacy_from(46, "evm.logs", 123)
+        .await
+        .expect("rollback legacy rows");
+
+    assert_table_count(&pool, "signature_pub_signature_submittion", 0).await;
+}
+
 fn legacy_events() -> Vec<LegacyOrmPEvent> {
     vec![
         LegacyOrmPEvent::HashImported {
@@ -558,6 +712,39 @@ async fn assignment_fields(
 ) -> (Option<String>, Option<bool>, Option<String>) {
     sqlx::query_as::<_, (Option<String>, Option<bool>, Option<String>)>(
         r#"SELECT oracle, oracle_assigned, oracle_assigned_fee::TEXT
+           FROM ormp_message_accepted
+           WHERE id = $1"#,
+    )
+    .bind(msg_hash)
+    .fetch_one(pool)
+    .await
+    .expect("fetch accepted assignment fields")
+}
+
+async fn all_assignment_fields(
+    pool: &PgPool,
+    msg_hash: &str,
+) -> (
+    Option<String>,
+    Option<bool>,
+    Option<String>,
+    Option<String>,
+    Option<bool>,
+    Option<String>,
+) {
+    sqlx::query_as::<
+        _,
+        (
+            Option<String>,
+            Option<bool>,
+            Option<String>,
+            Option<String>,
+            Option<bool>,
+            Option<String>,
+        ),
+    >(
+        r#"SELECT oracle, oracle_assigned, oracle_assigned_fee::TEXT,
+                  relayer, relayer_assigned, relayer_assigned_fee::TEXT
            FROM ormp_message_accepted
            WHERE id = $1"#,
     )

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -1,9 +1,12 @@
 use sqlx::PgPool;
 
-use ormpindexer::schema::{LEGACY_MIXED_CASE_ACCEPTED_ID, LEGACY_MIXED_CASE_ACCEPTED_ORACLE};
 use ormpindexer::{
+    checkpoint::{BlockAnchor, CheckpointStore},
+    config::FinalityMode,
+    database::PostgresCheckpointStore,
     database::{EventWriter, PostgresEventWriter, apply_migrations},
     schema::{ADDRESS_ORACLE, ADDRESS_RELAYER, ChainLogMetadata, EventSource, LegacyOrmPEvent},
+    schema::{LEGACY_MIXED_CASE_ACCEPTED_ID, LEGACY_MIXED_CASE_ACCEPTED_ORACLE},
 };
 
 #[tokio::test]
@@ -160,6 +163,78 @@ async fn test_postgres_writer_inserts_legacy_events_idempotently_and_backfills_a
     assert_eq!(late.3.as_deref(), Some(ADDRESS_RELAYER[0]));
     assert_eq!(late.4, Some(true));
     assert_eq!(late.5.as_deref(), Some("66"));
+}
+
+#[tokio::test]
+async fn test_postgres_rollback_deletes_legacy_rows_anchors_and_resets_checkpoint() {
+    let Some(database_url) = test_database_url() else {
+        eprintln!("skipping Postgres rollback test; ORMPINDEXER_TEST_DATABASE_URL is not set");
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("connect test postgres");
+    apply_migrations(&pool).await.expect("apply migrations");
+    truncate_legacy_tables(&pool).await;
+
+    let checkpoints = PostgresCheckpointStore::new(pool.clone());
+    checkpoints
+        .read_or_create(46, "evm.logs", 10)
+        .await
+        .expect("seed checkpoint");
+    checkpoints
+        .advance(46, "evm.logs", 130)
+        .await
+        .expect("advance checkpoint");
+    checkpoints
+        .upsert_block_anchors(&[
+            BlockAnchor {
+                chain_id: 46,
+                dataset: "evm.logs".to_owned(),
+                block_number: 122,
+                block_hash: "0xold".to_owned(),
+                parent_hash: Some("0xold-parent".to_owned()),
+                finality: FinalityMode::Latest,
+            },
+            BlockAnchor {
+                chain_id: 46,
+                dataset: "evm.logs".to_owned(),
+                block_number: 123,
+                block_hash: "0xremoved".to_owned(),
+                parent_hash: Some("0xremoved-parent".to_owned()),
+                finality: FinalityMode::Latest,
+            },
+        ])
+        .await
+        .expect("seed anchors");
+
+    let writer = PostgresEventWriter::new(pool.clone());
+    writer
+        .write_events(&rollback_legacy_events())
+        .await
+        .expect("write rollback legacy events");
+
+    checkpoints
+        .rollback_legacy_from(46, "evm.logs", 123)
+        .await
+        .expect("rollback legacy rows");
+
+    assert_table_count(&pool, "ormp_hash_imported", 0).await;
+    assert_table_count(&pool, "ormp_message_accepted", 0).await;
+    assert_table_count(&pool, "ormp_message_assigned", 0).await;
+    assert_table_count(&pool, "ormp_message_dispatched", 0).await;
+    assert_table_count(&pool, "msgport_message_recv", 0).await;
+    assert_table_count(&pool, "msgport_message_sent", 0).await;
+    assert_table_count(&pool, "signature_pub_signature_submittion", 0).await;
+    assert_table_count(&pool, "ormp_indexer_block_anchor", 1).await;
+    assert_eq!(
+        checkpoints
+            .read_or_create(46, "evm.logs", 10)
+            .await
+            .expect("read checkpoint")
+            .next_block,
+        123
+    );
 }
 
 fn legacy_events() -> Vec<LegacyOrmPEvent> {
@@ -392,6 +467,71 @@ fn legacy_events() -> Vec<LegacyOrmPEvent> {
     ]
 }
 
+fn rollback_legacy_events() -> Vec<LegacyOrmPEvent> {
+    vec![
+        LegacyOrmPEvent::HashImported {
+            metadata: evm_metadata("rollback-hash-log"),
+            src_chain_id: 1,
+            target_chain_id: 46,
+            oracle: ADDRESS_ORACLE[0].to_owned(),
+            channel: "0xchannel".to_owned(),
+            msg_index: 7,
+            hash: "0xhash".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAccepted {
+            metadata: evm_metadata("rollback-accepted-log"),
+            msg_hash: "0xrollback-accepted".to_owned(),
+            channel: "0xchannel".to_owned(),
+            index: 8,
+            from_chain_id: 1,
+            from: "0xfrom".to_owned(),
+            to_chain_id: 46,
+            to: "0xto".to_owned(),
+            gas_limit: 500_000,
+            encoded: "0xencoded".to_owned(),
+        },
+        LegacyOrmPEvent::MessageAssigned {
+            metadata: evm_metadata("rollback-assigned-log"),
+            msg_hash: "0xrollback-accepted".to_owned(),
+            oracle: ADDRESS_ORACLE[0].to_owned(),
+            relayer: ADDRESS_RELAYER[0].to_owned(),
+            oracle_fee: 11,
+            relayer_fee: 22,
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::MessageDispatched {
+            metadata: evm_metadata("rollback-dispatched-log"),
+            target_chain_id: 46,
+            msg_hash: "0xrollback-accepted".to_owned(),
+            dispatch_result: true,
+        },
+        LegacyOrmPEvent::MsgportMessageRecv {
+            metadata: evm_metadata("rollback-recv-log"),
+            msg_id: "0xmsgid".to_owned(),
+            result: true,
+            return_data: "0xreturn".to_owned(),
+        },
+        LegacyOrmPEvent::MsgportMessageSent {
+            metadata: evm_metadata("rollback-sent-log"),
+            msg_id: "0xmsgid".to_owned(),
+            from_dapp: "0xfromdapp".to_owned(),
+            to_chain_id: 46,
+            to_dapp: "0xtodapp".to_owned(),
+            message: "0xmessage".to_owned(),
+            params: "0xparams".to_owned(),
+        },
+        LegacyOrmPEvent::SignatureSubmittion {
+            metadata: evm_metadata("rollback-signature-log"),
+            chain_id: 46,
+            channel: "0xchannel".to_owned(),
+            signer: "0xsigner".to_owned(),
+            msg_index: 9,
+            signature: "0xsig".to_owned(),
+            data: "0xdata".to_owned(),
+        },
+    ]
+}
+
 fn evm_metadata(id: &str) -> ChainLogMetadata {
     evm_metadata_at(id, 46, 123)
 }
@@ -402,7 +542,7 @@ fn evm_metadata_at(id: &str, chain_id: u128, block_number: u128) -> ChainLogMeta
         source: EventSource::Evm,
         chain_id,
         block_number,
-        block_hash: None,
+        block_hash: Some("0xblock".to_owned()),
         block_timestamp: 456,
         transaction_hash: "0xtx".to_owned(),
         transaction_index: 2,
@@ -439,6 +579,8 @@ async fn assert_table_count(pool: &PgPool, table: &str, expected: i64) {
 async fn truncate_legacy_tables(pool: &PgPool) {
     sqlx::query(
         "TRUNCATE
+            ormp_indexer_block_anchor,
+            ormp_indexer_checkpoint,
             ormp_hash_imported,
             ormp_message_accepted,
             ormp_message_assigned,

--- a/tests/postgres_writer.rs
+++ b/tests/postgres_writer.rs
@@ -5,7 +5,10 @@ use ormpindexer::{
     config::FinalityMode,
     database::PostgresCheckpointStore,
     database::{EventWriter, PostgresEventWriter, apply_migrations},
-    schema::{ADDRESS_ORACLE, ADDRESS_RELAYER, ChainLogMetadata, EventSource, LegacyOrmPEvent},
+    schema::{
+        ADDRESS_ORACLE, ADDRESS_RELAYER, AssignmentConfig, ChainLogMetadata, EventSource,
+        LegacyOrmPEvent,
+    },
     schema::{LEGACY_MIXED_CASE_ACCEPTED_ID, LEGACY_MIXED_CASE_ACCEPTED_ORACLE},
 };
 
@@ -337,6 +340,86 @@ async fn test_postgres_rollback_recomputes_assignment_backfills_for_remaining_ac
     assert_eq!(restored.1, Some(true));
     assert_eq!(restored.2.as_deref(), Some("33"));
     assert_eq!(restored.3.as_deref(), Some(ADDRESS_RELAYER[0]));
+    assert_eq!(restored.4, Some(true));
+    assert_eq!(restored.5.as_deref(), Some("44"));
+}
+
+#[tokio::test]
+async fn test_postgres_rollback_recomputes_assignment_backfills_with_configured_policy() {
+    let Some(database_url) = test_database_url() else {
+        eprintln!(
+            "skipping Postgres configured assignment rollback test; ORMPINDEXER_TEST_DATABASE_URL is not set"
+        );
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("connect test postgres");
+    apply_migrations(&pool).await.expect("apply migrations");
+    truncate_legacy_tables(&pool).await;
+
+    let oracle = "0x00000000000000000000000000000000000000a1";
+    let relayer = "0x00000000000000000000000000000000000000b2";
+    let assignment_config = AssignmentConfig {
+        oracle_addresses: vec![oracle.to_owned()],
+        relayer_addresses: vec![relayer.to_owned()],
+    };
+    let writer =
+        PostgresEventWriter::with_assignment_config(pool.clone(), assignment_config.clone());
+    writer
+        .write_events(&[
+            LegacyOrmPEvent::MessageAccepted {
+                metadata: evm_metadata_at("rollback-configured-accepted-log", 46, 121),
+                msg_hash: "0xrollback-configured".to_owned(),
+                channel: "0xchannel".to_owned(),
+                index: 3,
+                from_chain_id: 1,
+                from: "0xfrom".to_owned(),
+                to_chain_id: 46,
+                to: "0xto".to_owned(),
+                gas_limit: 500_000,
+                encoded: "0xencoded".to_owned(),
+            },
+            LegacyOrmPEvent::MessageAssigned {
+                metadata: evm_metadata_at("rollback-configured-old-assigned-log", 46, 122),
+                msg_hash: "0xrollback-configured".to_owned(),
+                oracle: oracle.to_owned(),
+                relayer: relayer.to_owned(),
+                oracle_fee: 33,
+                relayer_fee: 44,
+                params: "0xparams".to_owned(),
+            },
+            LegacyOrmPEvent::MessageAssigned {
+                metadata: evm_metadata_at("rollback-configured-new-assigned-log", 46, 123),
+                msg_hash: "0xrollback-configured".to_owned(),
+                oracle: oracle.to_owned(),
+                relayer: relayer.to_owned(),
+                oracle_fee: 55,
+                relayer_fee: 66,
+                params: "0xparams".to_owned(),
+            },
+        ])
+        .await
+        .expect("write configured assignment events");
+
+    let before = all_assignment_fields(&pool, "0xrollback-configured").await;
+    assert_eq!(before.0.as_deref(), Some(oracle));
+    assert_eq!(before.2.as_deref(), Some("55"));
+    assert_eq!(before.3.as_deref(), Some(relayer));
+    assert_eq!(before.5.as_deref(), Some("66"));
+
+    let checkpoints =
+        PostgresCheckpointStore::with_assignment_config(pool.clone(), assignment_config);
+    checkpoints
+        .rollback_legacy_from(46, "evm.logs", 123)
+        .await
+        .expect("rollback legacy rows");
+
+    let restored = all_assignment_fields(&pool, "0xrollback-configured").await;
+    assert_eq!(restored.0.as_deref(), Some(oracle));
+    assert_eq!(restored.1, Some(true));
+    assert_eq!(restored.2.as_deref(), Some("33"));
+    assert_eq!(restored.3.as_deref(), Some(relayer));
     assert_eq!(restored.4, Some(true));
     assert_eq!(restored.5.as_deref(), Some("44"));
 }

--- a/tests/runtime_config.rs
+++ b/tests/runtime_config.rs
@@ -103,6 +103,7 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
     assert_eq!(config.batch_size, 250);
     assert_eq!(config.start_block, 1000);
     assert_eq!(config.finality_mode, FinalityMode::Durable);
+    assert_eq!(config.reorg_window_blocks, 128);
     assert!(config.warmup.enabled);
     assert!(!config.warmup.ensure_on_startup);
     assert!(config.warmup.required);
@@ -119,6 +120,105 @@ fn test_runtime_config_from_env_map_reads_datalens_database_and_chain_settings()
     assert_eq!(config.chain(46).expect("chain 46").start_block, 2000);
     assert_eq!(config.chain(1).expect("chain 1").batch_size, 250);
     assert_eq!(config.chain(46).expect("chain 46").batch_size, 50);
+    assert_eq!(
+        config.chain(1).expect("chain 1").finality_mode,
+        FinalityMode::Durable
+    );
+    assert_eq!(
+        config.chain(46).expect("chain 46").finality_mode,
+        FinalityMode::Durable
+    );
+}
+
+#[test]
+fn test_runtime_config_accepts_safe_and_latest_finality_modes() {
+    for (value, expected) in [
+        ("safe", FinalityMode::Safe),
+        ("latest", FinalityMode::Latest),
+    ] {
+        let env = BTreeMap::from([
+            (
+                "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+                "https://datalens.example".to_owned(),
+            ),
+            (
+                "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+                "ormp-production".to_owned(),
+            ),
+            ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+            ("ORMPINDEXER_FINALITY_MODE".to_owned(), value.to_owned()),
+        ]);
+
+        let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+
+        assert_eq!(config.finality_mode, expected);
+        assert_eq!(config.chain(46).expect("chain 46").finality_mode, expected);
+    }
+}
+
+#[test]
+fn test_runtime_config_chain_finality_override_takes_precedence() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "1,46".to_owned()),
+        (
+            "ORMPINDEXER_FINALITY_MODE".to_owned(),
+            "finalized".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_CHAIN_46_FINALITY_MODE".to_owned(),
+            "latest".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_REORG_WINDOW_BLOCKS".to_owned(),
+            "256".to_owned(),
+        ),
+    ]);
+
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+
+    assert_eq!(config.finality_mode, FinalityMode::Finalized);
+    assert_eq!(
+        config.chain(1).expect("chain 1").finality_mode,
+        FinalityMode::Finalized
+    );
+    assert_eq!(
+        config.chain(46).expect("chain 46").finality_mode,
+        FinalityMode::Latest
+    );
+    assert_eq!(config.reorg_window_blocks, 256);
+}
+
+#[test]
+fn test_runtime_config_rejects_zero_reorg_window_for_reorg_finality() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_FINALITY_MODE".to_owned(), "safe".to_owned()),
+        ("ORMPINDEXER_REORG_WINDOW_BLOCKS".to_owned(), "0".to_owned()),
+    ]);
+
+    let error = RuntimeConfig::from_env_map(&env).expect_err("zero reorg window is invalid");
+
+    assert!(
+        error
+            .to_string()
+            .contains("ORMPINDEXER_REORG_WINDOW_BLOCKS must be greater than zero")
+    );
 }
 
 #[test]

--- a/tests/runtime_runner.rs
+++ b/tests/runtime_runner.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use ormpindexer::{
-    checkpoint::{CheckpointStore, InMemoryCheckpointStore},
+    checkpoint::{BlockAnchor, CheckpointStore, InMemoryCheckpointStore},
     config::{FinalityMode, RuntimeConfig},
     database::DryRunEventWriter,
     datalens::{DatalensLog, DatalensTransaction, DatalensTransactionQuery},
@@ -48,6 +48,7 @@ async fn test_runner_successful_batch_advances_checkpoint_to_next_range() {
         chain_id: 46,
         block_number: 12,
         block_hash: None,
+        parent_hash: None,
         block_timestamp: Some(1_700_000_000_000),
         transaction_hash: "0xtx".to_owned(),
         transaction_index: Some(0),
@@ -108,6 +109,7 @@ async fn test_runner_enriches_evm_logs_with_transaction_senders() {
         chain_id: 46,
         block_number: 12,
         block_hash: None,
+        parent_hash: None,
         block_timestamp: Some(1_700_000_000_000),
         transaction_hash: tx_hash.trim_start_matches("0x").to_ascii_uppercase(),
         transaction_index: Some(0),
@@ -159,6 +161,125 @@ async fn test_runner_enriches_evm_logs_with_transaction_senders() {
             finality_mode: FinalityMode::Finalized,
         }]
     );
+}
+
+#[tokio::test]
+async fn test_runner_rolls_back_first_mismatched_anchor_before_processing_safe_range() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "20".to_owned()),
+        ("ORMPINDEXER_FINALITY_MODE".to_owned(), "safe".to_owned()),
+        (
+            "ORMPINDEXER_REORG_WINDOW_BLOCKS".to_owned(),
+            "10".to_owned(),
+        ),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    checkpoints
+        .read_or_create(46, "evm.logs", 20)
+        .await
+        .expect("seed checkpoint");
+    checkpoints
+        .advance(46, "evm.logs", 24)
+        .await
+        .expect("advance checkpoint");
+    checkpoints
+        .upsert_block_anchors(&[
+            BlockAnchor {
+                chain_id: 46,
+                dataset: "evm.logs".to_owned(),
+                block_number: 20,
+                block_hash: "0xold-20".to_owned(),
+                parent_hash: Some("0xparent-19".to_owned()),
+                finality: FinalityMode::Safe,
+            },
+            BlockAnchor {
+                chain_id: 46,
+                dataset: "evm.logs".to_owned(),
+                block_number: 21,
+                block_hash: "0xhash-21".to_owned(),
+                parent_hash: Some("0xnew-20".to_owned()),
+                finality: FinalityMode::Safe,
+            },
+        ])
+        .await
+        .expect("seed anchors");
+    let reader = RecordingDatalensReader::new(vec![
+        DatalensLog {
+            id: Some("46-20-0".to_owned()),
+            chain_id: 46,
+            block_number: 20,
+            block_hash: Some("0xnew-20".to_owned()),
+            parent_hash: Some("0xparent-19".to_owned()),
+            block_timestamp: Some(1_700_000_000_000),
+            transaction_hash: "0xtx20".to_owned(),
+            transaction_index: Some(0),
+            log_index: 1,
+            address: "0x333".to_owned(),
+            transaction_from: None,
+            topics: vec!["0xaaa".to_owned()],
+            data: "0x".to_owned(),
+            event_name: None,
+            event_signature: None,
+            indexed_fields: Vec::new(),
+            non_indexed_fields: None,
+        },
+        DatalensLog {
+            id: Some("46-21-0".to_owned()),
+            chain_id: 46,
+            block_number: 21,
+            block_hash: Some("0xhash-21".to_owned()),
+            parent_hash: Some("0xnew-20".to_owned()),
+            block_timestamp: Some(1_700_000_000_000),
+            transaction_hash: "0xtx21".to_owned(),
+            transaction_index: Some(0),
+            log_index: 1,
+            address: "0x333".to_owned(),
+            transaction_from: None,
+            topics: vec!["0xaaa".to_owned()],
+            data: "0x".to_owned(),
+            event_name: None,
+            event_signature: None,
+            indexed_fields: Vec::new(),
+            non_indexed_fields: None,
+        },
+    ])
+    .with_head(46, 24);
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let report = runner.run_once().await.expect("safe pass succeeds");
+
+    assert_eq!(report.ranges_queried, 1);
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 24);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries
+            .iter()
+            .map(|query| (query.from_block, query.to_block, query.finality_mode))
+            .collect::<Vec<_>>(),
+        vec![(20, 21, FinalityMode::Safe), (20, 23, FinalityMode::Safe)]
+    );
+    let anchors = checkpoints
+        .read_block_anchors(46, "evm.logs", 20, 21)
+        .await
+        .expect("read anchors");
+    assert_eq!(anchors[0].block_hash, "0xnew-20");
 }
 
 #[tokio::test]

--- a/tests/runtime_runner.rs
+++ b/tests/runtime_runner.rs
@@ -7,7 +7,7 @@ use ormpindexer::{
     checkpoint::{BlockAnchor, CheckpointStore, InMemoryCheckpointStore},
     config::{FinalityMode, RuntimeConfig},
     database::DryRunEventWriter,
-    datalens::{DatalensLog, DatalensTransaction, DatalensTransactionQuery},
+    datalens::{DatalensBlock, DatalensLog, DatalensTransaction, DatalensTransactionQuery},
     decoder::NoopDecoder,
     planner::MSGPORT_MESSAGE_SENT_TOPIC,
     runner::{IndexerRunner, RunnerReport},
@@ -254,7 +254,14 @@ async fn test_runner_rolls_back_first_mismatched_anchor_before_processing_safe_r
             non_indexed_fields: None,
         },
     ])
+    .with_blocks(vec![
+        datalens_block(20, "0xnew-20", "0xparent-19"),
+        datalens_block(21, "0xhash-21", "0xnew-20"),
+        datalens_block(22, "0xhash-22", "0xhash-21"),
+        datalens_block(23, "0xhash-23", "0xhash-22"),
+    ])
     .with_head(46, 24);
+    let block_queries = reader.block_queries();
     let runner = IndexerRunner::new(
         config,
         reader.clone(),
@@ -273,13 +280,184 @@ async fn test_runner_rolls_back_first_mismatched_anchor_before_processing_safe_r
             .iter()
             .map(|query| (query.from_block, query.to_block, query.finality_mode))
             .collect::<Vec<_>>(),
-        vec![(20, 21, FinalityMode::Safe), (20, 23, FinalityMode::Safe)]
+        vec![(20, 23, FinalityMode::Safe)]
+    );
+    assert_eq!(
+        block_queries
+            .lock()
+            .expect("block queries lock")
+            .iter()
+            .map(|query| (query.from_block, query.to_block, query.finality_mode))
+            .collect::<Vec<_>>(),
+        vec![(20, 23, FinalityMode::Safe), (20, 23, FinalityMode::Safe)]
     );
     let anchors = checkpoints
         .read_block_anchors(46, "evm.logs", 20, 21)
         .await
         .expect("read anchors");
     assert_eq!(anchors[0].block_hash, "0xnew-20");
+}
+
+#[tokio::test]
+async fn test_runner_rolls_back_empty_block_that_later_gains_event_after_reorg() {
+    let env = BTreeMap::from([
+        (
+            "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+            "https://datalens.example".to_owned(),
+        ),
+        (
+            "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+            "ormp-production".to_owned(),
+        ),
+        ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+        ("ORMPINDEXER_BATCH_SIZE".to_owned(), "10".to_owned()),
+        ("ORMPINDEXER_START_BLOCK".to_owned(), "20".to_owned()),
+        ("ORMPINDEXER_FINALITY_MODE".to_owned(), "safe".to_owned()),
+        ("ORMPINDEXER_REORG_WINDOW_BLOCKS".to_owned(), "5".to_owned()),
+    ]);
+    let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+    let checkpoints = InMemoryCheckpointStore::default();
+    checkpoints
+        .read_or_create(46, "evm.logs", 20)
+        .await
+        .expect("seed checkpoint");
+    checkpoints
+        .advance(46, "evm.logs", 25)
+        .await
+        .expect("advance checkpoint");
+    checkpoints
+        .upsert_block_anchors(&[
+            block_anchor(20, "0xhash-20", "0xparent-19", FinalityMode::Safe),
+            block_anchor(21, "0xhash-21", "0xhash-20", FinalityMode::Safe),
+            block_anchor(23, "0xold-23", "0xold-22", FinalityMode::Safe),
+            block_anchor(24, "0xold-24", "0xold-23", FinalityMode::Safe),
+        ])
+        .await
+        .expect("seed anchors");
+    let reader = RecordingDatalensReader::new(vec![
+        datalens_log(20, "0xhash-20", "0xparent-19"),
+        datalens_log(21, "0xhash-21", "0xhash-20"),
+        datalens_log(22, "0xnew-22", "0xhash-21"),
+        datalens_log(23, "0xnew-23", "0xnew-22"),
+        datalens_log(24, "0xnew-24", "0xnew-23"),
+    ])
+    .with_blocks(vec![
+        datalens_block(20, "0xhash-20", "0xparent-19"),
+        datalens_block(21, "0xhash-21", "0xhash-20"),
+        datalens_block(22, "0xnew-22", "0xhash-21"),
+        datalens_block(23, "0xnew-23", "0xnew-22"),
+        datalens_block(24, "0xnew-24", "0xnew-23"),
+    ])
+    .with_head(46, 25);
+    let block_queries = reader.block_queries();
+    let runner = IndexerRunner::new(
+        config,
+        reader.clone(),
+        checkpoints.clone(),
+        NoopDecoder,
+        DryRunEventWriter,
+    );
+
+    let report = runner.run_once().await.expect("safe pass succeeds");
+
+    assert_eq!(report.ranges_queried, 1);
+    assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 25);
+    let queries = reader.queries.lock().expect("queries lock");
+    assert_eq!(
+        queries
+            .iter()
+            .map(|query| (query.from_block, query.to_block, query.finality_mode))
+            .collect::<Vec<_>>(),
+        vec![(22, 24, FinalityMode::Safe)]
+    );
+    assert_eq!(
+        block_queries
+            .lock()
+            .expect("block queries lock")
+            .iter()
+            .map(|query| (query.from_block, query.to_block, query.finality_mode))
+            .collect::<Vec<_>>(),
+        vec![(20, 24, FinalityMode::Safe), (22, 24, FinalityMode::Safe)]
+    );
+    let anchors = checkpoints
+        .read_block_anchors(46, "evm.logs", 20, 24)
+        .await
+        .expect("read anchors");
+    assert_eq!(
+        anchors
+            .iter()
+            .map(|anchor| (anchor.block_number, anchor.block_hash.as_str()))
+            .collect::<Vec<_>>(),
+        vec![
+            (20, "0xhash-20"),
+            (21, "0xhash-21"),
+            (22, "0xnew-22"),
+            (23, "0xnew-23"),
+            (24, "0xnew-24"),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_runner_writes_anchors_for_empty_blocks_in_reorg_finality_modes() {
+    for finality_mode in [FinalityMode::Safe, FinalityMode::Latest] {
+        let finality = finality_mode.as_str().to_owned();
+        let env = BTreeMap::from([
+            (
+                "ORMPINDEXER_DATALENS_ENDPOINT".to_owned(),
+                "https://datalens.example".to_owned(),
+            ),
+            (
+                "ORMPINDEXER_DATALENS_APPLICATION".to_owned(),
+                "ormp-production".to_owned(),
+            ),
+            ("ORMPINDEXER_ENABLED_CHAINS".to_owned(), "46".to_owned()),
+            ("ORMPINDEXER_BATCH_SIZE".to_owned(), "5".to_owned()),
+            ("ORMPINDEXER_START_BLOCK".to_owned(), "20".to_owned()),
+            ("ORMPINDEXER_FINALITY_MODE".to_owned(), finality),
+            ("ORMPINDEXER_REORG_WINDOW_BLOCKS".to_owned(), "5".to_owned()),
+        ]);
+        let config = RuntimeConfig::from_env_map(&env).expect("config parses");
+        let checkpoints = InMemoryCheckpointStore::default();
+        let reader = RecordingDatalensReader::new(vec![datalens_log(22, "0xhash-22", "0xhash-21")])
+            .with_blocks(vec![
+                datalens_block(20, "0xhash-20", "0xparent-19"),
+                datalens_block(21, "0xhash-21", "0xhash-20"),
+                datalens_block(22, "0xhash-22", "0xhash-21"),
+                datalens_block(23, "0xhash-23", "0xhash-22"),
+                datalens_block(24, "0xhash-24", "0xhash-23"),
+            ])
+            .with_head(46, 25);
+        let runner = IndexerRunner::new(
+            config,
+            reader,
+            checkpoints.clone(),
+            NoopDecoder,
+            DryRunEventWriter,
+        );
+
+        let report = runner.run_once().await.expect("batch pass succeeds");
+
+        assert_eq!(report.checkpoints_advanced, 1);
+        assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 25);
+        let anchors = checkpoints
+            .read_block_anchors(46, "evm.logs", 20, 24)
+            .await
+            .expect("read anchors");
+        assert_eq!(
+            anchors
+                .iter()
+                .map(|anchor| (anchor.block_number, anchor.finality))
+                .collect::<Vec<_>>(),
+            vec![
+                (20, finality_mode),
+                (21, finality_mode),
+                (22, finality_mode),
+                (23, finality_mode),
+                (24, finality_mode),
+            ]
+        );
+    }
 }
 
 #[tokio::test]
@@ -887,4 +1065,51 @@ async fn test_runner_loop_recovers_chain_errors_without_blocking_other_chains() 
 
     assert_eq!(checkpoints.next_block(1, "evm.logs").await.unwrap(), 10);
     run.abort();
+}
+
+fn block_anchor(
+    block_number: u64,
+    block_hash: &str,
+    parent_hash: &str,
+    finality: FinalityMode,
+) -> BlockAnchor {
+    BlockAnchor {
+        chain_id: 46,
+        dataset: "evm.logs".to_owned(),
+        block_number,
+        block_hash: block_hash.to_owned(),
+        parent_hash: Some(parent_hash.to_owned()),
+        finality,
+    }
+}
+
+fn datalens_log(block_number: u64, block_hash: &str, parent_hash: &str) -> DatalensLog {
+    DatalensLog {
+        id: Some(format!("46-{block_number}-0")),
+        chain_id: 46,
+        block_number,
+        block_hash: Some(block_hash.to_owned()),
+        parent_hash: Some(parent_hash.to_owned()),
+        block_timestamp: Some(1_700_000_000_000),
+        transaction_hash: format!("0xtx{block_number}"),
+        transaction_index: Some(0),
+        log_index: 1,
+        address: "0x333".to_owned(),
+        transaction_from: None,
+        topics: vec!["0xaaa".to_owned()],
+        data: "0x".to_owned(),
+        event_name: None,
+        event_signature: None,
+        indexed_fields: Vec::new(),
+        non_indexed_fields: None,
+    }
+}
+
+fn datalens_block(block_number: u64, block_hash: &str, parent_hash: &str) -> DatalensBlock {
+    DatalensBlock {
+        chain_id: 46,
+        block_number,
+        block_hash: block_hash.to_owned(),
+        parent_hash: Some(parent_hash.to_owned()),
+    }
 }

--- a/tests/runtime_runner.rs
+++ b/tests/runtime_runner.rs
@@ -274,14 +274,16 @@ async fn test_runner_rolls_back_first_mismatched_anchor_before_processing_safe_r
 
     assert_eq!(report.ranges_queried, 1);
     assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 24);
-    let queries = reader.queries.lock().expect("queries lock");
-    assert_eq!(
-        queries
-            .iter()
-            .map(|query| (query.from_block, query.to_block, query.finality_mode))
-            .collect::<Vec<_>>(),
-        vec![(20, 23, FinalityMode::Safe)]
-    );
+    {
+        let queries = reader.queries.lock().expect("queries lock");
+        assert_eq!(
+            queries
+                .iter()
+                .map(|query| (query.from_block, query.to_block, query.finality_mode))
+                .collect::<Vec<_>>(),
+            vec![(20, 23, FinalityMode::Safe)]
+        );
+    }
     assert_eq!(
         block_queries
             .lock()
@@ -362,14 +364,16 @@ async fn test_runner_rolls_back_empty_block_that_later_gains_event_after_reorg()
 
     assert_eq!(report.ranges_queried, 1);
     assert_eq!(checkpoints.next_block(46, "evm.logs").await.unwrap(), 25);
-    let queries = reader.queries.lock().expect("queries lock");
-    assert_eq!(
-        queries
-            .iter()
-            .map(|query| (query.from_block, query.to_block, query.finality_mode))
-            .collect::<Vec<_>>(),
-        vec![(22, 24, FinalityMode::Safe)]
-    );
+    {
+        let queries = reader.queries.lock().expect("queries lock");
+        assert_eq!(
+            queries
+                .iter()
+                .map(|query| (query.from_block, query.to_block, query.finality_mode))
+                .collect::<Vec<_>>(),
+            vec![(22, 24, FinalityMode::Safe)]
+        );
+    }
     assert_eq!(
         block_queries
             .lock()

--- a/tests/runtime_support/mod.rs
+++ b/tests/runtime_support/mod.rs
@@ -8,8 +8,9 @@ use ormpindexer::{
     config::FinalityMode,
     database::EventWriter,
     datalens::{
-        DatalensLog, DatalensLogQuery, DatalensLogQueryResult, DatalensLogReader,
-        DatalensTransaction, DatalensTransactionQuery, DatalensTransactionQueryResult,
+        DatalensBlock, DatalensBlockQuery, DatalensBlockQueryResult, DatalensLog, DatalensLogQuery,
+        DatalensLogQueryResult, DatalensLogReader, DatalensTransaction, DatalensTransactionQuery,
+        DatalensTransactionQueryResult,
     },
     decoder::EventDecoder,
     schema::{ChainLogMetadata, EventSource, LegacyOrmPEvent},
@@ -17,6 +18,7 @@ use ormpindexer::{
 
 #[derive(Clone)]
 pub struct RecordingDatalensReader {
+    blocks: Vec<DatalensBlock>,
     logs: Vec<DatalensLog>,
     transactions: Vec<DatalensTransaction>,
     heads: BTreeMap<u64, u64>,
@@ -24,12 +26,14 @@ pub struct RecordingDatalensReader {
     query_failures: BTreeMap<u64, String>,
     range_query_failures: BTreeMap<(u64, u64, u64), String>,
     pub queries: Arc<Mutex<Vec<DatalensLogQuery>>>,
+    block_queries: Arc<Mutex<Vec<DatalensBlockQuery>>>,
     transaction_queries: Arc<Mutex<Vec<DatalensTransactionQuery>>>,
 }
 
 impl RecordingDatalensReader {
     pub fn new(logs: Vec<DatalensLog>) -> Self {
         Self {
+            blocks: Vec::new(),
             logs,
             transactions: Vec::new(),
             heads: BTreeMap::new(),
@@ -37,6 +41,7 @@ impl RecordingDatalensReader {
             query_failures: BTreeMap::new(),
             range_query_failures: BTreeMap::new(),
             queries: Arc::new(Mutex::new(Vec::new())),
+            block_queries: Arc::new(Mutex::new(Vec::new())),
             transaction_queries: Arc::new(Mutex::new(Vec::new())),
         }
     }
@@ -49,6 +54,15 @@ impl RecordingDatalensReader {
     pub fn with_transactions(mut self, transactions: Vec<DatalensTransaction>) -> Self {
         self.transactions = transactions;
         self
+    }
+
+    pub fn with_blocks(mut self, blocks: Vec<DatalensBlock>) -> Self {
+        self.blocks = blocks;
+        self
+    }
+
+    pub fn block_queries(&self) -> Arc<Mutex<Vec<DatalensBlockQuery>>> {
+        self.block_queries.clone()
     }
 
     pub fn transaction_queries(&self) -> Arc<Mutex<Vec<DatalensTransactionQuery>>> {
@@ -112,6 +126,28 @@ impl DatalensLogReader for RecordingDatalensReader {
                     log.chain_id == query.chain_id
                         && log.block_number >= query.from_block
                         && log.block_number <= query.to_block
+                })
+                .cloned()
+                .collect(),
+        })
+    }
+
+    async fn query_blocks(
+        &self,
+        query: DatalensBlockQuery,
+    ) -> anyhow::Result<DatalensBlockQueryResult> {
+        self.block_queries
+            .lock()
+            .expect("block queries lock")
+            .push(query.clone());
+        Ok(DatalensBlockQueryResult {
+            blocks: self
+                .blocks
+                .iter()
+                .filter(|block| {
+                    block.chain_id == query.chain_id
+                        && block.block_number >= query.from_block
+                        && block.block_number <= query.to_block
                 })
                 .cloned()
                 .collect(),

--- a/tests/runtime_support/mod.rs
+++ b/tests/runtime_support/mod.rs
@@ -105,7 +105,16 @@ impl DatalensLogReader for RecordingDatalensReader {
             anyhow::bail!("{error}");
         }
         Ok(DatalensLogQueryResult {
-            logs: self.logs.clone(),
+            logs: self
+                .logs
+                .iter()
+                .filter(|log| {
+                    log.chain_id == query.chain_id
+                        && log.block_number >= query.from_block
+                        && log.block_number <= query.to_block
+                })
+                .cloned()
+                .collect(),
         })
     }
 

--- a/tests/tron_decoder.rs
+++ b/tests/tron_decoder.rs
@@ -86,6 +86,7 @@ fn test_decode_tron_raw_message_accepted_from_block_scan_fields() {
         block_hash: Some(
             "0x9c64f37100000000000000000000000000000000000000000000000000000000".to_owned(),
         ),
+        parent_hash: None,
         block_timestamp: Some(1_800_000_000_000),
         transaction_hash: "trontx".to_owned(),
         transaction_index: Some(4),
@@ -246,6 +247,7 @@ fn tron_log() -> DatalensLog {
         chain_id: TRON_CHAIN_ID,
         block_number: 123,
         block_hash: None,
+        parent_hash: None,
         block_timestamp: Some(456),
         transaction_hash: "trontx".to_owned(),
         transaction_index: Some(2),


### PR DESCRIPTION
## Summary

- add safe/latest finality modes with per-chain overrides
- add block header anchors and recent-window rollback for reorg protection
- keep event writes, anchors, and checkpoints transactional, including rollback cleanup for legacy tables

## Validation

- `cargo test --locked`
- code review completed locally with no remaining findings
