### PR TITLE
fix(database): add block anchor as separate migration

### DIFF
--- a/migrations/0001_schema_compat.sql
+++ b/migrations/0001_schema_compat.sql
@@ -129,14 +129,3 @@ CREATE TABLE IF NOT EXISTS ormp_indexer_checkpoint (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (chain_id, dataset)
 );
-
-CREATE TABLE IF NOT EXISTS ormp_indexer_block_anchor (
-  chain_id NUMERIC NOT NULL,
-  dataset TEXT NOT NULL,
-  block_number NUMERIC NOT NULL,
-  block_hash TEXT NOT NULL,
-  parent_hash TEXT,
-  finality TEXT NOT NULL,
-  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-  PRIMARY KEY (chain_id, dataset, block_number)
-);

--- a/migrations/0002_block_anchor.sql
+++ b/migrations/0002_block_anchor.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS ormp_indexer_block_anchor (
+  chain_id NUMERIC NOT NULL,
+  dataset TEXT NOT NULL,
+  block_number NUMERIC NOT NULL,
+  block_hash TEXT NOT NULL,
+  parent_hash TEXT,
+  finality TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (chain_id, dataset, block_number)
+);


### PR DESCRIPTION
## Summary

- restore `0001_schema_compat.sql` to its previously applied contents
- add `0002_block_anchor.sql` for the new reorg anchor table

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked`

## Runtime issue

The deployed pod failed because sqlx detected that migration 1 had already been applied with a different checksum. Existing databases should receive the anchor table through migration 2 instead.
