### PR TITLE
fix(graphql): support msgscan legacy filters

### DIFF
--- a/src/graphql/query.rs
+++ b/src/graphql/query.rs
@@ -327,11 +327,23 @@ fn push_where_group<'a>(
     text_cmp!(where_.from_eq, r#""from""#, " = ");
     text_cmp!(where_.to_eq, r#""to""#, " = ");
     text_cmp!(where_.from_dapp_eq, "from_dapp", " = ");
+    #[cfg(feature = "legacy-query-compat")]
+    text_in!(where_.from_dapp_in, "from_dapp", false);
     text_cmp!(where_.to_dapp_eq, "to_dapp", " = ");
+    #[cfg(feature = "legacy-query-compat")]
+    text_in!(where_.to_dapp_in, "to_dapp", false);
+    #[cfg(feature = "legacy-query-compat")]
+    text_cmp!(where_.transaction_from_eq, "transaction_from", " = ");
     bigint_cmp!(where_.from_chain_id_eq, "from_chain_id", " = ");
+    #[cfg(feature = "legacy-query-compat")]
+    bigint_in!(where_.from_chain_id_in, "from_chain_id");
     bigint_cmp!(where_.to_chain_id_eq, "to_chain_id", " = ");
+    #[cfg(feature = "legacy-query-compat")]
+    bigint_in!(where_.to_chain_id_in, "to_chain_id");
     bigint_cmp!(where_.src_chain_id_eq, "src_chain_id", " = ");
     bigint_cmp!(where_.target_chain_id_eq, "target_chain_id", " = ");
+    #[cfg(feature = "legacy-query-compat")]
+    bigint_in!(where_.target_chain_id_in, "target_chain_id");
     bigint_cmp!(where_.msg_index_eq, "msg_index", " = ");
     #[cfg(feature = "legacy-query-compat")]
     {
@@ -346,6 +358,7 @@ fn push_where_group<'a>(
         bigint_cmp!(where_.index_lte, r#""index""#, " <= ");
         bool_cmp!(where_.oracle_assigned_eq, "oracle_assigned", " = ");
         bool_cmp!(where_.relayer_assigned_eq, "relayer_assigned", " = ");
+        bool_cmp!(where_.dispatch_result_eq, "dispatch_result", " = ");
     }
 
     if let Some(groups) = where_.and.as_ref() {

--- a/src/graphql/root.rs
+++ b/src/graphql/root.rs
@@ -64,11 +64,13 @@ impl QueryRoot {
     async fn ormp_message_accepteds(
         &self,
         ctx: &Context<'_>,
-        where_: Option<LegacyWhereInput>,
-        order_by: Option<Vec<LegacyOrderByInput>>,
+        where_: Option<ORMPMessageAcceptedWhereInput>,
+        order_by: Option<Vec<ORMPMessageAcceptedOrderByInput>>,
         offset: Option<i32>,
         limit: Option<i32>,
     ) -> GraphqlResult<Vec<ORMPMessageAccepted>> {
+        let where_ = where_.map(LegacyWhereInput::from);
+        let order_by = order_by.map(legacy_order_by_vec);
         query_ormp_message_accepteds(
             pool(ctx)?,
             where_.as_ref(),
@@ -82,11 +84,13 @@ impl QueryRoot {
     async fn ormp_message_accepteds_page(
         &self,
         ctx: &Context<'_>,
-        where_: Option<LegacyWhereInput>,
-        order_by: Option<Vec<LegacyOrderByInput>>,
+        where_: Option<ORMPMessageAcceptedWhereInput>,
+        order_by: Option<Vec<ORMPMessageAcceptedOrderByInput>>,
         offset: Option<i32>,
         limit: Option<i32>,
     ) -> GraphqlResult<ORMPMessageAcceptedPage> {
+        let where_ = where_.map(LegacyWhereInput::from);
+        let order_by = order_by.map(legacy_order_by_vec);
         query_ormp_message_accepteds_page(
             pool(ctx)?,
             where_.as_ref(),
@@ -152,11 +156,13 @@ impl QueryRoot {
     async fn ormp_message_dispatcheds(
         &self,
         ctx: &Context<'_>,
-        where_: Option<LegacyWhereInput>,
-        order_by: Option<Vec<LegacyOrderByInput>>,
+        where_: Option<ORMPMessageDispatchedWhereInput>,
+        order_by: Option<Vec<ORMPMessageDispatchedOrderByInput>>,
         offset: Option<i32>,
         limit: Option<i32>,
     ) -> GraphqlResult<Vec<ORMPMessageDispatched>> {
+        let where_ = where_.map(LegacyWhereInput::from);
+        let order_by = order_by.map(legacy_order_by_vec);
         query_ormp_message_dispatcheds(
             pool(ctx)?,
             where_.as_ref(),
@@ -170,11 +176,13 @@ impl QueryRoot {
     async fn ormp_message_dispatcheds_page(
         &self,
         ctx: &Context<'_>,
-        where_: Option<LegacyWhereInput>,
-        order_by: Option<Vec<LegacyOrderByInput>>,
+        where_: Option<ORMPMessageDispatchedWhereInput>,
+        order_by: Option<Vec<ORMPMessageDispatchedOrderByInput>>,
         offset: Option<i32>,
         limit: Option<i32>,
     ) -> GraphqlResult<ORMPMessageDispatchedPage> {
+        let where_ = where_.map(LegacyWhereInput::from);
+        let order_by = order_by.map(legacy_order_by_vec);
         query_ormp_message_dispatcheds_page(
             pool(ctx)?,
             where_.as_ref(),
@@ -240,11 +248,13 @@ impl QueryRoot {
     async fn msgport_message_sents(
         &self,
         ctx: &Context<'_>,
-        where_: Option<LegacyWhereInput>,
-        order_by: Option<Vec<LegacyOrderByInput>>,
+        where_: Option<MsgportMessageSentWhereInput>,
+        order_by: Option<Vec<MsgportMessageSentOrderByInput>>,
         offset: Option<i32>,
         limit: Option<i32>,
     ) -> GraphqlResult<Vec<MsgportMessageSent>> {
+        let where_ = where_.map(LegacyWhereInput::from);
+        let order_by = order_by.map(legacy_order_by_vec);
         query_msgport_message_sents(
             pool(ctx)?,
             where_.as_ref(),
@@ -258,11 +268,13 @@ impl QueryRoot {
     async fn msgport_message_sents_page(
         &self,
         ctx: &Context<'_>,
-        where_: Option<LegacyWhereInput>,
-        order_by: Option<Vec<LegacyOrderByInput>>,
+        where_: Option<MsgportMessageSentWhereInput>,
+        order_by: Option<Vec<MsgportMessageSentOrderByInput>>,
         offset: Option<i32>,
         limit: Option<i32>,
     ) -> GraphqlResult<MsgportMessageSentPage> {
+        let where_ = where_.map(LegacyWhereInput::from);
+        let order_by = order_by.map(legacy_order_by_vec);
         query_msgport_message_sents_page(
             pool(ctx)?,
             where_.as_ref(),
@@ -271,6 +283,46 @@ impl QueryRoot {
             limit,
         )
         .await
+    }
+
+    #[cfg(feature = "legacy-query-compat")]
+    async fn msgport_message_sents_connection(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<MsgportMessageSentWhereInput>,
+        order_by: Option<Vec<MsgportMessageSentOrderByInput>>,
+    ) -> GraphqlResult<LegacyTotalCountConnection> {
+        let where_ = where_.map(LegacyWhereInput::from);
+        let order_by = order_by.map(legacy_order_by_vec);
+        let page = query_msgport_message_sents_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            Some(0),
+            Some(0),
+        )
+        .await?;
+        Ok(LegacyTotalCountConnection::new(page.total_count))
+    }
+
+    #[cfg(feature = "legacy-query-compat")]
+    async fn ormp_message_dispatcheds_connection(
+        &self,
+        ctx: &Context<'_>,
+        where_: Option<ORMPMessageDispatchedWhereInput>,
+        order_by: Option<Vec<ORMPMessageDispatchedOrderByInput>>,
+    ) -> GraphqlResult<LegacyTotalCountConnection> {
+        let where_ = where_.map(LegacyWhereInput::from);
+        let order_by = order_by.map(legacy_order_by_vec);
+        let page = query_ormp_message_dispatcheds_page(
+            pool(ctx)?,
+            where_.as_ref(),
+            order_by.as_deref(),
+            Some(0),
+            Some(0),
+        )
+        .await?;
+        Ok(LegacyTotalCountConnection::new(page.total_count))
     }
 
     async fn signature_pub_signature_submittion_by_id(
@@ -320,4 +372,11 @@ impl QueryRoot {
 
 fn pool<'a>(ctx: &'a Context<'_>) -> GraphqlResult<&'a PgPool> {
     Ok(&ctx.data::<GraphqlState>()?.pool)
+}
+
+fn legacy_order_by_vec<T>(order_by: Vec<T>) -> Vec<LegacyOrderByInput>
+where
+    LegacyOrderByInput: From<T>,
+{
+    order_by.into_iter().map(LegacyOrderByInput::from).collect()
 }

--- a/src/graphql/types.rs
+++ b/src/graphql/types.rs
@@ -160,16 +160,37 @@ pub struct LegacyWhereInput {
     pub to_eq: Option<String>,
     #[graphql(name = "fromDapp_eq")]
     pub from_dapp_eq: Option<String>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "fromDapp_in")]
+    pub from_dapp_in: Option<Vec<String>>,
     #[graphql(name = "toDapp_eq")]
     pub to_dapp_eq: Option<String>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "toDapp_in")]
+    pub to_dapp_in: Option<Vec<String>>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "transactionFrom_eq")]
+    pub transaction_from_eq: Option<String>,
     #[graphql(name = "fromChainId_eq")]
     pub from_chain_id_eq: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "fromChainId_in")]
+    pub from_chain_id_in: Option<Vec<BigInt>>,
     #[graphql(name = "toChainId_eq")]
     pub to_chain_id_eq: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "toChainId_in")]
+    pub to_chain_id_in: Option<Vec<BigInt>>,
     #[graphql(name = "srcChainId_eq")]
     pub src_chain_id_eq: Option<BigInt>,
     #[graphql(name = "targetChainId_eq")]
     pub target_chain_id_eq: Option<BigInt>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "targetChainId_in")]
+    pub target_chain_id_in: Option<Vec<BigInt>>,
+    #[cfg(feature = "legacy-query-compat")]
+    #[graphql(name = "dispatchResult_eq")]
+    pub dispatch_result_eq: Option<bool>,
     #[graphql(name = "msgIndex_eq")]
     pub msg_index_eq: Option<BigInt>,
     #[cfg(feature = "legacy-query-compat")]
@@ -206,6 +227,33 @@ pub struct LegacyWhereInput {
     #[graphql(name = "relayerAssigned_eq")]
     pub relayer_assigned_eq: Option<bool>,
 }
+
+macro_rules! legacy_where_alias {
+    ($name:ident, $graphql_name:literal) => {
+        #[derive(Clone, Debug, Default, InputObject)]
+        #[graphql(name = $graphql_name)]
+        pub struct $name {
+            #[graphql(flatten)]
+            pub legacy: LegacyWhereInput,
+        }
+
+        impl From<$name> for LegacyWhereInput {
+            fn from(value: $name) -> Self {
+                value.legacy
+            }
+        }
+    };
+}
+
+legacy_where_alias!(MsgportMessageSentWhereInput, "MsgportMessageSentWhereInput");
+legacy_where_alias!(
+    ORMPMessageAcceptedWhereInput,
+    "ORMPMessageAcceptedWhereInput"
+);
+legacy_where_alias!(
+    ORMPMessageDispatchedWhereInput,
+    "ORMPMessageDispatchedWhereInput"
+);
 
 #[derive(Clone, Copy, Debug, Eq, Enum, PartialEq)]
 pub enum LegacyOrderByInput {
@@ -254,6 +302,103 @@ pub enum LegacyOrderByInput {
     #[graphql(name = "msgIndex_DESC")]
     MsgIndexDesc,
 }
+
+macro_rules! legacy_order_alias {
+    ($name:ident, $graphql_name:literal) => {
+        #[derive(Clone, Copy, Debug, Eq, Enum, PartialEq)]
+        #[graphql(name = $graphql_name)]
+        pub enum $name {
+            #[graphql(name = "id_ASC")]
+            IdAsc,
+            #[graphql(name = "id_DESC")]
+            IdDesc,
+            #[graphql(name = "blockNumber_ASC")]
+            BlockNumberAsc,
+            #[graphql(name = "blockNumber_DESC")]
+            BlockNumberDesc,
+            #[graphql(name = "blockTimestamp_ASC")]
+            BlockTimestampAsc,
+            #[graphql(name = "blockTimestamp_DESC")]
+            BlockTimestampDesc,
+            #[graphql(name = "chainId_ASC")]
+            ChainIdAsc,
+            #[graphql(name = "chainId_DESC")]
+            ChainIdDesc,
+            #[graphql(name = "logIndex_ASC")]
+            LogIndexAsc,
+            #[graphql(name = "logIndex_DESC")]
+            LogIndexDesc,
+            #[graphql(name = "transactionIndex_ASC")]
+            TransactionIndexAsc,
+            #[graphql(name = "transactionIndex_DESC")]
+            TransactionIndexDesc,
+            #[graphql(name = "msgHash_ASC")]
+            MsgHashAsc,
+            #[graphql(name = "msgHash_DESC")]
+            MsgHashDesc,
+            #[graphql(name = "msgId_ASC")]
+            MsgIdAsc,
+            #[graphql(name = "msgId_DESC")]
+            MsgIdDesc,
+            #[cfg(feature = "legacy-query-compat")]
+            #[graphql(name = "index_ASC")]
+            IndexAsc,
+            #[cfg(feature = "legacy-query-compat")]
+            #[graphql(name = "index_DESC")]
+            IndexDesc,
+            #[cfg(feature = "legacy-query-compat")]
+            #[graphql(name = "msgIndex_ASC")]
+            MsgIndexAsc,
+            #[cfg(feature = "legacy-query-compat")]
+            #[graphql(name = "msgIndex_DESC")]
+            MsgIndexDesc,
+        }
+
+        impl From<$name> for LegacyOrderByInput {
+            fn from(value: $name) -> Self {
+                match value {
+                    $name::IdAsc => Self::IdAsc,
+                    $name::IdDesc => Self::IdDesc,
+                    $name::BlockNumberAsc => Self::BlockNumberAsc,
+                    $name::BlockNumberDesc => Self::BlockNumberDesc,
+                    $name::BlockTimestampAsc => Self::BlockTimestampAsc,
+                    $name::BlockTimestampDesc => Self::BlockTimestampDesc,
+                    $name::ChainIdAsc => Self::ChainIdAsc,
+                    $name::ChainIdDesc => Self::ChainIdDesc,
+                    $name::LogIndexAsc => Self::LogIndexAsc,
+                    $name::LogIndexDesc => Self::LogIndexDesc,
+                    $name::TransactionIndexAsc => Self::TransactionIndexAsc,
+                    $name::TransactionIndexDesc => Self::TransactionIndexDesc,
+                    $name::MsgHashAsc => Self::MsgHashAsc,
+                    $name::MsgHashDesc => Self::MsgHashDesc,
+                    $name::MsgIdAsc => Self::MsgIdAsc,
+                    $name::MsgIdDesc => Self::MsgIdDesc,
+                    #[cfg(feature = "legacy-query-compat")]
+                    $name::IndexAsc => Self::IndexAsc,
+                    #[cfg(feature = "legacy-query-compat")]
+                    $name::IndexDesc => Self::IndexDesc,
+                    #[cfg(feature = "legacy-query-compat")]
+                    $name::MsgIndexAsc => Self::MsgIndexAsc,
+                    #[cfg(feature = "legacy-query-compat")]
+                    $name::MsgIndexDesc => Self::MsgIndexDesc,
+                }
+            }
+        }
+    };
+}
+
+legacy_order_alias!(
+    MsgportMessageSentOrderByInput,
+    "MsgportMessageSentOrderByInput"
+);
+legacy_order_alias!(
+    ORMPMessageAcceptedOrderByInput,
+    "ORMPMessageAcceptedOrderByInput"
+);
+legacy_order_alias!(
+    ORMPMessageDispatchedOrderByInput,
+    "ORMPMessageDispatchedOrderByInput"
+);
 
 #[derive(Clone, Debug, FromRow, SimpleObject)]
 #[graphql(name = "ORMPHashImported", rename_fields = "camelCase")]
@@ -442,3 +587,17 @@ page_type!(
     "SignaturePubSignatureSubmittionPage",
     SignaturePubSignatureSubmittion
 );
+
+#[cfg(feature = "legacy-query-compat")]
+#[derive(Clone, Debug, SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct LegacyTotalCountConnection {
+    pub(super) total_count: i64,
+}
+
+#[cfg(feature = "legacy-query-compat")]
+impl LegacyTotalCountConnection {
+    pub(super) fn new(total_count: i64) -> Self {
+        Self { total_count }
+    }
+}

--- a/tests/graphql_server.rs
+++ b/tests/graphql_server.rs
@@ -28,8 +28,8 @@ async fn test_graphql_schema_exposes_pages_without_connections() {
         assert!(sdl.contains(page_type), "schema is missing {page_type}");
     }
     assert!(
-        !sdl.contains("Connection"),
-        "schema must not expose connection fields or types"
+        !sdl.contains("edges:") && !sdl.contains("nodes:"),
+        "schema must not expose cursor-style connection payloads"
     );
     assert!(sdl.contains("scalar BigInt"), "schema must expose BigInt");
     assert!(
@@ -47,6 +47,16 @@ async fn test_graphql_schema_exposes_pages_without_connections() {
     #[cfg(feature = "legacy-query-compat")]
     {
         for legacy_query_compat_name in [
+            "input MsgportMessageSentWhereInput",
+            "enum MsgportMessageSentOrderByInput",
+            "input ORMPMessageAcceptedWhereInput",
+            "enum ORMPMessageAcceptedOrderByInput",
+            "input ORMPMessageDispatchedWhereInput",
+            "enum ORMPMessageDispatchedOrderByInput",
+            "fromChainId_in",
+            "toChainId_in",
+            "fromDapp_in",
+            "transactionFrom_eq",
             "index_ASC",
             "msgIndex_DESC",
             "index_gt",


### PR DESCRIPTION
## Summary
- add msgscan-compatible GraphQL input/order type aliases
- add legacy totalCount connection fields used by msgscan stats queries
- map msgscan legacy filters to SQL where clauses

## Tests
- cargo fmt
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --locked
- cargo test --no-default-features --test graphql_server test_graphql_schema_exposes_pages_without_connections -- --nocapture