### PR TITLE
fix(graphql): enable cors for public api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1619,6 +1619,7 @@ dependencies = [
  "sqlx",
  "tokio",
  "tower",
+ "tower-http",
  "tracing-log",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0.145"
 sha2 = "0.10.9"
 sqlx = { version = "0.8.6", default-features = false, features = ["macros", "migrate", "postgres", "runtime-tokio-rustls"] }
 tokio = { version = "1.52.3", features = ["macros", "net", "rt-multi-thread"] }
+tower-http = { version = "0.6.11", features = ["cors"] }
 tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["ansi", "env-filter", "fmt"] }
 

--- a/src/graphql/router.rs
+++ b/src/graphql/router.rs
@@ -4,11 +4,12 @@ use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{
     Json, Router,
     extract::State,
-    http::{HeaderValue, StatusCode, header::CONTENT_TYPE},
+    http::{HeaderValue, Method, StatusCode, header::CONTENT_TYPE},
     response::{Html, IntoResponse},
     routing::{get, post},
 };
 use sqlx::PgPool;
+use tower_http::cors::{Any, CorsLayer};
 
 use super::QueryRoot;
 use crate::ops;
@@ -30,6 +31,14 @@ pub fn build_router(schema: IndexerGraphqlSchema, pool: PgPool) -> Router {
         .route("/graphql", post(graphql_handler))
         .route("/graphiql", get(graphql_graphiql))
         .with_state(HttpState { schema, pool })
+        .layer(cors_layer())
+}
+
+fn cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods([Method::GET, Method::POST, Method::OPTIONS])
+        .allow_headers(Any)
 }
 
 async fn graphql_handler(

--- a/tests/ops_endpoints.rs
+++ b/tests/ops_endpoints.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::{Body, to_bytes},
-    http::{HeaderMap, Request, StatusCode},
+    http::{HeaderMap, Method, Request, StatusCode, header},
 };
 use serde_json::Value;
 use sqlx::{PgPool, postgres::PgPoolOptions};
@@ -53,6 +53,64 @@ async fn test_readyz_reports_service_unavailable_when_database_is_unreachable() 
         .expect("readyz response");
 
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn test_graphql_preflight_allows_msgscan_origin() {
+    let pool = unreachable_pool();
+    let app = build_router(build_schema(pool.clone()), pool);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::OPTIONS)
+                .uri("/graphql")
+                .header(header::ORIGIN, "https://msgport-scan.ringdao.com")
+                .header(header::ACCESS_CONTROL_REQUEST_METHOD, "POST")
+                .header(header::ACCESS_CONTROL_REQUEST_HEADERS, "content-type")
+                .body(Body::empty())
+                .expect("cors preflight request"),
+        )
+        .await
+        .expect("cors preflight response");
+
+    assert!(response.status().is_success());
+    assert_eq!(
+        response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&"*".parse().expect("wildcard header"))
+    );
+    assert!(
+        response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_METHODS)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.contains("POST"))
+    );
+}
+
+#[tokio::test]
+async fn test_graphql_response_allows_msgscan_origin() {
+    let pool = unreachable_pool();
+    let app = build_router(build_schema(pool.clone()), pool);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/graphql")
+                .header(header::ORIGIN, "https://msgport-scan.ringdao.com")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"query":"{ __typename }"}"#))
+                .expect("graphql cors request"),
+        )
+        .await
+        .expect("graphql cors response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&"*".parse().expect("wildcard header"))
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add CORS middleware to ORMPIndexer HTTP router
- allow browser preflight and GraphQL responses for msgscan/public origins
- add regression tests for `OPTIONS /graphql` and `POST /graphql` with `Origin: https://msgport-scan.ringdao.com`

## Validation

- `cargo fmt`
- `cargo test --test ops_endpoints`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --locked`

## Msgscan investigation

`packages/web` directly uses `https://ormpindexer.ringdao.com/graphql` through `graphql-request`. `packages/gripper` is a separate package referenced by its own scripts/Dockerfile and is not imported by `packages/web`.
